### PR TITLE
fix(output): use enum names, sanitize UINT_MAX sentinel, raise client timeout

### DIFF
--- a/openspec/changes/2026-02-20-phase2.6-output-quality/proposal.md
+++ b/openspec/changes/2026-02-20-phase2.6-output-quality/proposal.md
@@ -1,0 +1,48 @@
+# Proposal: phase2.6-output-quality
+
+## Summary
+
+Fix three output-quality issues in the daemon server and client:
+1. Enum values show as numeric repr instead of readable names
+2. UINT_MAX sentinel byte-size values show as large integers instead of "-"
+3. Client socket timeout is too short (2s) causing failures on slow handlers
+
+## Motivation
+
+- `pipe_topology`, `pipe_blend`, `pipe_stencil`, `pipe_samplers`, `postvs`: enum fields like
+  topology, blend factors, stencil ops, and address modes printed as `<BlendFactor.SrcAlpha: 3>`
+  instead of `"SrcAlpha"`.
+- `pipe_vbuffers`, `pipe_ibuffer`: RenderDoc uses `UINT64_MAX` as sentinel for "unknown size";
+  displaying as `18446744073709551615` is confusing.
+- `daemon_client.send_request` defaulted to 2s timeout; shader disassembly and heavy pipeline
+  queries can take longer, causing spurious `TimeoutError`.
+
+## Design
+
+### Helpers added to `daemon_server.py`
+
+```python
+_UINT_MAX_SENTINEL = (1 << 64) - 1
+
+def _enum_name(v: Any) -> Any:
+    return v.name if hasattr(v, "name") else v
+
+def _sanitize_size(v: int) -> int | str:
+    return "-" if v >= _UINT_MAX_SENTINEL else v
+```
+
+### Handler changes
+
+| Handler | Field | Change |
+|---|---|---|
+| `pipe_topology` | `topology` | `_enum_name(GetPrimitiveTopology())` |
+| `pipe_blend` | `srcColor/dstColor/colorOp/srcAlpha/dstAlpha/alphaOp` | `_enum_name(...)` |
+| `pipe_stencil` | `failOperation/depthFailOperation/passOperation/function` | `_enum_name(...)` |
+| `pipe_samplers` | `addressU/addressV/addressW/filter` | `_enum_name(...)` |
+| `postvs` | `topology` | `_enum_name(...)` |
+| `pipe_vbuffers` | `byteSize` | `_sanitize_size(...)` |
+| `pipe_ibuffer` | `byteSize` | `_sanitize_size(...)` |
+
+### Client change
+
+`daemon_client.send_request` default `timeout` raised from `2.0` to `30.0`.

--- a/openspec/changes/2026-02-20-phase2.6-output-quality/tasks.md
+++ b/openspec/changes/2026-02-20-phase2.6-output-quality/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: phase2.6-output-quality
+
+## Implementation
+
+- [x] Add `_UINT_MAX_SENTINEL`, `_enum_name`, `_sanitize_size` to `daemon_server.py`
+- [x] `pipe_topology`: wrap topology with `_enum_name`
+- [x] `pipe_blend`: wrap all blend factor/op fields with `_enum_name`
+- [x] `pipe_stencil`: wrap all stencil op/function fields with `_enum_name`
+- [x] `pipe_samplers`: wrap address mode and filter fields with `_enum_name`
+- [x] `postvs`: wrap topology with `_enum_name`
+- [x] `pipe_vbuffers`: wrap `byteSize` with `_sanitize_size`
+- [x] `pipe_ibuffer`: wrap `byteSize` with `_sanitize_size`
+- [x] `daemon_client.py`: raise default `timeout` from `2.0` to `30.0`
+
+## Tests
+
+- [x] Write `tests/unit/test_daemon_output_quality.py`
+  - [x] `TestEnumName` — 5 cases
+  - [x] `TestSanitizeSize` — 4 cases
+  - [x] `TestClientTimeout` — 1 case
+  - [x] `TestPipeTopologyEnumName` — 1 case
+  - [x] `TestPipeBlendEnumNames` — 1 case
+  - [x] `TestPipeStencilEnumNames` — 1 case
+  - [x] `TestPipeSamplersEnumNames` — 1 case
+  - [x] `TestPipeVbuffersUintMax` — 2 cases
+  - [x] `TestPipeIbufferUintMax` — 2 cases
+
+## CI
+
+- [x] `pixi run check` passes (lint + typecheck + test)

--- a/openspec/changes/2026-02-20-phase2.6-output-quality/test-plan.md
+++ b/openspec/changes/2026-02-20-phase2.6-output-quality/test-plan.md
@@ -1,0 +1,69 @@
+# Test Plan: phase2.6-output-quality
+
+## Scope
+
+**In scope:**
+- Unit tests for `_enum_name` and `_sanitize_size` helpers
+- Handler integration tests for enum name rendering
+- Handler integration tests for UINT_MAX sanitization
+- Client timeout default value verification
+
+**Out of scope:**
+- GPU integration tests (no behavior change, only display format)
+- CLI command tests (handlers called via existing commands unchanged)
+
+## Test Matrix
+
+| Layer | File | Cases |
+|---|---|---|
+| Unit | `test_daemon_output_quality.py` | helpers, handlers, client |
+
+## Cases
+
+### Helper: `_enum_name`
+- enum-like object with `.name` attr → returns `.name` string
+- plain string → returns unchanged
+- plain int → returns unchanged
+- empty string → returns unchanged
+- None → returns None
+
+### Helper: `_sanitize_size`
+- normal int (4096) → returns 4096
+- zero → returns 0
+- `(1<<64)-1` (UINT_MAX) → returns `"-"`
+- `(1<<64)-2` (just below) → returns value unchanged
+
+### Client timeout
+- `inspect.signature(send_request).parameters["timeout"].default == 30.0`
+
+### `pipe_topology` handler
+- topology field is plain name string (no dots, no angle brackets)
+
+### `pipe_blend` handler
+- blend factor fields (`srcColor`, `dstColor`, `colorOp`, `srcAlpha`, `dstAlpha`, `alphaOp`) are plain names
+
+### `pipe_stencil` handler
+- stencil op fields (`failOperation`, `depthFailOperation`, `passOperation`, `function`) are plain names
+
+### `pipe_samplers` handler
+- sampler fields (`addressU`, `addressV`, `addressW`, `filter`) are plain names
+
+### `pipe_vbuffers` handler
+- UINT_MAX `byteSize` → `"-"`
+- Normal `byteSize` → integer
+
+### `pipe_ibuffer` handler
+- UINT_MAX `byteSize` → `"-"`
+- Normal `byteSize` → integer
+
+## Assertions
+
+- All enum name fields: `assert "." not in str(field_value)` and `isinstance(field_value, str)`
+- Sentinel: `assert resp["result"]["byteSize"] == "-"`
+- Normal size: `assert resp["result"]["byteSize"] == <int>`
+- Timeout: `assert sig.parameters["timeout"].default == 30.0`
+
+## Risks & Rollback
+
+- Low risk: helpers are pure functions with no side effects
+- Rollback: revert `_enum_name`/`_sanitize_size` calls, restore `timeout=2.0`

--- a/src/rdc/daemon_client.py
+++ b/src/rdc/daemon_client.py
@@ -9,7 +9,7 @@ def send_request(
     host: str,
     port: int,
     payload: dict[str, Any],
-    timeout: float = 2.0,
+    timeout: float = 30.0,
 ) -> dict[str, Any]:
     data = (json.dumps(payload) + "\n").encode("utf-8")
     with socket.create_connection((host, port), timeout=timeout) as sock:

--- a/tests/unit/test_daemon_output_quality.py
+++ b/tests/unit/test_daemon_output_quality.py
@@ -1,0 +1,244 @@
+"""Tests for phase2.6-output-quality: _enum_name, _sanitize_size, client timeout."""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
+
+import mock_renderdoc as mock_rd  # noqa: E402
+from mock_renderdoc import (  # noqa: E402
+    ActionDescription,
+    ActionFlags,
+    BlendEquation,
+    BoundVBuffer,
+    ColorBlend,
+    MeshFormat,
+    MockPipeState,
+    ResourceDescription,
+    ResourceId,
+    SamplerData,
+    ShaderStage,
+    StencilFace,
+)
+
+from rdc.adapter import RenderDocAdapter
+from rdc.daemon_client import send_request
+from rdc.daemon_server import DaemonState, _enum_name, _handle_request, _sanitize_size
+from rdc.vfs.tree_cache import build_vfs_skeleton
+
+
+def _req(method: str, **params: Any) -> dict[str, Any]:
+    p: dict[str, Any] = {"_token": "abcdef1234567890"}
+    p.update(params)
+    return {"id": 1, "method": method, "params": p}
+
+
+def _make_state(pipe: MockPipeState, tmp_path: Path) -> DaemonState:
+    actions = [
+        ActionDescription(eventId=10, flags=ActionFlags.Drawcall, numIndices=3, _name="Draw")
+    ]
+    resources = [ResourceDescription(resourceId=ResourceId(1), name="res0")]
+    controller = SimpleNamespace(
+        GetRootActions=lambda: actions,
+        GetResources=lambda: resources,
+        GetAPIProperties=lambda: SimpleNamespace(pipelineType="Vulkan"),
+        SetFrameEvent=lambda eid, force: None,
+        GetStructuredFile=lambda: SimpleNamespace(chunks=[]),
+        GetPipelineState=lambda: pipe,
+        GetTextures=lambda: [],
+        GetBuffers=lambda: [],
+        GetDebugMessages=lambda: [],
+        GetPostVSData=lambda inst, view, stage: MeshFormat(
+            numIndices=3,
+            vertexByteStride=20,
+            topology=SimpleNamespace(name="TriangleList"),
+        ),
+        Shutdown=lambda: None,
+    )
+    s = DaemonState(capture="test.rdc", current_eid=0, token="abcdef1234567890")
+    s.adapter = RenderDocAdapter(controller=controller, version=(1, 41))
+    s.max_eid = 10
+    s.rd = mock_rd
+    s.temp_dir = tmp_path
+    s.vfs_tree = build_vfs_skeleton(actions, resources)
+    return s
+
+
+class TestEnumName:
+    def test_with_name_attr(self) -> None:
+        obj = SimpleNamespace(name="TriangleList")
+        assert _enum_name(obj) == "TriangleList"
+
+    def test_plain_string(self) -> None:
+        assert _enum_name("foo") == "foo"
+
+    def test_plain_int(self) -> None:
+        assert _enum_name(42) == 42
+
+    def test_empty_string(self) -> None:
+        assert _enum_name("") == ""
+
+    def test_none(self) -> None:
+        assert _enum_name(None) is None
+
+
+class TestSanitizeSize:
+    def test_normal_value(self) -> None:
+        assert _sanitize_size(4096) == 4096
+
+    def test_zero(self) -> None:
+        assert _sanitize_size(0) == 0
+
+    def test_uint_max(self) -> None:
+        assert _sanitize_size((1 << 64) - 1) == "-"
+
+    def test_just_below_uint_max(self) -> None:
+        assert _sanitize_size((1 << 64) - 2) == (1 << 64) - 2
+
+
+class TestClientTimeout:
+    def test_default_timeout_is_30(self) -> None:
+        sig = inspect.signature(send_request)
+        assert sig.parameters["timeout"].default == 30.0
+
+
+class TestPipeTopologyEnumName:
+    def test_enum_name_not_repr(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        pipe.GetPrimitiveTopology = lambda: SimpleNamespace(name="TriangleList")  # type: ignore[method-assign]
+        state = _make_state(pipe, tmp_path)
+        resp, _ = _handle_request(_req("pipe_topology", eid=10), state)
+        topo = resp["result"]["topology"]
+        assert topo == "TriangleList"
+        assert "." not in topo
+
+
+class TestPipeBlendEnumNames:
+    def test_blend_fields_are_plain_names(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        pipe._color_blends = [
+            ColorBlend(
+                enabled=True,
+                colorBlend=BlendEquation(
+                    source=SimpleNamespace(name="SrcAlpha"),  # type: ignore[arg-type]
+                    destination=SimpleNamespace(name="InvSrcAlpha"),  # type: ignore[arg-type]
+                    operation=SimpleNamespace(name="Add"),  # type: ignore[arg-type]
+                ),
+                alphaBlend=BlendEquation(
+                    source=SimpleNamespace(name="One"),  # type: ignore[arg-type]
+                    destination=SimpleNamespace(name="Zero"),  # type: ignore[arg-type]
+                    operation=SimpleNamespace(name="Add"),  # type: ignore[arg-type]
+                ),
+                writeMask=0xF,
+            )
+        ]
+        state = _make_state(pipe, tmp_path)
+        resp, _ = _handle_request(_req("pipe_blend", eid=10), state)
+        b = resp["result"]["blends"][0]
+        assert b["srcColor"] == "SrcAlpha"
+        assert b["dstColor"] == "InvSrcAlpha"
+        assert b["colorOp"] == "Add"
+        assert b["srcAlpha"] == "One"
+        assert b["dstAlpha"] == "Zero"
+        assert b["alphaOp"] == "Add"
+        for f in ("srcColor", "dstColor", "colorOp", "srcAlpha", "dstAlpha", "alphaOp"):
+            assert "." not in str(b[f])
+
+
+class TestPipeStencilEnumNames:
+    def test_stencil_fields_are_plain_names(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        pipe._stencil = (
+            StencilFace(
+                failOperation=SimpleNamespace(name="Keep"),  # type: ignore[arg-type]
+                depthFailOperation=SimpleNamespace(name="Keep"),  # type: ignore[arg-type]
+                passOperation=SimpleNamespace(name="Replace"),  # type: ignore[arg-type]
+                function=SimpleNamespace(name="LessEqual"),  # type: ignore[arg-type]
+            ),
+            StencilFace(
+                failOperation=SimpleNamespace(name="Keep"),  # type: ignore[arg-type]
+                depthFailOperation=SimpleNamespace(name="Keep"),  # type: ignore[arg-type]
+                passOperation=SimpleNamespace(name="Keep"),  # type: ignore[arg-type]
+                function=SimpleNamespace(name="AlwaysTrue"),  # type: ignore[arg-type]
+            ),
+        )
+        state = _make_state(pipe, tmp_path)
+        resp, _ = _handle_request(_req("pipe_stencil", eid=10), state)
+        front = resp["result"]["front"]
+        assert front["passOperation"] == "Replace"
+        assert front["function"] == "LessEqual"
+        assert "." not in str(front["failOperation"])
+        back = resp["result"]["back"]
+        assert back["function"] == "AlwaysTrue"
+
+
+class TestPipeSamplersEnumNames:
+    def test_sampler_address_fields_are_plain_names(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        sd = SamplerData(
+            addressU=SimpleNamespace(name="Wrap"),  # type: ignore[arg-type]
+            addressV=SimpleNamespace(name="Clamp"),  # type: ignore[arg-type]
+            addressW=SimpleNamespace(name="Mirror"),  # type: ignore[arg-type]
+            filter=SimpleNamespace(name="Linear"),  # type: ignore[arg-type]
+            maxAnisotropy=1,
+        )
+        pipe._samplers = {ShaderStage.Pixel: [sd]}
+        state = _make_state(pipe, tmp_path)
+        resp, _ = _handle_request(_req("pipe_samplers", eid=10), state)
+        s = resp["result"]["samplers"][0]
+        assert s["addressU"] == "Wrap"
+        assert s["addressV"] == "Clamp"
+        assert s["addressW"] == "Mirror"
+        assert s["filter"] == "Linear"
+        for f in ("addressU", "addressV", "addressW", "filter"):
+            assert "." not in str(s[f])
+
+
+class TestPipeVbuffersUintMax:
+    def test_uint_max_bytesize_shown_as_dash(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        pipe._vbuffers = [
+            BoundVBuffer(
+                resourceId=ResourceId(42),
+                byteOffset=0,
+                byteSize=(1 << 64) - 1,
+                byteStride=20,
+            )
+        ]
+        state = _make_state(pipe, tmp_path)
+        resp, _ = _handle_request(_req("pipe_vbuffers", eid=10), state)
+        assert resp["result"]["vbuffers"][0]["byteSize"] == "-"
+
+    def test_normal_bytesize_shown_as_int(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        pipe._vbuffers = [
+            BoundVBuffer(resourceId=ResourceId(42), byteOffset=0, byteSize=4096, byteStride=20)
+        ]
+        state = _make_state(pipe, tmp_path)
+        resp, _ = _handle_request(_req("pipe_vbuffers", eid=10), state)
+        assert resp["result"]["vbuffers"][0]["byteSize"] == 4096
+
+
+class TestPipeIbufferUintMax:
+    def test_uint_max_bytesize_shown_as_dash(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        pipe._ibuffer = BoundVBuffer(
+            resourceId=ResourceId(43), byteOffset=0, byteSize=(1 << 64) - 1, byteStride=4
+        )
+        state = _make_state(pipe, tmp_path)
+        resp, _ = _handle_request(_req("pipe_ibuffer", eid=10), state)
+        assert resp["result"]["byteSize"] == "-"
+
+    def test_normal_bytesize_shown_as_int(self, tmp_path: Path) -> None:
+        pipe = MockPipeState()
+        pipe._ibuffer = BoundVBuffer(
+            resourceId=ResourceId(43), byteOffset=0, byteSize=1024, byteStride=4
+        )
+        state = _make_state(pipe, tmp_path)
+        resp, _ = _handle_request(_req("pipe_ibuffer", eid=10), state)
+        assert resp["result"]["byteSize"] == 1024


### PR DESCRIPTION
## Summary
- Add `_enum_name()` helper for consistent enum display across pipe handlers (topology, blend, stencil, samplers, postvs)
- Add `_sanitize_size()` helper — show `"-"` instead of UINT_MAX/negative for unbound buffer sizes
- Raise daemon client timeout from 2s to 30s to prevent spurious timeouts on slow operations

## Test plan
- [x] `_enum_name` with enum-like and plain values (unit)
- [x] `_sanitize_size` with normal, UINT_MAX, and negative values (unit)
- [x] All affected handlers return enum names not numbers (unit)
- [x] vbuffers/ibuffer show "-" for sentinel sizes (unit)
- [x] Client timeout default is 30.0 (unit)

## Priority
P3 — display/formatting fixes for better output quality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enum fields now display as human-readable names instead of numeric values for topology, blend factors, stencil operations, and address modes.
  * Size fields now show "-" for sentinel values instead of large integers.

* **Bug Fixes**
  * Increased daemon client request timeout from 2s to 30s to handle slow request handlers.

* **Tests**
  * Added comprehensive unit tests for output formatting utilities and timeout configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->