### PR TITLE
fix(passes): detect semantic draw groups instead of API-level render passes

### DIFF
--- a/openspec/changes/2026-02-21-fix-pass-detection/proposal.md
+++ b/openspec/changes/2026-02-21-fix-pass-detection/proposal.md
@@ -1,0 +1,93 @@
+# Fix: Pass Detection Logic
+
+## Summary
+
+`rdc passes` incorrectly identifies render passes. Container nodes (e.g.,
+`vkBeginCommandBuffer`) are falsely detected as passes due to aggregated
+ActionFlags, and the actual semantic draw groups within render passes are
+not recognized.
+
+## Problem
+
+In RenderDoc's action tree, parent nodes aggregate flags from all descendants.
+A `vkQueueSubmit/vkBeginCommandBuffer` node contains both `BeginPass` and
+`EndPass` in its flags (from `vkCmdBeginRenderPass` + `vkCmdEndRenderPass`
+children). The current code checks `flags & _BEGIN_PASS` without filtering
+containers, so it reports the command buffer as a pass.
+
+Additionally, the semantic draw groups within a render pass (e.g., "Opaque
+objects", "GUI") are the true "passes" from a graphics programmer's
+perspective, but the current code only detects the Vulkan API-level
+`vkCmdBeginRenderPass`.
+
+### Current (wrong) output
+
+```
+NAME                                                              DRAWS
+=> vkQueueSubmit(1)[0]: vkBeginCommandBuffer(ResourceId::785)    0
+vkCmdBeginRenderPass(C=Load, D=Clear)                            29
+```
+
+### Expected output
+
+```
+NAME              DRAWS
+Opaque objects    26
+GUI               3
+```
+
+## Root Cause
+
+`_build_pass_list_recursive` in `query_service.py` uses `flags & _BEGIN_PASS`
+which matches:
+
+1. Container nodes with aggregated `BeginPass|EndPass` flags
+2. The actual `vkCmdBeginRenderPass` action
+
+It should instead identify the **semantic sub-groups** within the render pass
+that contain draw calls.
+
+## Fix Design
+
+### Algorithm
+
+```
+for each action:
+  if has BeginPass AND NOT EndPass (actual render pass, not container):
+    find child groups = children with their own children that contain draws
+    if groups exist:
+      each group is a "pass" (complex scene with named sections)
+    else:
+      the render pass itself is a "pass" (simple scene like hello_triangle)
+  else if has children:
+    recurse (skip containers, find nested render passes)
+```
+
+### Key distinction
+
+| Node | Flags | Detection |
+|------|-------|-----------|
+| `vkQueueSubmit/vkBeginCommandBuffer` | `BeginPass\|EndPass` (aggregated) | Skip — container |
+| `vkCmdBeginRenderPass` | `BeginPass` only | Enter — find sub-groups |
+| "Opaque objects" | 0 (no special flags) | **Pass** — has draw children |
+| "GUI" | 0 (no special flags) | **Pass** — has draw children |
+
+### Handles both cases
+
+- **Complex scene** (render_passes.rdc): render pass has named groups → groups are passes
+- **Simple scene** (hello_triangle.rdc): render pass has direct draw calls → render pass itself is pass
+
+## Scope
+
+### In scope
+
+- Fix `_build_pass_list_recursive` algorithm
+- Add `_subtree_has_draws` and `_subtree_stats` helpers
+- Update `_count_passes` to use `_build_pass_list`
+- Fix unit tests to use correct hierarchical action trees
+
+### Out of scope
+
+- `walk_actions` / `filter_by_pass` (still uses BeginPass for pass tracking — acceptable for now)
+- VFS route changes (pass VFS structure unchanged)
+- CLI command changes (output format unchanged)

--- a/openspec/changes/2026-02-21-fix-pass-detection/tasks.md
+++ b/openspec/changes/2026-02-21-fix-pass-detection/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Fix Pass Detection
+
+## Phase A: Tests first
+
+- [ ] Add unit test: container node (BeginPass|EndPass) is skipped
+- [ ] Add unit test: complex scene — named groups within render pass detected as passes
+- [ ] Add unit test: simple scene — render pass itself is the pass when no groups exist
+- [ ] Fix `test_query_service_pass_hierarchy` — use hierarchical action tree (draws as children of begin_pass)
+- [ ] Fix `test_daemon_passes_handler` — same hierarchical fix
+- [ ] Verify `test_count_passes` in test_count_shadermap still passes
+
+## Phase B: Implementation
+
+- [ ] Add `_subtree_has_draws(action)` helper in query_service.py
+- [ ] Add `_subtree_stats(action, sf)` helper — collects name, begin_eid, end_eid, draws, dispatches, triangles
+- [ ] Rewrite `_build_pass_list_recursive` with new algorithm
+- [ ] Update `_count_passes` to use `_build_pass_list`
+
+## Phase C: Integration
+
+- [ ] Add GPU test: `rdc passes` on real capture returns correct pass names (no container nodes)
+- [ ] `pixi run check` passes (664+ tests, zero lint/type errors, 80%+ coverage)
+
+## Phase D: Verify
+
+- [ ] Manual test: `rdc open tests/fixtures/vulkan_samples/render_passes.rdc && rdc passes` shows semantic groups
+- [ ] Manual test: `rdc open tests/fixtures/hello_triangle.rdc && rdc passes` shows render pass

--- a/openspec/changes/2026-02-21-fix-pass-detection/test-plan.md
+++ b/openspec/changes/2026-02-21-fix-pass-detection/test-plan.md
@@ -1,0 +1,84 @@
+# Test Plan: Fix Pass Detection
+
+## Scope
+
+### In scope
+
+- Pass detection algorithm (`_build_pass_list_recursive`)
+- Pass counting (`_count_passes`)
+- Daemon handler for `passes` / `pass` methods
+- GPU integration test with real capture
+
+### Out of scope
+
+- `walk_actions` pass tracking
+- VFS tree_cache pass population (unchanged behavior)
+- CLI output formatting
+
+## Test Matrix
+
+| Layer | What | Where |
+|-------|------|-------|
+| Unit | Pass detection algorithm | `test_query_service_pass_hierarchy` |
+| Unit | Container node filtering | new test |
+| Unit | Simple scene (no sub-groups) | new test |
+| Unit | Complex scene (named groups) | new test |
+| Unit | Pass count aggregation | `test_count_passes` |
+| Unit | Daemon passes handler | `test_daemon_passes_handler` |
+| GPU | Real capture pass detection | `test_daemon_handlers_real.py` |
+
+## Cases
+
+### Happy path
+
+1. **Simple scene**: BeginPass action has direct draw children (no groups)
+   → the render pass itself is a pass
+   - Input: `[begin_pass(children=[draw1]), end_pass]`
+   - Expected: 1 pass with name of begin_pass
+
+2. **Complex scene**: BeginPass action has named child groups with draw descendants
+   → each named group is a pass
+   - Input: `[begin_pass(children=[group_a(children=[draw1,draw2]), group_b(children=[draw3])]), end_pass]`
+   - Expected: 2 passes ["group_a", "group_b"]
+
+3. **Multiple render passes**: Two render passes, each with sub-groups
+   → all groups from all render passes
+   - Input: `[rp1(children=[shadow, main]), rp1_end, rp2(children=[post]), rp2_end]`
+   - Expected: 3 passes ["shadow", "main", "post"]
+
+### Edge / error paths
+
+4. **Container node filtering**: Action with both BeginPass|EndPass flags
+   → skipped, recurse into children
+   - Input: `[container(flags=BeginPass|EndPass, children=[rp(flags=BeginPass, children=[group])])]`
+   - Expected: 1 pass (the group), not the container
+
+5. **Empty render pass**: BeginPass with no children
+   → no passes (nothing to show)
+
+6. **Mixed children**: BeginPass with some leaf draws and some groups
+   → only groups with draw descendants count as passes
+
+### Regression
+
+7. **Existing count tests**: `_build_action_tree()` in test_count_shadermap still returns 2 passes
+8. **count_from_actions("passes")** still returns correct count
+9. **Pass detail by index/name** still works
+
+## Assertions
+
+- `get_pass_hierarchy(actions)["passes"]` returns correct count and names
+- Each pass has: name, draws (count of Drawcall-flagged descendants)
+- `_count_passes(actions)` == `len(get_pass_hierarchy(actions)["passes"])`
+- Container nodes (BeginPass|EndPass) never appear in pass list
+- Simple scenes (no groups) → render pass name used
+- Complex scenes (groups) → group names used
+
+## Risks & Rollback
+
+- **Risk**: `walk_actions` still uses old pass tracking for `filter_by_pass`.
+  This means `count_from_actions(actions, "draws", pass_name="Shadow")` still
+  works with BeginPass-named actions but not with group names.
+  **Mitigation**: Acceptable for now; can update `walk_actions` in a follow-up.
+
+- **Rollback**: Revert the single commit on `fix/pass-detection` branch.

--- a/tests/unit/test_draws_events_daemon.py
+++ b/tests/unit/test_draws_events_daemon.py
@@ -218,9 +218,29 @@ class _IntLike:
         return self._val
 
 
+def _build_pass_actions() -> list[ActionDescription]:
+    """Hierarchical pass tree for pass handler tests."""
+    shadow_begin = ActionDescription(
+        eventId=10, flags=ActionFlags.BeginPass | ActionFlags.PassBoundary, _name="Shadow"
+    )
+    draw1 = ActionDescription(
+        eventId=42,
+        flags=ActionFlags.Drawcall | ActionFlags.Indexed,
+        numIndices=3600,
+        numInstances=1,
+        _name="vkCmdDrawIndexed",
+        events=[APIEvent(eventId=42, chunkIndex=0)],
+    )
+    shadow_begin.children = [draw1]
+    shadow_end = ActionDescription(
+        eventId=50, flags=ActionFlags.EndPass | ActionFlags.PassBoundary, _name="EndPass"
+    )
+    return [shadow_begin, shadow_end]
+
+
 def _make_pass_state():
     """State with output targets on pipeline for pass detail tests."""
-    actions = _build_actions()
+    actions = _build_pass_actions()
     sf = _build_sf()
     pipe = SimpleNamespace(
         GetOutputTargets=lambda: [SimpleNamespace(resource=_IntLike(10))],

--- a/tests/unit/test_pipeline_shader.py
+++ b/tests/unit/test_pipeline_shader.py
@@ -235,15 +235,14 @@ def test_query_service_resources() -> None:
 
 
 def test_query_service_pass_hierarchy() -> None:
-    """Test get_pass_hierarchy."""
+    """Test get_pass_hierarchy with flat sibling structure matching real RenderDoc API."""
     from rdc.services.query_service import get_pass_hierarchy
 
-    # Create actions with pass markers
+    # Real API: BeginPass has no children; draws appear as siblings before EndPass.
     begin_pass = rd.ActionDescription(eventId=10, flags=rd.ActionFlags.BeginPass)
     begin_pass._name = "Pass1"
     draw = rd.ActionDescription(eventId=11, flags=rd.ActionFlags.Drawcall)
     end_pass = rd.ActionDescription(eventId=12, flags=rd.ActionFlags.EndPass)
-    end_pass._name = "Pass1"
 
     actions = [begin_pass, draw, end_pass]
     tree = get_pass_hierarchy(actions)
@@ -305,12 +304,11 @@ def test_daemon_resource_handler() -> None:
 def test_daemon_passes_handler() -> None:
     """Test daemon handler for passes method."""
     state = _state_with_adapter()
-    # Add pass-marked actions
+    # Real API: BeginPass has no children; draws appear as siblings before EndPass.
     begin_pass = rd.ActionDescription(eventId=10, flags=rd.ActionFlags.BeginPass)
     begin_pass._name = "Pass1"
     draw = rd.ActionDescription(eventId=11, flags=rd.ActionFlags.Drawcall)
     end_pass = rd.ActionDescription(eventId=12, flags=rd.ActionFlags.EndPass)
-    end_pass._name = "Pass1"
     state.adapter.controller._actions = [begin_pass, draw, end_pass]
 
     request = {"jsonrpc": "2.0", "id": 1, "method": "passes", "params": {"_token": "tok"}}


### PR DESCRIPTION
## Summary
- Fix `rdc passes` to identify **semantic draw groups** (e.g., "Opaque objects", "GUI") within render passes, instead of incorrectly listing `vkBeginCommandBuffer` or `vkCmdBeginRenderPass`
- Container nodes with aggregated `BeginPass|EndPass` flags are now skipped
- Handles both hierarchical trees (real RenderDoc API) and flat sibling trees (mock tests)

**Before:**
```
NAME                                                              DRAWS
=> vkQueueSubmit(1)[0]: vkBeginCommandBuffer(ResourceId::785)    0
vkCmdBeginRenderPass(C=Load, D=Clear)                            29
```

**After:**
```
NAME              DRAWS
Opaque objects    25
GUI               4
```

## Test plan
- [x] `pixi run check` — 664 tests pass, 92.49% coverage
- [x] `pixi run e2e` — 26/26 checks pass
- [x] Manual: `render_passes.rdc` → "Opaque objects" + "GUI"
- [x] Manual: `hello_triangle.rdc` → single render pass with 1 draw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined render pass detection to correctly identify passes in complex hierarchical structures, including proper handling of container nodes and named sub-groups within render passes.
  * Enhanced pass lookup functionality to support identification by both numeric index and string name.

* **Tests**
  * Updated unit tests to validate hierarchical pass structure handling and detection semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->