### PR TITLE
feat(pipeline): add push-constants, rasterizer, depth-stencil, msaa sections

### DIFF
--- a/openspec/changes/2026-02-20-phase2.6-pipeline-extended/proposal.md
+++ b/openspec/changes/2026-02-20-phase2.6-pipeline-extended/proposal.md
@@ -1,0 +1,49 @@
+# Proposal: phase2.6-pipeline-extended
+
+## Summary
+
+Add 4 new pipeline state sections as VFS leaves under `/draws/<eid>/pipeline/`:
+`push-constants`, `rasterizer`, `depth-stencil`, `msaa`.
+
+## Motivation
+
+Phase 2 established the pipeline VFS namespace. Phase 2.6 extends it with the
+remaining common Vulkan state blocks that renderers typically inspect for
+debugging rasterization and depth/stencil behavior.
+
+## Design
+
+Each section is a leaf node resolved by a new route in `router.py` and handled
+in `daemon_server.py`. Data is read from `get_pipeline_state()` attributes:
+
+| Section         | Handler               | Source attribute      |
+|-----------------|-----------------------|-----------------------|
+| push-constants  | pipe_push_constants   | GetShaderReflection   |
+| rasterizer      | pipe_rasterizer       | pipe_state.rasterizer |
+| depth-stencil   | pipe_depth_stencil    | pipe_state.depthStencil |
+| msaa            | pipe_msaa             | pipe_state.multisample |
+
+### push-constants
+Iterates active shader stages. For each stage with a shader bound, reads
+`pushConstantRangeByteOffset` and `pushConstantRangeByteSize` from shader
+reflection. Returns list of `{stage, offset, size}`.
+
+### rasterizer
+Reads `fillMode`, `cullMode`, `frontCCW`, `depthBiasEnable`,
+`depthBiasConstantFactor`, `depthBiasClamp`, `depthBiasSlopeFactor`,
+`lineWidth` from `pipe_state.rasterizer`. Enum values serialized via `.name`.
+
+### depth-stencil
+Reads `depthTestEnable`, `depthWriteEnable`, `depthFunction`,
+`depthBoundsEnable`, `minDepthBounds`, `maxDepthBounds`, `stencilTestEnable`
+from `pipe_state.depthStencil`. Enum values serialized via `.name`.
+
+### msaa
+Reads `rasterSamples`, `sampleShadingEnable`, `minSampleShading`,
+`sampleMask` from `pipe_state.multisample`.
+
+## Non-Goals
+
+- No binary/image output
+- No write operations
+- No D3D11/D3D12/GL-specific path (getattr-safe, returns partial data)

--- a/openspec/changes/2026-02-20-phase2.6-pipeline-extended/tasks.md
+++ b/openspec/changes/2026-02-20-phase2.6-pipeline-extended/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: phase2.6-pipeline-extended
+
+## Implementation checklist
+
+- [x] Add 4 mock attributes to `MockPipeState.__init__`
+- [x] Add `pushConstantRangeByteOffset/Size` to `ShaderReflection`
+- [x] Write unit tests for all 4 handlers
+- [x] Add 4 entries to `_PIPELINE_CHILDREN` in `tree_cache.py`
+- [x] Add 4 routes to `router.py`
+- [x] Implement 4 handler blocks in `daemon_server.py`
+- [x] `pixi run check` passes
+- [x] Commit and open PR

--- a/openspec/changes/2026-02-20-phase2.6-pipeline-extended/test-plan.md
+++ b/openspec/changes/2026-02-20-phase2.6-pipeline-extended/test-plan.md
@@ -1,0 +1,67 @@
+# Test Plan: phase2.6-pipeline-extended
+
+## Scope
+
+**In:**
+- Unit tests for all 4 new daemon handlers
+- VFS tree includes new pipeline children
+- Router resolves new paths correctly
+
+**Out:**
+- GPU integration tests (real renderdoc capture required, deferred)
+- D3D/GL API paths
+
+## Test Matrix
+
+| Layer       | Tool      | Coverage target |
+|-------------|-----------|-----------------|
+| unit/mock   | pytest    | all 4 handlers  |
+| router      | pytest    | 4 new routes    |
+| tree cache  | pytest    | 4 new children  |
+
+## Cases
+
+### pipe_push_constants
+- Happy path: stage with push constant range returns `{stage, offset, size}`
+- No push constants: empty list returned
+- No adapter: error -32002
+- Stage with no shader bound: skipped
+
+### pipe_rasterizer
+- Happy path: rasterizer present, fields serialized correctly
+- Enum fields use `.name`
+- No rasterizer attribute: returns `{eid}` only
+- No adapter: error -32002
+
+### pipe_depth_stencil
+- Happy path: depthStencil present, fields serialized correctly
+- Enum field (depthFunction) uses `.name`
+- No depthStencil attribute: returns `{eid}` only
+- No adapter: error -32002
+
+### pipe_msaa
+- Happy path: multisample present, numeric fields returned
+- No multisample attribute: returns `{eid}` only
+- No adapter: error -32002
+
+### Router
+- `/draws/10/pipeline/push-constants` -> handler=pipe_push_constants, eid=10
+- `/draws/10/pipeline/rasterizer` -> handler=pipe_rasterizer, eid=10
+- `/draws/10/pipeline/depth-stencil` -> handler=pipe_depth_stencil, eid=10
+- `/draws/10/pipeline/msaa` -> handler=pipe_msaa, eid=10
+
+### VFS Tree
+- `build_vfs_skeleton` produces nodes for all 4 new children
+
+## Assertions
+
+- exit code 0, no error key in response
+- result contains `eid` field
+- push_constants list entries have `stage`, `offset`, `size`
+- rasterizer/depth-stencil enum fields are strings, not ints
+- msaa numeric fields are int/float
+
+## Risks & Rollback
+
+- Real API attribute names differ from mock: handled with `getattr(..., None)` guards
+- Rollback: revert commits on this branch, no schema breakage

--- a/src/rdc/daemon_server.py
+++ b/src/rdc/daemon_server.py
@@ -1245,6 +1245,96 @@ def _handle_request(request: dict[str, Any], state: DaemonState) -> tuple[dict[s
             },
         ), True
 
+    if method == "pipe_push_constants":
+        if state.adapter is None:
+            return _error_response(request_id, -32002, "no replay loaded"), True
+        eid = int(params.get("eid", state.current_eid))
+        err = _set_frame_event(state, eid)
+        if err:
+            return _error_response(request_id, -32002, err), True
+        pipe_state = state.adapter.get_pipeline_state()
+        stage_names = {0: "vs", 1: "hs", 2: "ds", 3: "gs", 4: "ps", 5: "cs"}
+        ranges: list[dict[str, Any]] = []
+        for stage_val, stage_name in stage_names.items():
+            if int(pipe_state.GetShader(stage_val)) == 0:
+                continue
+            refl = pipe_state.GetShaderReflection(stage_val)
+            if refl is None:
+                continue
+            offset = getattr(refl, "pushConstantRangeByteOffset", 0)
+            size = getattr(refl, "pushConstantRangeByteSize", 0)
+            if size > 0:
+                ranges.append({"stage": stage_name, "offset": offset, "size": size})
+        return _result_response(request_id, {"eid": eid, "push_constants": ranges}), True
+
+    if method == "pipe_rasterizer":
+        if state.adapter is None:
+            return _error_response(request_id, -32002, "no replay loaded"), True
+        eid = int(params.get("eid", state.current_eid))
+        err = _set_frame_event(state, eid)
+        if err:
+            return _error_response(request_id, -32002, err), True
+        pipe_state = state.adapter.get_pipeline_state()
+        rast = getattr(pipe_state, "rasterizer", None)
+        rast_data: dict[str, Any] = {"eid": eid}
+        if rast is not None:
+            for f in (
+                "fillMode",
+                "cullMode",
+                "frontCCW",
+                "depthBiasEnable",
+                "depthBiasConstantFactor",
+                "depthBiasClamp",
+                "depthBiasSlopeFactor",
+                "lineWidth",
+            ):
+                v = getattr(rast, f, None)
+                if v is not None:
+                    rast_data[f] = v.name if hasattr(v, "name") else v
+        return _result_response(request_id, rast_data), True
+
+    if method == "pipe_depth_stencil":
+        if state.adapter is None:
+            return _error_response(request_id, -32002, "no replay loaded"), True
+        eid = int(params.get("eid", state.current_eid))
+        err = _set_frame_event(state, eid)
+        if err:
+            return _error_response(request_id, -32002, err), True
+        pipe_state = state.adapter.get_pipeline_state()
+        ds = getattr(pipe_state, "depthStencil", None)
+        ds_data: dict[str, Any] = {"eid": eid}
+        if ds is not None:
+            for f in (
+                "depthTestEnable",
+                "depthWriteEnable",
+                "depthFunction",
+                "depthBoundsEnable",
+                "minDepthBounds",
+                "maxDepthBounds",
+                "stencilTestEnable",
+            ):
+                v = getattr(ds, f, None)
+                if v is not None:
+                    ds_data[f] = v.name if hasattr(v, "name") else v
+        return _result_response(request_id, ds_data), True
+
+    if method == "pipe_msaa":
+        if state.adapter is None:
+            return _error_response(request_id, -32002, "no replay loaded"), True
+        eid = int(params.get("eid", state.current_eid))
+        err = _set_frame_event(state, eid)
+        if err:
+            return _error_response(request_id, -32002, err), True
+        pipe_state = state.adapter.get_pipeline_state()
+        ms = getattr(pipe_state, "multisample", None)
+        ms_data: dict[str, Any] = {"eid": eid}
+        if ms is not None:
+            for f in ("rasterSamples", "sampleShadingEnable", "minSampleShading", "sampleMask"):
+                v = getattr(ms, f, None)
+                if v is not None:
+                    ms_data[f] = v
+        return _result_response(request_id, ms_data), True
+
     if method == "postvs":
         if state.adapter is None:
             return _error_response(request_id, -32002, "no replay loaded"), True

--- a/src/rdc/vfs/router.py
+++ b/src/rdc/vfs/router.py
@@ -65,6 +65,10 @@ _r(
 _r(r"/draws/(?P<eid>\d+)/pipeline/samplers", "leaf", "pipe_samplers", [("eid", int)])
 _r(r"/draws/(?P<eid>\d+)/pipeline/vbuffers", "leaf", "pipe_vbuffers", [("eid", int)])
 _r(r"/draws/(?P<eid>\d+)/pipeline/ibuffer", "leaf", "pipe_ibuffer", [("eid", int)])
+_r(r"/draws/(?P<eid>\d+)/pipeline/push-constants", "leaf", "pipe_push_constants", [("eid", int)])
+_r(r"/draws/(?P<eid>\d+)/pipeline/rasterizer", "leaf", "pipe_rasterizer", [("eid", int)])
+_r(r"/draws/(?P<eid>\d+)/pipeline/depth-stencil", "leaf", "pipe_depth_stencil", [("eid", int)])
+_r(r"/draws/(?P<eid>\d+)/pipeline/msaa", "leaf", "pipe_msaa", [("eid", int)])
 _r(r"/draws/(?P<eid>\d+)/shader", "dir", None, [("eid", int)])
 _r(
     rf"/draws/(?P<eid>\d+)/shader/(?P<stage>{_STAGES})",

--- a/src/rdc/vfs/tree_cache.py
+++ b/src/rdc/vfs/tree_cache.py
@@ -57,6 +57,10 @@ _PIPELINE_CHILDREN = [
     "samplers",
     "vbuffers",
     "ibuffer",
+    "push-constants",
+    "rasterizer",
+    "depth-stencil",
+    "msaa",
 ]
 _PASS_CHILDREN = ["info", "draws", "attachments"]
 _SHADER_STAGE_CHILDREN = ["disasm", "source", "reflect", "constants"]

--- a/tests/mocks/mock_renderdoc.py
+++ b/tests/mocks/mock_renderdoc.py
@@ -607,6 +607,58 @@ class StencilFace:
     writeMask: int = 0xFF
 
 
+class FillMode:
+    """Stub for fill mode enum with .name attribute."""
+
+    def __init__(self, name: str = "Solid") -> None:
+        self.name = name
+
+
+class CullMode:
+    """Stub for cull mode enum with .name attribute."""
+
+    def __init__(self, name: str = "None") -> None:
+        self.name = name
+
+
+class CompFunc:
+    """Stub for comparison function enum with .name attribute."""
+
+    def __init__(self, name: str = "LessEqual") -> None:
+        self.name = name
+
+
+@dataclass
+class RasterizerState:
+    fillMode: FillMode | None = None
+    cullMode: CullMode | None = None
+    frontCCW: bool | None = None
+    depthBiasEnable: bool | None = None
+    depthBiasConstantFactor: float | None = None
+    depthBiasClamp: float | None = None
+    depthBiasSlopeFactor: float | None = None
+    lineWidth: float | None = None
+
+
+@dataclass
+class DepthStencilState:
+    depthTestEnable: bool | None = None
+    depthWriteEnable: bool | None = None
+    depthFunction: CompFunc | None = None
+    depthBoundsEnable: bool | None = None
+    minDepthBounds: float | None = None
+    maxDepthBounds: float | None = None
+    stencilTestEnable: bool | None = None
+
+
+@dataclass
+class MultisampleState:
+    rasterSamples: int = 1
+    sampleShadingEnable: bool = False
+    minSampleShading: float = 0.0
+    sampleMask: int = 0xFFFFFFFF
+
+
 @dataclass
 class BoundVBuffer:
     resourceId: ResourceId = field(default_factory=ResourceId)
@@ -844,6 +896,8 @@ class ShaderReflection:
     rayPayload: Any = None
     rayAttributes: Any = None
     taskPayload: Any = None
+    pushConstantRangeByteOffset: int = 0
+    pushConstantRangeByteSize: int = 0
 
 
 @dataclass
@@ -914,6 +968,9 @@ class MockPipeState:
         self._ibuffer: BoundVBuffer = BoundVBuffer()
         self._cbuffer_descriptors: dict[tuple[int, int], Descriptor] = {}
         self._used_descriptors: list[UsedDescriptor] = []
+        self.rasterizer: RasterizerState | None = None
+        self.depthStencil: DepthStencilState | None = None
+        self.multisample: MultisampleState = MultisampleState()
 
     def GetShader(self, stage: ShaderStage) -> ResourceId:
         return self._shaders.get(stage, ResourceId.Null())

--- a/tests/unit/test_daemon_pipeline_extended.py
+++ b/tests/unit/test_daemon_pipeline_extended.py
@@ -1,0 +1,341 @@
+"""Tests for extended pipeline state handlers (phase2.6-pipeline-extended)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
+
+import mock_renderdoc as mock_rd
+from mock_renderdoc import (
+    ActionDescription,
+    ActionFlags,
+    DepthStencilState,
+    MockPipeState,
+    MultisampleState,
+    RasterizerState,
+    ResourceDescription,
+    ResourceId,
+    ShaderReflection,
+    ShaderStage,
+)
+
+from rdc.adapter import RenderDocAdapter
+from rdc.daemon_server import DaemonState, _handle_request
+from rdc.vfs.router import resolve_path
+from rdc.vfs.tree_cache import _PIPELINE_CHILDREN, build_vfs_skeleton
+
+
+def _build_actions() -> list[ActionDescription]:
+    return [ActionDescription(eventId=10, flags=ActionFlags.Drawcall, numIndices=3, _name="Draw")]
+
+
+def _build_resources() -> list[ResourceDescription]:
+    return [ResourceDescription(resourceId=ResourceId(1), name="res0")]
+
+
+def _req(method: str, **params: Any) -> dict[str, Any]:
+    p: dict[str, Any] = {"_token": "abcdef1234567890"}
+    p.update(params)
+    return {"id": 1, "method": method, "params": p}
+
+
+def _make_state(tmp_path: Path, pipe: MockPipeState) -> DaemonState:
+    actions = _build_actions()
+    resources = _build_resources()
+    controller = SimpleNamespace(
+        GetRootActions=lambda: actions,
+        GetResources=lambda: resources,
+        GetAPIProperties=lambda: SimpleNamespace(pipelineType="Vulkan"),
+        SetFrameEvent=lambda eid, force: None,
+        GetStructuredFile=lambda: SimpleNamespace(chunks=[]),
+        GetPipelineState=lambda: pipe,
+        GetTextures=lambda: [],
+        GetBuffers=lambda: [],
+        GetDebugMessages=lambda: [],
+        Shutdown=lambda: None,
+    )
+    s = DaemonState(capture="test.rdc", current_eid=0, token="abcdef1234567890")
+    s.adapter = RenderDocAdapter(controller=controller, version=(1, 41))
+    s.max_eid = 10
+    s.rd = mock_rd
+    s.temp_dir = tmp_path
+    s.vfs_tree = build_vfs_skeleton(actions, resources)
+    return s
+
+
+# ── VFS tree cache ────────────────────────────────────────────────────────────
+
+
+class TestPipelineChildren:
+    def test_new_children_in_list(self) -> None:
+        for name in ("push-constants", "rasterizer", "depth-stencil", "msaa"):
+            assert name in _PIPELINE_CHILDREN
+
+    def test_tree_has_pipeline_nodes(self, tmp_path: Path) -> None:
+        actions = _build_actions()
+        resources = _build_resources()
+        tree = build_vfs_skeleton(actions, resources)
+        node = tree.static["/draws/10/pipeline"]
+        for name in ("push-constants", "rasterizer", "depth-stencil", "msaa"):
+            assert name in node.children
+        for name in ("push-constants", "rasterizer", "depth-stencil", "msaa"):
+            assert f"/draws/10/pipeline/{name}" in tree.static
+
+
+# ── Router ────────────────────────────────────────────────────────────────────
+
+
+class TestPipelineExtendedRoutes:
+    def test_push_constants_route(self) -> None:
+        m = resolve_path("/draws/10/pipeline/push-constants")
+        assert m is not None
+        assert m.kind == "leaf"
+        assert m.handler == "pipe_push_constants"
+        assert m.args["eid"] == 10
+
+    def test_rasterizer_route(self) -> None:
+        m = resolve_path("/draws/10/pipeline/rasterizer")
+        assert m is not None
+        assert m.handler == "pipe_rasterizer"
+        assert m.args["eid"] == 10
+
+    def test_depth_stencil_route(self) -> None:
+        m = resolve_path("/draws/10/pipeline/depth-stencil")
+        assert m is not None
+        assert m.handler == "pipe_depth_stencil"
+        assert m.args["eid"] == 10
+
+    def test_msaa_route(self) -> None:
+        m = resolve_path("/draws/10/pipeline/msaa")
+        assert m is not None
+        assert m.handler == "pipe_msaa"
+        assert m.args["eid"] == 10
+
+    def test_eid_coercion(self) -> None:
+        for path, handler in (
+            ("/draws/42/pipeline/push-constants", "pipe_push_constants"),
+            ("/draws/42/pipeline/rasterizer", "pipe_rasterizer"),
+            ("/draws/42/pipeline/depth-stencil", "pipe_depth_stencil"),
+            ("/draws/42/pipeline/msaa", "pipe_msaa"),
+        ):
+            m = resolve_path(path)
+            assert m is not None
+            assert isinstance(m.args["eid"], int)
+            assert m.args["eid"] == 42
+            assert m.handler == handler
+
+
+# ── pipe_push_constants ───────────────────────────────────────────────────────
+
+
+class TestPipePushConstants:
+    def test_no_adapter(self) -> None:
+        s = DaemonState(capture="t.rdc", current_eid=0, token="abcdef1234567890")
+        resp, _ = _handle_request(_req("pipe_push_constants", eid=10), s)
+        assert resp["error"]["code"] == -32002
+
+    def test_empty_when_no_shaders(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        s = _make_state(tmp_path, pipe)
+        resp, _ = _handle_request(_req("pipe_push_constants", eid=10), s)
+        assert "error" not in resp
+        assert resp["result"]["push_constants"] == []
+        assert resp["result"]["eid"] == 10
+
+    def test_empty_when_size_is_zero(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        refl = ShaderReflection(
+            resourceId=ResourceId(5),
+            pushConstantRangeByteOffset=0,
+            pushConstantRangeByteSize=0,
+        )
+        pipe._shaders[ShaderStage.Vertex] = ResourceId(5)
+        pipe._reflections[ShaderStage.Vertex] = refl
+        s = _make_state(tmp_path, pipe)
+        resp, _ = _handle_request(_req("pipe_push_constants", eid=10), s)
+        assert resp["result"]["push_constants"] == []
+
+    def test_returns_range_when_size_nonzero(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        refl = ShaderReflection(
+            resourceId=ResourceId(5),
+            pushConstantRangeByteOffset=16,
+            pushConstantRangeByteSize=64,
+        )
+        pipe._shaders[ShaderStage.Vertex] = ResourceId(5)
+        pipe._reflections[ShaderStage.Vertex] = refl
+        s = _make_state(tmp_path, pipe)
+        resp, _ = _handle_request(_req("pipe_push_constants", eid=10), s)
+        ranges = resp["result"]["push_constants"]
+        assert len(ranges) == 1
+        assert ranges[0]["stage"] == "vs"
+        assert ranges[0]["offset"] == 16
+        assert ranges[0]["size"] == 64
+
+    def test_multiple_stages(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        for stage, stage_id in (
+            (ShaderStage.Vertex, 5),
+            (ShaderStage.Pixel, 6),
+        ):
+            refl = ShaderReflection(
+                resourceId=ResourceId(stage_id),
+                pushConstantRangeByteOffset=0,
+                pushConstantRangeByteSize=128,
+            )
+            pipe._shaders[stage] = ResourceId(stage_id)
+            pipe._reflections[stage] = refl
+        s = _make_state(tmp_path, pipe)
+        resp, _ = _handle_request(_req("pipe_push_constants", eid=10), s)
+        ranges = resp["result"]["push_constants"]
+        stage_names = {r["stage"] for r in ranges}
+        assert "vs" in stage_names
+        assert "ps" in stage_names
+
+
+# ── pipe_rasterizer ───────────────────────────────────────────────────────────
+
+
+class TestPipeRasterizer:
+    def test_no_adapter(self) -> None:
+        s = DaemonState(capture="t.rdc", current_eid=0, token="abcdef1234567890")
+        resp, _ = _handle_request(_req("pipe_rasterizer", eid=10), s)
+        assert resp["error"]["code"] == -32002
+
+    def test_happy_path(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        pipe.rasterizer = RasterizerState(frontCCW=True, lineWidth=1.5)
+        s = _make_state(tmp_path, pipe)
+        resp, _ = _handle_request(_req("pipe_rasterizer", eid=10), s)
+        r = resp["result"]
+        assert r["eid"] == 10
+        assert r["frontCCW"] is True
+        assert r["lineWidth"] == 1.5
+
+    def test_enum_fields_serialized_as_name(self, tmp_path: Path) -> None:
+        from mock_renderdoc import CullMode, FillMode
+
+        pipe = MockPipeState()
+        pipe.rasterizer = RasterizerState(
+            fillMode=FillMode("Wireframe"),
+            cullMode=CullMode("None"),
+        )
+        s = _make_state(tmp_path, pipe)
+        resp, _ = _handle_request(_req("pipe_rasterizer", eid=10), s)
+        r = resp["result"]
+        assert r["fillMode"] == "Wireframe"
+        assert r["cullMode"] == "None"
+
+    def test_no_rasterizer_attribute(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        del pipe.rasterizer
+        s = _make_state(tmp_path, pipe)
+        resp, _ = _handle_request(_req("pipe_rasterizer", eid=10), s)
+        assert resp["result"] == {"eid": 10}
+
+    def test_depth_bias_fields(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        pipe.rasterizer = RasterizerState(
+            depthBiasEnable=True,
+            depthBiasConstantFactor=2.0,
+            depthBiasClamp=0.5,
+            depthBiasSlopeFactor=1.5,
+        )
+        s = _make_state(tmp_path, pipe)
+        resp, _ = _handle_request(_req("pipe_rasterizer", eid=10), s)
+        r = resp["result"]
+        assert r["depthBiasEnable"] is True
+        assert r["depthBiasConstantFactor"] == 2.0
+        assert r["depthBiasClamp"] == 0.5
+        assert r["depthBiasSlopeFactor"] == 1.5
+
+
+# ── pipe_depth_stencil ────────────────────────────────────────────────────────
+
+
+class TestPipeDepthStencil:
+    def test_no_adapter(self) -> None:
+        s = DaemonState(capture="t.rdc", current_eid=0, token="abcdef1234567890")
+        resp, _ = _handle_request(_req("pipe_depth_stencil", eid=10), s)
+        assert resp["error"]["code"] == -32002
+
+    def test_happy_path(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        pipe.depthStencil = DepthStencilState(
+            depthTestEnable=True,
+            depthWriteEnable=True,
+            depthBoundsEnable=False,
+            minDepthBounds=0.0,
+            maxDepthBounds=1.0,
+            stencilTestEnable=False,
+        )
+        s = _make_state(tmp_path, pipe)
+        resp, _ = _handle_request(_req("pipe_depth_stencil", eid=10), s)
+        r = resp["result"]
+        assert r["eid"] == 10
+        assert r["depthTestEnable"] is True
+        assert r["depthWriteEnable"] is True
+        assert r["stencilTestEnable"] is False
+        assert r["minDepthBounds"] == 0.0
+        assert r["maxDepthBounds"] == 1.0
+
+    def test_depth_function_serialized_as_name(self, tmp_path: Path) -> None:
+        from mock_renderdoc import CompFunc
+
+        pipe = MockPipeState()
+        pipe.depthStencil = DepthStencilState(depthFunction=CompFunc("LessEqual"))
+        s = _make_state(tmp_path, pipe)
+        resp, _ = _handle_request(_req("pipe_depth_stencil", eid=10), s)
+        assert resp["result"]["depthFunction"] == "LessEqual"
+
+    def test_no_depth_stencil_attribute(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        del pipe.depthStencil
+        s = _make_state(tmp_path, pipe)
+        resp, _ = _handle_request(_req("pipe_depth_stencil", eid=10), s)
+        assert resp["result"] == {"eid": 10}
+
+
+# ── pipe_msaa ─────────────────────────────────────────────────────────────────
+
+
+class TestPipeMsaa:
+    def test_no_adapter(self) -> None:
+        s = DaemonState(capture="t.rdc", current_eid=0, token="abcdef1234567890")
+        resp, _ = _handle_request(_req("pipe_msaa", eid=10), s)
+        assert resp["error"]["code"] == -32002
+
+    def test_happy_path(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        pipe.multisample = MultisampleState(
+            rasterSamples=4,
+            sampleShadingEnable=True,
+            minSampleShading=0.5,
+            sampleMask=0xFFFF,
+        )
+        s = _make_state(tmp_path, pipe)
+        resp, _ = _handle_request(_req("pipe_msaa", eid=10), s)
+        r = resp["result"]
+        assert r["eid"] == 10
+        assert r["rasterSamples"] == 4
+        assert r["sampleShadingEnable"] is True
+        assert r["minSampleShading"] == 0.5
+        assert r["sampleMask"] == 0xFFFF
+
+    def test_default_single_sample(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        s = _make_state(tmp_path, pipe)
+        resp, _ = _handle_request(_req("pipe_msaa", eid=10), s)
+        r = resp["result"]
+        assert r["rasterSamples"] == 1
+
+    def test_no_multisample_attribute(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        del pipe.multisample
+        s = _make_state(tmp_path, pipe)
+        resp, _ = _handle_request(_req("pipe_msaa", eid=10), s)
+        assert resp["result"] == {"eid": 10}

--- a/tests/unit/test_vfs_tree_cache.py
+++ b/tests/unit/test_vfs_tree_cache.py
@@ -174,6 +174,10 @@ class TestBuildVfsSkeleton:
             "samplers",
             "vbuffers",
             "ibuffer",
+            "push-constants",
+            "rasterizer",
+            "depth-stencil",
+            "msaa",
         ]
         assert pipe.children == expected
 


### PR DESCRIPTION
## Summary
- Add 4 new pipeline state leaves under `/draws/<eid>/pipeline/`:
  - `push-constants` — per-stage push constant ranges
  - `rasterizer` — fill mode, cull mode, depth bias, line width
  - `depth-stencil` — depth/stencil test enables and functions
  - `msaa` — raster samples, sample shading, sample mask
- Add VFS routes, tree cache entries, and mock support

## Test plan
- [x] All 4 handlers return expected data (unit)
- [x] VFS tree includes new pipeline children (unit)
- [x] Router resolves new paths (unit)
- [ ] GPU integration test with real capture

## Priority
P2 — new pipeline state sections for richer inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new pipeline state inspection endpoints exposing push constants, rasterizer configuration (fill mode, cull mode, depth bias), depth-stencil settings, and MSAA parameters for improved debugging of rendering state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->