### PR TITLE
feat(vfs): add shell completion for VFS path arguments

### DIFF
--- a/openspec/changes/2026-02-20-vfs-path-completion/proposal.md
+++ b/openspec/changes/2026-02-20-vfs-path-completion/proposal.md
@@ -1,0 +1,47 @@
+# Proposal: VFS Path Shell Completion
+
+## Summary
+
+Wire Click 8's native `shell_complete` callback into `rdc ls`, `rdc cat`, and
+`rdc tree` path arguments so that `rdc ls /dr<TAB>` expands to `/draws/`.
+
+## Motivation
+
+`rdc completion` generates shell scripts that handle command/option completion,
+but VFS path arguments complete as filesystem paths (useless). The hidden
+`_complete` command already queries the daemon for VFS children but is not
+connected to the shell completion system.
+
+## Design
+
+Add a single `_complete_vfs_path(ctx, param, incomplete)` callback that:
+
+1. Parses `incomplete` into `dir_path` + `prefix`
+2. Calls `_daemon_call("vfs_ls", {"path": dir_path})`
+3. Filters children by prefix
+4. Returns `list[CompletionItem]` with `/` suffix for directories
+
+Wire it via `shell_complete=_complete_vfs_path` on the `path` argument of
+`ls_cmd`, `cat_cmd`, and `tree_cmd`.
+
+No new shell scripts needed — Click's generated scripts already invoke the
+completion system. Users must re-source their completion script after upgrade.
+
+### Edge cases
+
+- No active session → `_daemon_call` raises `SystemExit` → return `[]`
+- Root completion (`/d`) → list `/` children, filter by `d`
+- Nested completion (`/draws/14`) → list `/draws/` children, filter by `14`
+- Empty incomplete → list all children of `/`
+
+## Scope
+
+**In:** `_complete_vfs_path` callback, `shell_complete=` on 3 commands, unit tests.
+
+**Out:** `_complete` hidden command removal (keep for manual testing), new shell
+script format, fish/bash-specific workarounds.
+
+## Files Changed
+
+- `src/rdc/commands/vfs.py` — add callback, modify 3 argument decorators
+- `tests/unit/test_vfs_completion.py` — new test file

--- a/openspec/changes/2026-02-20-vfs-path-completion/tasks.md
+++ b/openspec/changes/2026-02-20-vfs-path-completion/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: VFS Path Shell Completion
+
+## Phase A: Tests
+
+- [ ] Create `tests/unit/test_vfs_completion.py`
+- [ ] Test `_complete_vfs_path` with mocked `_daemon_call` — 8 cases
+- [ ] Test argument wiring on `ls_cmd`, `cat_cmd`, `tree_cmd` — 3 cases
+
+## Phase B: Implementation
+
+- [ ] Add `_complete_vfs_path(ctx, param, incomplete)` to `src/rdc/commands/vfs.py`
+- [ ] Add `shell_complete=_complete_vfs_path` to `ls_cmd` path argument
+- [ ] Add `shell_complete=_complete_vfs_path` to `cat_cmd` path argument
+- [ ] Add `shell_complete=_complete_vfs_path` to `tree_cmd` path argument
+
+## Phase C: Verify
+
+- [ ] `pixi run check` passes (lint + typecheck + test)
+- [ ] Manual smoke test: `rdc completion zsh | source /dev/stdin && rdc ls /d<TAB>`

--- a/openspec/changes/2026-02-20-vfs-path-completion/test-plan.md
+++ b/openspec/changes/2026-02-20-vfs-path-completion/test-plan.md
@@ -1,0 +1,50 @@
+# Test Plan: VFS Path Shell Completion
+
+## Scope
+
+**In:** `_complete_vfs_path` callback logic, integration with `ls_cmd`/`cat_cmd`/`tree_cmd`.
+
+**Out:** Actual shell integration (bash/zsh/fish runtime behavior), `_complete` hidden command.
+
+## Test Matrix
+
+| Layer | What | Count |
+|-------|------|-------|
+| Unit | `_complete_vfs_path` callback with mock daemon | 8 |
+| Unit | Argument wiring verification | 3 |
+
+## Cases
+
+### Happy path
+
+1. **Root completion** — incomplete=`/d` → returns `["/draws/"]`
+2. **Root all** — incomplete=`` (empty) → returns all root children
+3. **Nested dir** — incomplete=`/draws/` → returns EID children
+4. **Nested partial** — incomplete=`/draws/14` → filters to matching EIDs
+5. **Leaf vs dir suffix** — dirs get `/`, leaves don't
+6. **Deep path** — incomplete=`/draws/142/sh` → returns `/draws/142/shader/`
+
+### Error path
+
+7. **No session** — `_daemon_call` raises `SystemExit` → returns `[]`
+8. **Invalid path** — daemon returns empty children → returns `[]`
+
+### Wiring
+
+9. **ls_cmd path has shell_complete** — verify callback is wired
+10. **cat_cmd path has shell_complete** — verify callback is wired
+11. **tree_cmd path has shell_complete** — verify callback is wired
+
+## Assertions
+
+- Return type is `list[CompletionItem]`
+- Each item's `value` is a full path (not just the child name)
+- Directory items end with `/`
+- Leaf items do not end with `/`
+- Empty list on error (no exception propagation)
+
+## Risks & Rollback
+
+- **Risk:** Completion callback makes daemon call during shell completion — adds
+  latency. Mitigation: VFS ls is fast (tree cache), acceptable for TAB.
+- **Rollback:** Remove `shell_complete=` parameter from 3 decorators.

--- a/tests/unit/test_vfs_completion.py
+++ b/tests/unit/test_vfs_completion.py
@@ -1,0 +1,139 @@
+"""Tests for _complete_vfs_path shell completion callback and command wiring."""
+
+from __future__ import annotations
+
+from click.shell_completion import CompletionItem
+
+import rdc.commands.vfs as vfs_mod
+from rdc.commands.vfs import _complete_vfs_path, cat_cmd, ls_cmd, tree_cmd
+
+_ROOT_CHILDREN = [
+    {"name": "info", "kind": "leaf"},
+    {"name": "draws", "kind": "dir"},
+    {"name": "events", "kind": "dir"},
+    {"name": "stats", "kind": "leaf"},
+]
+
+_DRAWS_CHILDREN = [
+    {"name": "140", "kind": "dir"},
+    {"name": "141", "kind": "dir"},
+    {"name": "142", "kind": "dir"},
+    {"name": "200", "kind": "dir"},
+]
+
+_DRAW_142_CHILDREN = [
+    {"name": "shader", "kind": "dir"},
+    {"name": "pipeline", "kind": "dir"},
+    {"name": "descriptors", "kind": "leaf"},
+]
+
+
+def _patch(monkeypatch, children: list[dict]) -> None:
+    monkeypatch.setattr(vfs_mod, "_daemon_call", lambda method, params=None: {"children": children})
+
+
+def _values(items: list[CompletionItem]) -> list[str]:
+    return [item.value for item in items]
+
+
+# ── _complete_vfs_path callback ──────────────────────────────────────
+
+
+def test_complete_root_partial(monkeypatch) -> None:
+    _patch(monkeypatch, _ROOT_CHILDREN)
+    result = _complete_vfs_path(ctx=None, param=None, incomplete="/d")
+    values = _values(result)
+    assert "/draws/" in values
+    assert "/info" not in values
+
+
+def test_complete_root_empty(monkeypatch) -> None:
+    _patch(monkeypatch, _ROOT_CHILDREN)
+    result = _complete_vfs_path(ctx=None, param=None, incomplete="")
+    values = _values(result)
+    assert "/draws/" in values
+    assert "/events/" in values
+    assert "/info" in values
+    assert "/stats" in values
+
+
+def test_complete_nested_dir(monkeypatch) -> None:
+    called_with: list[dict] = []
+
+    def fake_call(method: str, params: dict | None = None) -> dict:
+        if params:
+            called_with.append(params)
+        return {"children": _DRAWS_CHILDREN}
+
+    monkeypatch.setattr(vfs_mod, "_daemon_call", fake_call)
+    result = _complete_vfs_path(ctx=None, param=None, incomplete="/draws/")
+    assert called_with[0]["path"] == "/draws"
+    values = _values(result)
+    assert "/draws/142/" in values
+    assert "/draws/140/" in values
+
+
+def test_complete_nested_partial(monkeypatch) -> None:
+    _patch(monkeypatch, _DRAWS_CHILDREN)
+    result = _complete_vfs_path(ctx=None, param=None, incomplete="/draws/14")
+    values = _values(result)
+    assert "/draws/140/" in values
+    assert "/draws/141/" in values
+    assert "/draws/142/" in values
+    assert "/draws/200/" not in values
+
+
+def test_complete_leaf_no_slash(monkeypatch) -> None:
+    children = [
+        {"name": "descriptors", "kind": "leaf"},
+        {"name": "binary_buf", "kind": "leaf_bin"},
+        {"name": "shader", "kind": "dir"},
+    ]
+    _patch(monkeypatch, children)
+    result = _complete_vfs_path(ctx=None, param=None, incomplete="/draws/142/")
+    values = _values(result)
+    assert "/draws/142/descriptors" in values
+    assert "/draws/142/binary_buf" in values
+    assert "/draws/142/shader/" in values
+
+
+def test_complete_deep_path(monkeypatch) -> None:
+    _patch(monkeypatch, _DRAW_142_CHILDREN)
+    result = _complete_vfs_path(ctx=None, param=None, incomplete="/draws/142/sh")
+    values = _values(result)
+    assert "/draws/142/shader/" in values
+    assert "/draws/142/pipeline/" not in values
+
+
+def test_complete_no_session(monkeypatch) -> None:
+    def fake_call(method: str, params: dict | None = None) -> dict:
+        raise SystemExit(1)
+
+    monkeypatch.setattr(vfs_mod, "_daemon_call", fake_call)
+    result = _complete_vfs_path(ctx=None, param=None, incomplete="/d")
+    assert result == []
+
+
+def test_complete_no_matches(monkeypatch) -> None:
+    _patch(monkeypatch, _ROOT_CHILDREN)
+    result = _complete_vfs_path(ctx=None, param=None, incomplete="/xyz")
+    assert result == []
+
+
+# ── argument wiring ──────────────────────────────────────────────────
+
+
+def _path_param(cmd):
+    return next(p for p in cmd.params if p.name == "path")
+
+
+def test_ls_cmd_has_shell_complete() -> None:
+    assert _path_param(ls_cmd).shell_complete is not None
+
+
+def test_cat_cmd_has_shell_complete() -> None:
+    assert _path_param(cat_cmd).shell_complete is not None
+
+
+def test_tree_cmd_has_shell_complete() -> None:
+    assert _path_param(tree_cmd).shell_complete is not None


### PR DESCRIPTION
## Summary

- Add `_complete_vfs_path` Click 8 `shell_complete` callback that queries the daemon for VFS children during tab completion
- Wire callback into `rdc ls`, `rdc cat`, `rdc tree` path arguments
- `rdc ls /dr<TAB>` now expands to `/draws/`, `rdc cat /draws/142/sh<TAB>` expands to `/draws/142/shader/`, etc.
- No session → silently returns empty completions (no crash)
- Existing `_complete` hidden command preserved for manual testing

## Test plan

- 11 new unit tests in `test_vfs_completion.py` (8 callback logic + 3 wiring verification)
- 664 total tests, 92.54% coverage, lint + mypy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added shell tab-completion support for VFS paths in the `ls`, `cat`, and `tree` commands. Users can now press Tab to auto-complete VFS path inputs, with trailing slashes automatically added for directories. Supports nested paths, root paths, and partial input completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->