### PR TITLE
feat(cli): add rdc count and rdc shader-map commands

### DIFF
--- a/src/rdc/cli.py
+++ b/src/rdc/cli.py
@@ -6,6 +6,7 @@ from rdc import __version__
 from rdc.commands.capture import capture_cmd
 from rdc.commands.doctor import doctor_cmd
 from rdc.commands.session import close_cmd, goto_cmd, open_cmd, status_cmd
+from rdc.commands.unix_helpers import count_cmd, shader_map_cmd
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -20,6 +21,8 @@ main.add_command(open_cmd, name="open")
 main.add_command(close_cmd, name="close")
 main.add_command(status_cmd, name="status")
 main.add_command(goto_cmd, name="goto")
+main.add_command(count_cmd, name="count")
+main.add_command(shader_map_cmd, name="shader-map")
 
 
 if __name__ == "__main__":

--- a/src/rdc/commands/unix_helpers.py
+++ b/src/rdc/commands/unix_helpers.py
@@ -1,0 +1,79 @@
+"""Unix-tool-friendly helper commands: rdc count, rdc shader-map."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+from rdc.daemon_client import send_request
+from rdc.formatters.tsv import format_row
+from rdc.protocol import _request
+from rdc.session_state import load_session
+
+_COUNT_TARGETS = ["draws", "events", "resources", "triangles", "passes", "dispatches", "clears"]
+_SHADER_MAP_HEADER = ["EID", "VS", "HS", "DS", "GS", "PS", "CS"]
+_SHADER_MAP_COLS = ["eid", "vs", "hs", "ds", "gs", "ps", "cs"]
+
+
+def _require_session() -> tuple[str, int, str]:
+    """Load active session or exit with error.
+
+    Returns:
+        Tuple of (host, port, token).
+    """
+    session = load_session()
+    if session is None:
+        click.echo("error: no active session (run 'rdc open' first)", err=True)
+        raise SystemExit(1)
+    return session.host, session.port, session.token
+
+
+def _get_count_value(what: str, pass_name: str | None = None) -> int:
+    """Get count value from daemon."""
+    host, port, token = _require_session()
+    params: dict[str, Any] = {"_token": token, "what": what}
+    if pass_name is not None:
+        params["pass"] = pass_name
+    payload = _request("count", 1, params).to_dict()
+    response = send_request(host, port, payload)
+    if "error" in response:
+        click.echo(f"error: {response['error']['message']}", err=True)
+        raise SystemExit(1)
+    value: int = response["result"]["value"]
+    return value
+
+
+def _get_shader_map_rows() -> list[dict[str, Any]]:
+    """Get shader-map rows from daemon."""
+    host, port, token = _require_session()
+    payload = _request("shader_map", 1, {"_token": token}).to_dict()
+    response = send_request(host, port, payload)
+    if "error" in response:
+        click.echo(f"error: {response['error']['message']}", err=True)
+        raise SystemExit(1)
+    rows: list[dict[str, Any]] = response["result"]["rows"]
+    return rows
+
+
+@click.command("count")
+@click.argument("what", type=click.Choice(_COUNT_TARGETS, case_sensitive=False))
+@click.option("--pass", "pass_name", default=None, help="Filter by render pass name.")
+def count_cmd(what: str, pass_name: str | None) -> None:
+    """Output a single integer count to stdout.
+
+    Targets: draws, events, resources, triangles, passes, dispatches, clears.
+    """
+    value = _get_count_value(what, pass_name)
+    click.echo(value)
+
+
+@click.command("shader-map")
+@click.option("--no-header", is_flag=True, default=False, help="Omit TSV header row.")
+def shader_map_cmd(no_header: bool) -> None:
+    """Output EID-to-shader mapping as TSV."""
+    rows = _get_shader_map_rows()
+    if not no_header:
+        click.echo(format_row(_SHADER_MAP_HEADER))
+    for row in rows:
+        click.echo(format_row([row[c] for c in _SHADER_MAP_COLS]))

--- a/src/rdc/protocol.py
+++ b/src/rdc/protocol.py
@@ -42,3 +42,20 @@ def goto_request(token: str, eid: int, request_id: int = 1) -> dict[str, Any]:
 
 def shutdown_request(token: str, request_id: int = 1) -> dict[str, Any]:
     return _request("shutdown", request_id, {"_token": token}).to_dict()
+
+
+def count_request(
+    token: str,
+    what: str,
+    *,
+    pass_name: str | None = None,
+    request_id: int = 1,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {"_token": token, "what": what}
+    if pass_name is not None:
+        params["pass"] = pass_name
+    return _request("count", request_id, params).to_dict()
+
+
+def shader_map_request(token: str, request_id: int = 1) -> dict[str, Any]:
+    return _request("shader_map", request_id, {"_token": token}).to_dict()

--- a/src/rdc/services/query_service.py
+++ b/src/rdc/services/query_service.py
@@ -1,0 +1,151 @@
+"""Query service for count and shader-map aggregation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_VALID_COUNT_TARGETS = frozenset(
+    {"draws", "events", "resources", "triangles", "passes", "dispatches", "clears"}
+)
+
+# Flag constants matching renderdoc ActionFlags
+_FLAG_DRAWCALL = 0x0001
+_FLAG_DISPATCH = 0x0010
+_FLAG_CLEAR = 0x0020
+_FLAG_BEGIN_PASS = 0x2000
+_FLAG_END_PASS = 0x4000
+
+
+def count_from_actions(
+    actions: list[Any],
+    what: str,
+    *,
+    pass_name: str | None = None,
+) -> int:
+    """Count items from the action tree.
+
+    Args:
+        actions: Root action list from controller.GetRootActions().
+        what: Target to count (draws, events, triangles, passes, dispatches, clears).
+        pass_name: Optional render pass name filter.
+
+    Returns:
+        Integer count.
+
+    Raises:
+        ValueError: If *what* is not a recognised target.
+    """
+    if what == "resources":
+        msg = "use count_resources() for resource counting"
+        raise ValueError(msg)
+    if what not in _VALID_COUNT_TARGETS:
+        msg = f"unknown count target: {what}"
+        raise ValueError(msg)
+
+    counter = _CountWalker()
+    counter.walk(actions, pass_name)
+
+    lookup = {
+        "draws": counter.draws,
+        "events": counter.events,
+        "triangles": counter.triangles,
+        "passes": counter.passes,
+        "dispatches": counter.dispatches,
+        "clears": counter.clears,
+    }
+    return lookup[what]
+
+
+def count_resources(resources: list[Any]) -> int:
+    """Count total resources."""
+    return len(resources)
+
+
+class _CountWalker:
+    """Walk an action tree and tally counts."""
+
+    def __init__(self) -> None:
+        self.draws = 0
+        self.events = 0
+        self.triangles = 0
+        self.passes = 0
+        self.dispatches = 0
+        self.clears = 0
+
+    def walk(self, actions: list[Any], pass_name: str | None) -> None:
+        self._walk(actions, pass_name, None)
+
+    def _walk(
+        self,
+        actions: list[Any],
+        pass_name: str | None,
+        current_pass: str | None,
+    ) -> str | None:
+        for a in actions:
+            self.events += 1
+            flags = int(a.flags)
+
+            if flags & _FLAG_BEGIN_PASS:
+                current_pass = a.GetName(None)
+                self.passes += 1
+
+            in_target = pass_name is None or current_pass == pass_name
+
+            if flags & _FLAG_DRAWCALL and in_target:
+                self.draws += 1
+                tris = a.numIndices // 3 if a.numIndices else 0
+                self.triangles += tris * max(a.numInstances, 1)
+            elif flags & _FLAG_DISPATCH and in_target:
+                self.dispatches += 1
+            elif flags & _FLAG_CLEAR and in_target:
+                self.clears += 1
+
+            if a.children:
+                current_pass = self._walk(a.children, pass_name, current_pass)
+
+            if flags & _FLAG_END_PASS:
+                current_pass = None
+
+        return current_pass
+
+
+def collect_shader_map(
+    actions: list[Any],
+    pipe_states: dict[int, Any],
+) -> list[dict[str, Any]]:
+    """Collect shader-map rows from draw/dispatch actions.
+
+    Args:
+        actions: Flat or nested action list.
+        pipe_states: Mapping of EID -> PipeState for each draw/dispatch.
+
+    Returns:
+        List of dicts with keys: eid, vs, hs, ds, gs, ps, cs.
+    """
+    rows: list[dict[str, Any]] = []
+    _collect_recursive(actions, pipe_states, rows)
+    return rows
+
+
+def _collect_recursive(
+    actions: list[Any],
+    pipe_states: dict[int, Any],
+    rows: list[dict[str, Any]],
+) -> None:
+    stage_cols = {0: "vs", 1: "hs", 2: "ds", 3: "gs", 4: "ps", 5: "cs"}
+    for a in actions:
+        flags = int(a.flags)
+        if (flags & _FLAG_DRAWCALL) or (flags & _FLAG_DISPATCH):
+            eid = a.eventId
+            state = pipe_states.get(eid)
+            if state is not None:
+                row: dict[str, Any] = {"eid": eid}
+                for stage_val, col in stage_cols.items():
+                    sid = state.GetShader(stage_val)
+                    if getattr(sid, "value", 0) == 0:
+                        row[col] = "-"
+                    else:
+                        row[col] = sid.value
+                rows.append(row)
+        if a.children:
+            _collect_recursive(a.children, pipe_states, rows)

--- a/tests/unit/test_count_shadermap.py
+++ b/tests/unit/test_count_shadermap.py
@@ -1,0 +1,425 @@
+"""Tests for rdc count and rdc shader-map commands."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
+
+import mock_renderdoc as mrd  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers: build mock action trees
+# ---------------------------------------------------------------------------
+
+
+def _indexed_draw(
+    eid: int, name: str, indices: int = 300, instances: int = 1
+) -> mrd.ActionDescription:
+    return mrd.ActionDescription(
+        eventId=eid,
+        flags=mrd.ActionFlags.Drawcall | mrd.ActionFlags.Indexed,
+        numIndices=indices,
+        numInstances=instances,
+        _name=name,
+    )
+
+
+def _dispatch(eid: int, name: str) -> mrd.ActionDescription:
+    return mrd.ActionDescription(
+        eventId=eid,
+        flags=mrd.ActionFlags.Dispatch,
+        _name=name,
+    )
+
+
+def _clear(eid: int, name: str) -> mrd.ActionDescription:
+    return mrd.ActionDescription(
+        eventId=eid,
+        flags=mrd.ActionFlags.Clear,
+        _name=name,
+    )
+
+
+def _pass_begin(eid: int, name: str) -> mrd.ActionDescription:
+    return mrd.ActionDescription(
+        eventId=eid,
+        flags=mrd.ActionFlags.PassBoundary | mrd.ActionFlags.BeginPass,
+        _name=name,
+    )
+
+
+def _pass_end(eid: int, name: str) -> mrd.ActionDescription:
+    return mrd.ActionDescription(
+        eventId=eid,
+        flags=mrd.ActionFlags.PassBoundary | mrd.ActionFlags.EndPass,
+        _name=name,
+    )
+
+
+def _build_action_tree() -> list[mrd.ActionDescription]:
+    """Build a representative action tree with 2 passes."""
+    shadow_pass = _pass_begin(10, "Shadow")
+    shadow_pass.children = [
+        _indexed_draw(11, "vkCmdDrawIndexed", indices=900, instances=1),
+        _indexed_draw(12, "vkCmdDrawIndexed", indices=600, instances=1),
+    ]
+    shadow_end = _pass_end(13, "Shadow")
+
+    gbuffer_pass = _pass_begin(20, "GBuffer")
+    gbuffer_pass.children = [
+        _indexed_draw(21, "vkCmdDrawIndexed", indices=3600, instances=1),
+        _clear(22, "vkCmdClear"),
+        _dispatch(23, "vkCmdDispatch"),
+    ]
+    gbuffer_end = _pass_end(24, "GBuffer")
+
+    return [shadow_pass, shadow_end, gbuffer_pass, gbuffer_end]
+
+
+def _make_pipe_state(
+    vs: int = 0,
+    hs: int = 0,
+    ds: int = 0,
+    gs: int = 0,
+    ps: int = 0,
+    cs: int = 0,
+) -> mrd.MockPipeState:
+    """Create a MockPipeState with given shader resource IDs per stage."""
+    state = mrd.MockPipeState()
+    if vs:
+        state._shaders[mrd.ShaderStage.Vertex] = mrd.ResourceId(vs)
+    if hs:
+        state._shaders[mrd.ShaderStage.Hull] = mrd.ResourceId(hs)
+    if ds:
+        state._shaders[mrd.ShaderStage.Domain] = mrd.ResourceId(ds)
+    if gs:
+        state._shaders[mrd.ShaderStage.Geometry] = mrd.ResourceId(gs)
+    if ps:
+        state._shaders[mrd.ShaderStage.Pixel] = mrd.ResourceId(ps)
+    if cs:
+        state._shaders[mrd.ShaderStage.Compute] = mrd.ResourceId(cs)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Tests: count aggregation logic
+# ---------------------------------------------------------------------------
+
+
+class TestCountAggregation:
+    """Test the count aggregation logic in query_service."""
+
+    def test_count_draws(self) -> None:
+        from rdc.services.query_service import count_from_actions
+
+        assert count_from_actions(_build_action_tree(), "draws") == 3
+
+    def test_count_events(self) -> None:
+        from rdc.services.query_service import count_from_actions
+
+        assert count_from_actions(_build_action_tree(), "events") == 9
+
+    def test_count_triangles(self) -> None:
+        from rdc.services.query_service import count_from_actions
+
+        # (900 + 600 + 3600) // 3 = 1700
+        assert count_from_actions(_build_action_tree(), "triangles") == 1700
+
+    def test_count_dispatches(self) -> None:
+        from rdc.services.query_service import count_from_actions
+
+        assert count_from_actions(_build_action_tree(), "dispatches") == 1
+
+    def test_count_clears(self) -> None:
+        from rdc.services.query_service import count_from_actions
+
+        assert count_from_actions(_build_action_tree(), "clears") == 1
+
+    def test_count_passes(self) -> None:
+        from rdc.services.query_service import count_from_actions
+
+        assert count_from_actions(_build_action_tree(), "passes") == 2
+
+    def test_count_resources(self) -> None:
+        from rdc.services.query_service import count_resources
+
+        assert count_resources([mrd.ResourceDescription() for _ in range(5)]) == 5
+
+    def test_count_draws_with_pass_filter(self) -> None:
+        from rdc.services.query_service import count_from_actions
+
+        assert count_from_actions(_build_action_tree(), "draws", pass_name="Shadow") == 2
+
+    def test_count_triangles_with_pass_filter(self) -> None:
+        from rdc.services.query_service import count_from_actions
+
+        assert count_from_actions(_build_action_tree(), "triangles", pass_name="Shadow") == 500
+
+    def test_count_draws_nonexistent_pass(self) -> None:
+        from rdc.services.query_service import count_from_actions
+
+        assert count_from_actions(_build_action_tree(), "draws", pass_name="Nope") == 0
+
+    def test_count_zero_draws(self) -> None:
+        from rdc.services.query_service import count_from_actions
+
+        assert count_from_actions([], "draws") == 0
+
+    def test_count_invalid_target(self) -> None:
+        from rdc.services.query_service import count_from_actions
+
+        with pytest.raises(ValueError, match="unknown count target"):
+            count_from_actions([], "bogus_target")
+
+
+# ---------------------------------------------------------------------------
+# Tests: shader-map collection logic
+# ---------------------------------------------------------------------------
+
+
+class TestShaderMapCollection:
+    """Test shader-map collection logic."""
+
+    def test_shader_map_basic(self) -> None:
+        from rdc.services.query_service import collect_shader_map
+
+        actions = [_indexed_draw(42, "draw")]
+        states = {42: _make_pipe_state(vs=10, ps=11)}
+        rows = collect_shader_map(actions, states)
+        assert len(rows) == 1
+        assert rows[0] == {
+            "eid": 42,
+            "vs": 10,
+            "hs": "-",
+            "ds": "-",
+            "gs": "-",
+            "ps": 11,
+            "cs": "-",
+        }
+
+    def test_shader_map_mixed_stages(self) -> None:
+        from rdc.services.query_service import collect_shader_map
+
+        actions = [_indexed_draw(42, "d1"), _indexed_draw(43, "d2")]
+        states = {
+            42: _make_pipe_state(vs=10, gs=12, ps=11),
+            43: _make_pipe_state(vs=10, hs=20, ds=21, ps=11),
+        }
+        rows = collect_shader_map(actions, states)
+        assert len(rows) == 2
+        assert rows[0]["gs"] == 12
+        assert rows[1]["hs"] == 20
+
+    def test_shader_map_compute_only(self) -> None:
+        from rdc.services.query_service import collect_shader_map
+
+        actions = [_dispatch(50, "dispatch")]
+        states = {50: _make_pipe_state(cs=99)}
+        rows = collect_shader_map(actions, states)
+        assert len(rows) == 1
+        assert rows[0]["cs"] == 99
+        assert rows[0]["vs"] == "-"
+
+    def test_shader_map_empty(self) -> None:
+        from rdc.services.query_service import collect_shader_map
+
+        assert collect_shader_map([], {}) == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLI output format
+# ---------------------------------------------------------------------------
+
+
+class TestCountCLIOutput:
+    """Test that rdc count outputs exactly a single integer."""
+
+    def test_count_outputs_integer(self) -> None:
+        from rdc.cli import main
+
+        runner = CliRunner()
+        with patch("rdc.commands.unix_helpers._get_count_value", return_value=42):
+            result = runner.invoke(main, ["count", "draws"])
+        assert result.exit_code == 0
+        assert result.output == "42\n"
+        assert result.output.strip().isdigit()
+
+    def test_count_zero(self) -> None:
+        from rdc.cli import main
+
+        runner = CliRunner()
+        with patch("rdc.commands.unix_helpers._get_count_value", return_value=0):
+            result = runner.invoke(main, ["count", "draws"])
+        assert result.exit_code == 0
+        assert result.output == "0\n"
+
+    def test_count_no_session_error(self) -> None:
+        from rdc.cli import main
+
+        runner = CliRunner()
+        with patch("rdc.commands.unix_helpers._get_count_value", side_effect=SystemExit(1)):
+            result = runner.invoke(main, ["count", "draws"])
+        assert result.exit_code == 1
+
+    def test_count_invalid_target(self) -> None:
+        from rdc.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["count", "bogus"])
+        assert result.exit_code != 0
+
+
+class TestShaderMapCLIOutput:
+    """Test rdc shader-map TSV output format."""
+
+    def test_shader_map_with_header(self) -> None:
+        from rdc.cli import main
+
+        runner = CliRunner()
+        rows = [{"eid": 42, "vs": 10, "hs": "-", "ds": "-", "gs": "-", "ps": 11, "cs": "-"}]
+        with patch("rdc.commands.unix_helpers._get_shader_map_rows", return_value=rows):
+            result = runner.invoke(main, ["shader-map"])
+        assert result.exit_code == 0
+        lines = result.output.strip().split("\n")
+        assert lines[0] == "EID\tVS\tHS\tDS\tGS\tPS\tCS"
+        assert lines[1] == "42\t10\t-\t-\t-\t11\t-"
+
+    def test_shader_map_no_header(self) -> None:
+        from rdc.cli import main
+
+        runner = CliRunner()
+        rows = [{"eid": 42, "vs": 10, "hs": "-", "ds": "-", "gs": "-", "ps": 11, "cs": "-"}]
+        with patch("rdc.commands.unix_helpers._get_shader_map_rows", return_value=rows):
+            result = runner.invoke(main, ["shader-map", "--no-header"])
+        assert result.exit_code == 0
+        lines = result.output.strip().split("\n")
+        assert lines[0] == "42\t10\t-\t-\t-\t11\t-"
+
+    def test_shader_map_empty_with_header(self) -> None:
+        from rdc.cli import main
+
+        runner = CliRunner()
+        with patch("rdc.commands.unix_helpers._get_shader_map_rows", return_value=[]):
+            result = runner.invoke(main, ["shader-map"])
+        assert result.exit_code == 0
+        assert "EID\tVS\tHS\tDS\tGS\tPS\tCS" in result.output
+
+    def test_shader_map_empty_no_header(self) -> None:
+        from rdc.cli import main
+
+        runner = CliRunner()
+        with patch("rdc.commands.unix_helpers._get_shader_map_rows", return_value=[]):
+            result = runner.invoke(main, ["shader-map", "--no-header"])
+        assert result.exit_code == 0
+        assert result.output == ""
+
+
+# ---------------------------------------------------------------------------
+# Tests: daemon JSON-RPC handlers
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonCountMethod:
+    """Test the daemon count JSON-RPC method."""
+
+    def test_count_draws(self) -> None:
+        from rdc.daemon_server import DaemonState, _handle_request
+
+        actions = _build_action_tree()
+        state = DaemonState(
+            capture="test.rdc",
+            current_eid=0,
+            token="tok",
+            adapter=MagicMock(
+                get_root_actions=MagicMock(return_value=actions),
+                get_resources=MagicMock(return_value=[]),
+            ),
+        )
+        req = {"id": 1, "method": "count", "params": {"_token": "tok", "what": "draws"}}
+        resp, _ = _handle_request(req, state)
+        assert resp["result"]["value"] == 3
+
+    def test_count_resources(self) -> None:
+        from rdc.daemon_server import DaemonState, _handle_request
+
+        resources = [mrd.ResourceDescription() for _ in range(7)]
+        state = DaemonState(
+            capture="test.rdc",
+            current_eid=0,
+            token="tok",
+            adapter=MagicMock(
+                get_root_actions=MagicMock(return_value=[]),
+                get_resources=MagicMock(return_value=resources),
+            ),
+        )
+        req = {"id": 1, "method": "count", "params": {"_token": "tok", "what": "resources"}}
+        resp, _ = _handle_request(req, state)
+        assert resp["result"]["value"] == 7
+
+    def test_count_invalid_target(self) -> None:
+        from rdc.daemon_server import DaemonState, _handle_request
+
+        state = DaemonState(
+            capture="test.rdc",
+            current_eid=0,
+            token="tok",
+            adapter=MagicMock(get_root_actions=MagicMock(return_value=[])),
+        )
+        req = {"id": 1, "method": "count", "params": {"_token": "tok", "what": "bogus"}}
+        resp, _ = _handle_request(req, state)
+        assert "error" in resp
+
+    def test_count_with_pass_filter(self) -> None:
+        from rdc.daemon_server import DaemonState, _handle_request
+
+        actions = _build_action_tree()
+        state = DaemonState(
+            capture="test.rdc",
+            current_eid=0,
+            token="tok",
+            adapter=MagicMock(get_root_actions=MagicMock(return_value=actions)),
+        )
+        req = {
+            "id": 1,
+            "method": "count",
+            "params": {"_token": "tok", "what": "draws", "pass": "Shadow"},
+        }
+        resp, _ = _handle_request(req, state)
+        assert resp["result"]["value"] == 2
+
+
+class TestDaemonShaderMapMethod:
+    """Test the daemon shader_map JSON-RPC method."""
+
+    def test_shader_map_returns_rows(self) -> None:
+        from rdc.daemon_server import DaemonState, _handle_request
+
+        draw = _indexed_draw(42, "draw")
+        pipe_state = _make_pipe_state(vs=10, ps=11)
+
+        adapter = MagicMock()
+        adapter.get_root_actions.return_value = [draw]
+        adapter.get_pipeline_state.return_value = pipe_state
+        adapter.set_frame_event = MagicMock()
+
+        state = DaemonState(
+            capture="test.rdc",
+            current_eid=0,
+            token="tok",
+            adapter=adapter,
+        )
+
+        req = {"id": 1, "method": "shader_map", "params": {"_token": "tok"}}
+        resp, _ = _handle_request(req, state)
+        rows = resp["result"]["rows"]
+        assert len(rows) == 1
+        assert rows[0]["eid"] == 42
+        assert rows[0]["vs"] == 10
+        assert rows[0]["ps"] == 11
+        assert rows[0]["hs"] == "-"


### PR DESCRIPTION
## Change Type
- [x] feat: New feature

## Description
Implement `rdc count` and `rdc shader-map` Unix-tool-friendly helper commands (Phase 1 Week 4).

- `rdc count <target>`: outputs a single integer (draws/events/resources/triangles/passes/dispatches/clears)
- `rdc shader-map`: TSV mapping EID to shader ResourceId per stage
- Supports `--no-header`, `--pass NAME` filter

## Testing
- [x] Added/updated tests (29 new tests)
- [x] Local `make check` passes
- [x] Coverage >= 80% (85.31%)

## References
OpenSpec: openspec/changes/phase1-count-shadermap/

## Checklist
- [x] Complete type hints
- [x] Docstrings for all public functions
- [x] No print(), uses click.echo/formatters
- [x] Errors to stderr
- [x] TSV output compatible with awk/grep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `count` CLI to query rendering metrics (draws, events, resources, triangles, passes, dispatches, clears) with optional render-pass filtering.
  * Added `shader-map` CLI to export event→shader mappings as TSV with optional header suppression.
  * Daemon now supports `count` and `shader-map` requests; backend query service exposes counting and shader-map generation.

* **Tests**
  * Comprehensive unit tests covering counts, shader-map output, CLI behavior, and daemon request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->