### PR TITLE
ci(commitlint): add permissions for PR commit access

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### **User description**
## Change Type
- [x] ci: CI/CD fix

## Description
Add `permissions: contents: read, pull-requests: read` to commitlint workflow.
Without this, the commitlint GitHub Action cannot access PR commits and fails with
`Resource not accessible by integration`.

## Testing
- [x] No code changes, CI-only fix


___

### **PR Type**
Enhancement


___

### **Description**
- Add permissions block to commitlint workflow for PR access

- Grants `contents: read` and `pull-requests: read` permissions

- Fixes resource access errors in commitlint GitHub Action


___



### File Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commitlint.yml</strong><dd><code>Add permissions block to commitlint workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/commitlint.yml

<ul><li>Added <code>permissions</code> section with <code>contents: read</code> and <code>pull-requests: read</code><br> <li> Enables commitlint action to access PR commits without integration <br>errors</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/3/files#diff-6afdd3d5a5b90ed758101676cb67893ad6de8cdd028d0add6c9f94fff0dfc550">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

___

