### PR TITLE
docs: rewrite README with concise 4-part structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,148 +1,104 @@
 # rdc-cli
 
-Unix-friendly CLI for RenderDoc `.rdc` captures. Pipe-friendly TSV output, JSON mode, daemon-backed session for interactive exploration.
+Unix-friendly CLI for [RenderDoc](https://renderdoc.org/) `.rdc` captures. Pipe-friendly TSV output, JSON mode, 33 commands, daemon-backed session for interactive exploration.
 
-## Requirements
-
-- **Python >= 3.14**
-- **renderdoc** Python module (bundled with [RenderDoc](https://renderdoc.org/) >= 1.33, or build from source)
+```bash
+rdc open capture.rdc          # Start session
+rdc draws                     # List draw calls (TSV)
+rdc pipeline 142              # Pipeline state at EID 142
+rdc shader 142 ps             # Pixel shader disassembly
+rdc texture 5 -o out.png      # Export texture
+rdc draws --json | jq '...'   # Machine-readable output
+rdc close                     # End session
+```
 
 ## Install
 
-```bash
-pip install rdc-cli
-```
-
-Or from source with [pixi](https://pixi.sh/):
+### PyPI (recommended)
 
 ```bash
-pixi install
-pixi run sync
+pipx install rdc-cli
 ```
 
-### RenderDoc module discovery
+### AUR (Arch Linux)
 
-`rdc` auto-discovers the renderdoc Python module in this order:
+```bash
+yay -S rdc-cli-git
+```
+
+This builds the renderdoc Python module automatically — no extra setup needed.
+
+### From source
+
+```bash
+git clone https://github.com/BANANASJIM/rdc-cli.git
+cd rdc-cli
+pixi install && pixi run sync
+```
+
+## Setup renderdoc
+
+`rdc` requires the renderdoc Python module (`renderdoc.cpython-*.so`), which is **not** included in most system packages. Your Python version must match the one used to compile renderdoc.
+
+### Build from source
+
+```bash
+git clone --depth 1 https://github.com/baldurk/renderdoc.git
+cd renderdoc
+cmake -B build -DENABLE_PYRENDERDOC=ON -DENABLE_QRENDERDOC=OFF
+cmake --build build -j$(nproc)
+export RENDERDOC_PYTHON_PATH=$PWD/build/lib
+```
+
+### Module discovery order
 
 1. `RENDERDOC_PYTHON_PATH` environment variable
 2. `/usr/lib/renderdoc`, `/usr/local/lib/renderdoc`
 3. Sibling directory of `renderdoccmd` on PATH
 
-Verify with:
+### Verify
 
 ```bash
 rdc doctor
 ```
 
-## Usage
+## Commands
 
-### Session workflow
+Run `rdc --help` for the full command list, or `rdc <command> --help` for details.
 
-```bash
-rdc open capture.rdc          # Start daemon, load capture
-rdc status                    # Current session info
-rdc goto 142                  # Navigate to event 142
-rdc close                     # Stop daemon
-```
-
-### Inspection commands
-
-```bash
-rdc info                      # Capture metadata
-rdc stats                     # Per-pass breakdown, top draws
-rdc events                    # List all events
-rdc events --type draw        # Filter by type
-rdc draws                     # List draw calls
-rdc draw 142                  # Draw detail at EID
-rdc event 42                  # API call detail at EID
-rdc log                       # API validation messages
-```
-
-### GPU state
-
-```bash
-rdc pipeline 142              # Pipeline state at EID
-rdc bindings 142              # Bound resources per stage
-rdc shader 142 ps             # Shader disassembly
-rdc shaders                   # List unique shaders
-rdc shader-map                # EID-to-shader TSV mapping
-```
-
-### Resources and passes
-
-```bash
-rdc resources                 # List all resources
-rdc resource 42               # Resource detail by ID
-rdc passes                    # List render passes
-rdc usage 42                  # Resource usage across frame
-rdc usage --all               # Full resource usage matrix
-```
-
-### Export (binary)
-
-```bash
-rdc texture 5 -o out.png      # Export texture as PNG
-rdc rt 142 -o color0.png      # Render target at EID
-rdc buffer 3 -o data.bin      # Raw buffer data
-```
-
-### Search and counters
-
-```bash
-rdc search "gl_Position"      # Grep across all shaders
-rdc counters --list           # Available GPU counters
-rdc counters                  # Fetch counter values
-rdc counters --eid 142        # Counters at specific event
-```
-
-### VFS (virtual filesystem)
-
-```bash
-rdc ls /                      # List VFS root
-rdc ls /draws/142/            # List draw subnodes
-rdc cat /draws/142/pipeline   # Read VFS leaf
-rdc tree /draws/142 --depth 3 # Tree view
-```
-
-### Unix helpers
-
-```bash
-rdc count draws               # Single integer count
-rdc count resources
-rdc events --type draw | wc -l
-rdc draws --json | jq '.draws[] | .triangles'
-```
+| Category | Commands |
+|----------|----------|
+| Session | `open`, `close`, `status`, `goto` |
+| Inspection | `info`, `stats`, `events`, `draws`, `event`, `draw`, `log` |
+| GPU state | `pipeline`, `bindings`, `shader`, `shaders`, `shader-map` |
+| Resources | `resources`, `resource`, `passes`, `pass`, `usage` |
+| Export | `texture`, `rt`, `buffer` |
+| Search | `search`, `counters` |
+| VFS | `ls`, `cat`, `tree` |
+| Utility | `doctor`, `completion`, `capture`, `count` |
 
 All commands support `--json` for machine-readable output.
+
+### Shell completions
+
+```bash
+rdc completion bash > ~/.local/share/bash-completion/completions/rdc
+rdc completion zsh > ~/.zfunc/_rdc
+eval "$(rdc completion bash)"
+```
 
 ## Development
 
 ```bash
-pixi install
 pixi run sync                 # Install Python deps
-pixi run lint                 # ruff check + format
-pixi run typecheck            # mypy
-pixi run test                 # Unit tests (637 tests, 92% coverage)
-pixi run check                # lint + typecheck + test
+pixi run check                # lint + typecheck + test (653 tests, 92% coverage)
 ```
 
-### GPU integration tests
-
-Requires a real renderdoc module and a GPU:
+GPU integration tests require a real renderdoc module:
 
 ```bash
 export RENDERDOC_PYTHON_PATH=/path/to/renderdoc/build/lib
-pixi run test-gpu             # 150 GPU integration tests
-pixi run test-all             # Full suite
-```
-
-## Docker
-
-```bash
-docker build -t rdc-cli-dev -f docker/Dockerfile .
-docker run --rm -it -v "$PWD":/workspace rdc-cli-dev bash
-# Inside container:
-uv sync && rdc doctor
+pixi run test-gpu
 ```
 
 ## License


### PR DESCRIPTION
### **User description**
## Summary
- Replace verbose command listings with quick-start example, 3 install methods (pipx/AUR/source), renderdoc setup guide, and command category table
- Follows design decision from 打包分发.md: "简洁四段式，不重复维护"
- README now links to `rdc --help` instead of duplicating full command reference

## Test plan
- [x] All install methods documented (pipx, AUR, source)
- [x] renderdoc build steps match `rdc doctor` output
- [x] Command table covers all 33 commands
- [x] Shell completion instructions included


___

### **PR Type**
Documentation


___

### **Description**
- Restructured README into concise 4-part format: quick-start, install methods, renderdoc setup, command table

- Replaced verbose command listings with category table linking to `rdc --help`

- Added quick-start example showing 7 common use cases

- Streamlined install instructions (pipx, AUR, source) with renderdoc module discovery guide

- Simplified development and testing sections


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Verbose command listings"] -->|Replace| B["Category table + --help link"]
  C["Scattered install info"] -->|Consolidate| D["3 install methods + renderdoc setup"]
  E["No quick-start"] -->|Add| F["7-command example"]
  G["Verbose dev section"] -->|Simplify| H["Essential commands only"]
  B --> I["Concise 4-part README"]
  D --> I
  F --> I
  H --> I
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Restructure README into concise 4-part format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Replaced 148 lines of verbose command documentation with concise <br>4-part structure (104 lines)<br> <li> Added quick-start section with 7 practical command examples<br> <li> Consolidated install methods into 3 clear options: PyPI (pipx), AUR, <br>and source<br> <li> Created command category table linking to <code>rdc --help</code> instead of <br>duplicating full reference<br> <li> Expanded renderdoc setup section with build-from-source instructions <br>and module discovery order<br> <li> Streamlined development section to essential commands with test <br>coverage info<br> <li> Removed Docker section and verbose session workflow examples</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/25/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+53/-97</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions with simplified PyPI-based setup.
  * Added alternative installation methods (AUR and build-from-source options).
  * Clarified module discovery steps and usage patterns.
  * Enhanced development and testing guidance.
  * Added explicit note that all commands support JSON output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->