### PR TITLE
feat(aur): add PKGBUILD for rdc-cli-git with renderdoc module

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,91 @@
+# Maintainer: Jim <jim@example.com>
+pkgname=rdc-cli-git
+pkgver=0.1.0.r0.g0000000
+pkgrel=1
+pkgdesc="Unix-friendly CLI for RenderDoc captures"
+arch=('x86_64')
+url="https://github.com/BANANASJIM/rdc-cli"
+license=('MIT')
+depends=(
+  'python'
+  'python-click'
+  'libx11'
+  'libxcb'
+  'xcb-util-keysyms'
+)
+makedepends=(
+  'git'
+  'python-build'
+  'python-installer'
+  'python-setuptools'
+  'python-wheel'
+  'cmake'
+  'ninja'
+  'pcre'
+)
+optdepends=(
+  'python-pillow: texture/render target PNG export'
+  'python-numpy: buffer decode and diff support'
+)
+provides=('rdc-cli')
+conflicts=('rdc-cli')
+source=(
+  "git+https://github.com/BANANASJIM/rdc-cli.git"
+  "git+https://github.com/baldurk/renderdoc.git"
+  "renderdoc-swig::https://github.com/baldurk/swig/archive/renderdoc-modified-7.zip"
+)
+sha256sums=('SKIP'
+            'SKIP'
+            '9d7e5013ada6c42ec95ab167a34db52c1cc8c09b89c8e9373631b1f10596c648')
+
+pkgver() {
+  cd rdc-cli
+  git describe --long --tags 2>/dev/null | sed 's/^v//;s/-/.r/;s/-/./' ||
+    printf "0.1.0.r%s.g%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+  # Build renderdoc Python module (pyrenderdoc only, no Qt UI)
+  cd renderdoc
+  cmake -B build -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_PYRENDERDOC=ON \
+    -DENABLE_QRENDERDOC=OFF \
+    -DENABLE_RENDERDOCCMD=OFF \
+    -DENABLE_GL=OFF \
+    -DENABLE_GLES=OFF \
+    -DENABLE_VULKAN=ON \
+    -DRENDERDOC_SWIG_PACKAGE="$srcdir/renderdoc-modified-7.zip"
+  cmake --build build
+
+  # Build rdc-cli wheel
+  cd "$srcdir/rdc-cli"
+  python -m build --wheel --no-isolation
+
+  # Generate shell completion scripts
+  PYTHONPATH="$srcdir/rdc-cli/src" python -c "
+from rdc.commands.completion import _generate
+for shell, path in [('bash','$srcdir/rdc.bash'),('zsh','$srcdir/_rdc'),('fish','$srcdir/rdc.fish')]:
+    with open(path, 'w') as f:
+        f.write(_generate(shell))
+"
+}
+
+package() {
+  # Install rdc-cli
+  cd rdc-cli
+  python -m installer --destdir="$pkgdir" dist/*.whl
+
+  # Install renderdoc Python module
+  local _site="$(python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')"
+  install -Dm755 "$srcdir/renderdoc/build/lib/renderdoc.so" "$pkgdir/$_site/renderdoc.so"
+  install -Dm755 "$srcdir/renderdoc/build/lib/librenderdoc.so" "$pkgdir/$_site/librenderdoc.so"
+
+  # Install shell completions
+  install -Dm644 "$srcdir/rdc.bash" "$pkgdir/usr/share/bash-completion/completions/rdc"
+  install -Dm644 "$srcdir/_rdc" "$pkgdir/usr/share/zsh/site-functions/_rdc"
+  install -Dm644 "$srcdir/rdc.fish" "$pkgdir/usr/share/fish/vendor_completions.d/rdc.fish"
+
+  # Install license
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/openspec/changes/2026-02-20-phase2.5-aur-pkgbuild/proposal.md
+++ b/openspec/changes/2026-02-20-phase2.5-aur-pkgbuild/proposal.md
@@ -1,0 +1,34 @@
+# Phase 2.5 OpenSpec #4: AUR PKGBUILD
+
+## Summary
+
+Add `aur/PKGBUILD` for `rdc-cli-git` AUR package that builds renderdoc
+Python module from source and installs shell completions.
+
+## Motivation
+
+- Arch Linux is Jim's primary platform — AUR support is P0
+- Arch's `extra/renderdoc` package does NOT include the Python module
+- Users need a single `yay -S rdc-cli-git` to get everything working
+
+## Design
+
+### PKGBUILD structure
+
+- `source=()`: rdc-cli git repo, renderdoc git repo, baldurk's SWIG fork zip
+- `build()`: cmake renderdoc (pyrenderdoc only, no Qt/GL), build rdc-cli wheel,
+  generate shell completions
+- `package()`: install wheel, install renderdoc.so + librenderdoc.so to
+  site-packages, install completions to system paths
+
+### Key decisions
+
+- renderdoc built with `-DENABLE_QRENDERDOC=OFF -DENABLE_RENDERDOCCMD=OFF`
+  (Python module only, minimal build)
+- Custom SWIG fork pre-fetched via `source=()` to avoid network access in build
+- `librenderdoc.so` co-located with `renderdoc.so` in site-packages (RPATH=$ORIGIN)
+- Shell completions installed to standard system paths
+
+## Files
+
+- `aur/PKGBUILD` (new)

--- a/openspec/changes/2026-02-20-phase2.5-aur-pkgbuild/tasks.md
+++ b/openspec/changes/2026-02-20-phase2.5-aur-pkgbuild/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: AUR PKGBUILD
+
+- [x] Research renderdoc cmake build options and dependencies
+- [x] Write PKGBUILD with renderdoc Python module compilation
+- [x] Add shell completion generation and installation
+- [ ] Run namcap lint on PKGBUILD
+- [ ] Test makepkg -s in clean environment

--- a/openspec/changes/2026-02-20-phase2.5-aur-pkgbuild/test-plan.md
+++ b/openspec/changes/2026-02-20-phase2.5-aur-pkgbuild/test-plan.md
@@ -1,0 +1,35 @@
+# Test Plan: AUR PKGBUILD
+
+## Scope
+
+### In scope
+- PKGBUILD syntax and structure
+- Build-time dependency completeness
+- Runtime dependency completeness
+- Shell completion installation paths
+
+### Out of scope
+- Actual AUR submission (done manually)
+- Full makepkg build test (requires clean chroot, done manually)
+
+## Test Matrix
+
+| Layer | Target | Method |
+|-------|--------|--------|
+| Static | PKGBUILD syntax | `namcap` lint |
+| Static | Shell paths | Review standard Arch paths |
+| Manual | Full build | `makepkg -s` in clean chroot |
+| Manual | Install + smoke | `pacman -U`, `rdc doctor`, `rdc --help` |
+
+## Assertions
+
+- `pkgver()` produces valid version from git tags
+- `build()` compiles renderdoc with pyrenderdoc only (no Qt, no GL)
+- `package()` installs renderdoc.so + librenderdoc.so to site-packages
+- Shell completions at standard paths (bash/zsh/fish)
+- `rdc doctor` passes after install (renderdoc module found)
+
+## Risks
+
+- renderdoc build time is ~5min (acceptable for AUR -git package)
+- Python version upgrade breaks renderdoc.so (rebuild required)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "Unix-friendly CLI for RenderDoc captures"
 readme = "README.md"
 requires-python = ">=3.10"
+license = {text = "MIT"}
 authors = [{name = "Jim"}]
 dependencies = [
   "click>=8.1",


### PR DESCRIPTION
### **User description**
## Summary
- Add `aur/PKGBUILD` for `rdc-cli-git` AUR package
- Builds renderdoc Python module from source (pyrenderdoc only, no Qt/GL/renderdoccmd)
- Pre-fetches baldurk's custom SWIG fork zip for reproducible builds
- Installs `renderdoc.so` + `librenderdoc.so` to Python site-packages
- Generates and installs shell completions (bash/zsh/fish) to system paths
- Add MIT LICENSE file and `license` field to pyproject.toml

## User experience
```bash
yay -S rdc-cli-git    # builds everything
rdc doctor            # all checks pass
rdc open capture.rdc  # just works
```

## Test plan
- [ ] `namcap PKGBUILD` passes
- [ ] `makepkg -s` builds successfully in clean chroot
- [ ] `pacman -U rdc-cli-git-*.pkg.tar.zst` installs without errors
- [ ] `rdc doctor` passes (renderdoc module found in site-packages)
- [ ] `rdc --help` works, shell completion files present
- [ ] `pixi run check` passes (653 tests, 92% coverage)


___

### **PR Type**
Enhancement


___

### **Description**
- Add MIT LICENSE file and license metadata to pyproject.toml

- Create aur/PKGBUILD for rdc-cli-git AUR package
  - Builds renderdoc Python module from source (pyrenderdoc only)
  - Pre-fetches baldurk's custom SWIG fork for reproducible builds
  - Installs renderdoc.so and librenderdoc.so to Python site-packages
  - Generates and installs shell completions (bash/zsh/fish)

- Add OpenSpec documentation for Phase 2.5 AUR PKGBUILD feature


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LICENSE file"] --> B["MIT License metadata"]
  C["pyproject.toml"] --> B
  D["aur/PKGBUILD"] --> E["Build renderdoc module"]
  E --> F["Install to site-packages"]
  D --> G["Generate shell completions"]
  G --> H["Install to system paths"]
  I["OpenSpec documentation"] --> J["Design & test plan"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LICENSE</strong><dd><code>Add MIT License file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

LICENSE

<ul><li>Add MIT License file with copyright notice<br> <li> Provides legal framework for project distribution</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/27/files#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>proposal.md</strong><dd><code>Add OpenSpec proposal for AUR PKGBUILD</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/2026-02-20-phase2.5-aur-pkgbuild/proposal.md

<ul><li>Document motivation for AUR PKGBUILD (Arch Linux primary platform, <br>renderdoc Python module not in extra/renderdoc)<br> <li> Outline PKGBUILD structure and key design decisions<br> <li> Explain renderdoc build configuration (pyrenderdoc only, minimal <br>build)<br> <li> Detail shell completion installation to standard system paths</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/27/files#diff-7a2353f169353113d42ec0079f42edac5c8a0ff0c717d55a4914dbe010fa0c37">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.md</strong><dd><code>Add task checklist for AUR PKGBUILD</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/2026-02-20-phase2.5-aur-pkgbuild/tasks.md

<ul><li>List completed research and implementation tasks<br> <li> Identify pending manual testing tasks (namcap lint, makepkg build)</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/27/files#diff-56fb6e26d729ae94c06e0f29f5287a3d0ffacc1bdbb83ae9e9b725cf2d3d870f">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Add MIT license to pyproject.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Add <code>license = {text = "MIT"}</code> field to project metadata<br> <li> Declares MIT license in Python package configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/27/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PKGBUILD</strong><dd><code>Create PKGBUILD for rdc-cli-git AUR package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aur/PKGBUILD

<ul><li>Define package metadata (name, version, dependencies, conflicts)<br> <li> Implement <code>build()</code> function to compile renderdoc Python module with <br>cmake (pyrenderdoc only, no Qt/GL)<br> <li> Pre-fetch baldurk's SWIG fork zip for reproducible builds<br> <li> Generate shell completions (bash/zsh/fish) from rdc CLI<br> <li> Implement <code>package()</code> function to install wheel, <br>renderdoc.so/librenderdoc.so to site-packages, and completions to <br>system paths</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/27/files#diff-4898cf5c920fa6232cc4c9470b2571f243d2327b8fa48a219be8031e7d6a4e22">+89/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test-plan.md</strong><dd><code>Add comprehensive test plan for AUR PKGBUILD</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/2026-02-20-phase2.5-aur-pkgbuild/test-plan.md

<ul><li>Define test scope (PKGBUILD syntax, dependencies, shell paths)<br> <li> Specify test matrix with static and manual test layers<br> <li> Document assertions for build, install, and runtime behavior<br> <li> Identify risks (build time, Python version compatibility)</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/27/files#diff-ecbdabecd3f5ef63632cade330a9adf89efb570c8cf33c1b02bb2ab17a8c2bcd">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

