### PR TITLE
fix: remove broken --set filter

### DIFF
--- a/src/rdc/commands/pipeline.py
+++ b/src/rdc/commands/pipeline.py
@@ -87,22 +87,16 @@ def pipeline_cmd(eid: int | None, section: str | None, as_json: bool) -> None:
 
 @click.command("bindings")
 @click.argument("eid", required=False, type=int)
-@click.option("--set", "descriptor_set", type=int, help="Filter by descriptor set number.")
 @click.option("--binding", "binding_index", type=int, help="Filter by binding index.")
 @click.option("--json", "as_json", is_flag=True, default=False, help="Output JSON.")
-def bindings_cmd(
-    eid: int | None, descriptor_set: int | None, binding_index: int | None, as_json: bool
-) -> None:
+def bindings_cmd(eid: int | None, binding_index: int | None, as_json: bool) -> None:
     """Show bound resources per shader stage.
 
-    EID is the event ID. Use --set to filter by descriptor set,
-    --binding to filter by binding index.
+    EID is the event ID. Use --binding to filter by binding index.
     """
     params: dict[str, Any] = {}
     if eid is not None:
         params["eid"] = eid
-    if descriptor_set is not None:
-        params["set"] = descriptor_set
     if binding_index is not None:
         params["binding"] = binding_index
 

--- a/src/rdc/daemon_server.py
+++ b/src/rdc/daemon_server.py
@@ -241,11 +241,8 @@ def _handle_request(request: dict[str, Any], state: DaemonState) -> tuple[dict[s
         pipe_state = state.adapter.get_pipeline_state()
         rows = bindings_rows(state.current_eid, pipe_state)
 
-        # Filter by descriptor set and binding index
-        descriptor_set = params.get("set")
+        # Filter by binding index (descriptor set filtering not yet implemented)
         binding_index = params.get("binding")
-        if descriptor_set is not None:
-            rows = [r for r in rows if r.get("set") == descriptor_set]
         if binding_index is not None:
             rows = [r for r in rows if r.get("slot") == binding_index]
 


### PR DESCRIPTION
### **User description**
Remove broken --set option from rdc bindings (not yet implemented)


___

### **PR Type**
Bug fix


___

### **Description**
- Remove unimplemented --set filter from bindings command

- Simplify function signature by removing descriptor_set parameter

- Update documentation to reflect available filters only

- Clean up unused filtering logic in daemon server


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["bindings command"] -->|remove --set option| B["--binding filter only"]
  C["bindings_cmd function"] -->|remove descriptor_set param| D["simplified signature"]
  E["daemon_server filtering"] -->|remove set filtering logic| F["binding index filtering only"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pipeline.py</strong><dd><code>Remove --set option from bindings command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdc/commands/pipeline.py

<ul><li>Removed <code>--set</code> option from bindings command decorator<br> <li> Removed <code>descriptor_set</code> parameter from <code>bindings_cmd</code> function signature<br> <li> Updated docstring to remove reference to --set filter<br> <li> Removed code that passes descriptor_set to params dictionary</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/8/files#diff-488b2e436c8e06fb5c121d1a75cd8edaff45ab3fc67e9987f4ac9512774ec161">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>daemon_server.py</strong><dd><code>Remove descriptor set filtering from daemon server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdc/daemon_server.py

<ul><li>Removed descriptor_set extraction from params<br> <li> Removed filtering logic that filtered rows by descriptor set<br> <li> Updated comment to clarify descriptor set filtering not yet <br>implemented<br> <li> Kept binding index filtering logic intact</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/8/files#diff-c8fc48e38ee81838d8bad88541c08bdb66110557993c68cb1b97d8a98173398e">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

