### PR TITLE
fix(filters): correct shaders stage, draws pass, summary, friendly names, topology enum

### DIFF
--- a/openspec/changes/2026-02-21-phase2.7-bug-filters/proposal.md
+++ b/openspec/changes/2026-02-21-phase2.7-bug-filters/proposal.md
@@ -1,0 +1,193 @@
+# Fix: phase2.7-bug-filters
+
+## Summary
+
+Five bugs were discovered during real-world testing with Vulkan captures (hello_triangle,
+render_passes, hdr, msaa, subpasses). All bugs relate to filtering and display correctness
+in `rdc shaders`, `rdc draws`, and pipeline state output. The fixes are surgical: no new
+public API, no new commands, no schema changes. Each fix is self-contained and correctable
+in isolation.
+
+The root causes are: one filter param silently ignored in the daemon, one filter comparing
+incompatible name spaces (API name vs. semantic name), one summary computed from the wrong
+dataset, one pass name left as raw API text when no markers exist, and one SWIG enum
+serialized as a raw integer instead of its name string.
+
+## Problem
+
+### Bug 1: `rdc shaders --stage` filter silently ignored
+
+`src/rdc/daemon_server.py` lines 358-366 handle the `"shaders"` method. The handler calls
+`shader_inventory(pipe_states)` and returns the full unfiltered row list. It never reads
+`params.get("stage")` even though `src/rdc/commands/pipeline.py` lines 317-319 always
+forwards the `stage` param when the user passes `--stage`. The CLI option has no effect.
+
+### Bug 2: `rdc draws --pass` filter never matches semantic pass names
+
+`src/rdc/services/query_service.py` lines 142-145 implement `filter_by_pass`. It compares
+`a.pass_name` (set by `walk_actions` at line 100 from `BeginPass` API names like
+`"vkCmdBeginRenderPass(C=Load, D=Clear)"`) against the user-supplied name string.
+
+`_build_pass_list` (lines 526-582) builds a richer pass list using marker group names
+(e.g. `"Opaque objects"`, `"UI"`). The user naturally types these semantic names after
+seeing `rdc passes` output, but `filter_by_pass` compares against the raw API name, so
+no draw ever matches.
+
+`src/rdc/daemon_server.py` lines 1858-1860 call `filter_by_pass(flat, pass_name)` without
+passing `actions` or `sf`, so the EID-range fallback path cannot be taken.
+
+### Bug 3: `rdc draws` summary always uses unfiltered stats
+
+`src/rdc/daemon_server.py` lines 1878-1883 build the summary string from `all_stats`,
+which is computed from the unfiltered `all_flat` list (line 1856). When `--pass` or
+`--type` filters are active, the summary reports the total for the entire frame rather
+than for the filtered subset. Users see a mismatch between the number of rows returned
+and the count in the summary line.
+
+### Bug 4: Pass names are raw API text when no debug markers exist
+
+`src/rdc/services/query_service.py` lines 575-576 call `_window_stats(a, window, sf)`,
+which sets `"name"` directly from `begin.GetName(sf)` (line 464). When no marker groups
+are present (common in unoptimized or stripped captures), the name propagated to `rdc
+passes` output and used by `filter_by_pass` is the raw Vulkan API string
+`"vkCmdBeginRenderPass(C=Load, D=Clear)"`. This is neither readable nor stable across
+driver versions.
+
+### Bug 5: TOPOLOGY field displays a raw integer
+
+`src/rdc/services/query_service.py` line 326 sets `"topology"` with
+`str(pipe_state.GetPrimitiveTopology())`. For SWIG-wrapped enums returned by the real
+RenderDoc Python API, `str()` produces `"3"` instead of `"TriangleList"`. The same enum
+pattern is handled correctly elsewhere in the codebase using
+`getattr(v, "name", str(v))`.
+
+## Fix Design
+
+### Fix 1: Apply stage post-filter in shaders handler
+
+In `src/rdc/daemon_server.py`, after `rows = shader_inventory(pipe_states)` (line 365),
+read `params.get("stage")` and filter `rows` in-place:
+
+```python
+stage_filter = params.get("stage")
+if stage_filter:
+    stage_filter = stage_filter.lower()
+    rows = [r for r in rows if stage_filter in r["stages"].lower().split(",")]
+```
+
+The `"stages"` field in each row is a comma-separated string produced by
+`shader_inventory` (e.g. `"vs,ps"`). Lowercasing both sides makes the comparison
+case-insensitive and consistent with the CLI's normalization.
+
+### Fix 2: EID-range pass filtering via `_build_pass_list`
+
+Change `filter_by_pass` signature in `src/rdc/services/query_service.py` to accept
+optional `actions` and `sf` parameters:
+
+```python
+def filter_by_pass(
+    flat: list[FlatAction],
+    pass_name: str,
+    actions: list[Any] | None = None,
+    sf: Any = None,
+) -> list[FlatAction]:
+    if actions is not None:
+        passes = _build_pass_list(actions, sf)
+        target = next((p for p in passes if p["name"].lower() == pass_name.lower()), None)
+        if target:
+            return [a for a in flat if target["begin_eid"] <= a.eid <= target["end_eid"]]
+    lower = pass_name.lower()
+    return [a for a in flat if a.pass_name.lower() == lower]
+```
+
+Update the call site in `src/rdc/daemon_server.py` lines 1858-1860 to pass the action
+tree and string factory:
+
+```python
+if pass_name:
+    actions = state.adapter.get_root_actions()
+    sf = state.structured_file
+    flat = filter_by_pass(flat, pass_name, actions=actions, sf=sf)
+```
+
+### Fix 3: Summary from filtered stats
+
+In `src/rdc/daemon_server.py` lines 1855-1883, compute summary from the pass-filtered
+action list (before `filter_by_type`). The key insight: `flat` at line 1857 is already
+filtered to draw-type only, so `aggregate_stats(flat)` would always show 0 dispatches
+and 0 clears. Instead, apply pass filter to `all_flat` first, then compute stats:
+
+```python
+all_flat = _get_flat_actions(state)
+pass_name = params.get("pass")
+if pass_name:
+    actions = state.adapter.get_root_actions()
+    sf = state.structured_file
+    all_flat = filter_by_pass(all_flat, pass_name, actions=actions, sf=sf)
+stats = aggregate_stats(all_flat)
+flat = filter_by_type(all_flat, "draw")
+# ... sort/limit on flat ...
+summary = (
+    f"{stats.total_draws} draw calls "
+    f"({stats.indexed_draws} indexed, "
+    f"{stats.dispatches} dispatches, "
+    f"{stats.clears} clears)"
+)
+```
+
+This ensures summary counts dispatches/clears within the filtered pass, not just draws.
+
+### Fix 4: Friendly pass names when no debug markers
+
+Add `_friendly_pass_name(api_name: str, index: int) -> str` to
+`src/rdc/services/query_service.py`. This helper is called inside
+`_build_pass_list_recursive` for any pass whose name was taken from the raw API name
+rather than a marker group:
+
+```python
+def _friendly_pass_name(api_name: str, index: int) -> str:
+    color_count = api_name.count("C=")
+    has_depth = "D=" in api_name
+    parts = []
+    if color_count:
+        parts.append(f"{color_count} Target{'s' if color_count > 1 else ''}")
+    if has_depth:
+        parts.append("Depth")
+    suffix = f" ({' + '.join(parts)})" if parts else ""
+    return f"Colour Pass #{index + 1}{suffix}"
+```
+
+Apply in `_window_stats` and the `_subtree_stats(a, sf)` call-site at line 558 where
+no marker groups exist: replace the raw `name` with `_friendly_pass_name(name, index)`
+where `index` is the zero-based pass number within the current recursive context.
+
+### Fix 5: Topology enum name via getattr
+
+In `src/rdc/services/query_service.py` line 326, change:
+
+```python
+"topology": str(pipe_state.GetPrimitiveTopology()),
+```
+
+to:
+
+```python
+"topology": getattr(pipe_state.GetPrimitiveTopology(), "name", str(pipe_state.GetPrimitiveTopology())),
+```
+
+This is consistent with the existing pattern used throughout the codebase for SWIG enums
+(e.g. `pipelineType`, `AddressMode`).
+
+## Scope
+
+### In scope
+- `src/rdc/daemon_server.py`: Fix 1 (shaders stage filter), Fix 2 call-site (pass actions arg), Fix 3 (summary from filtered stats)
+- `src/rdc/services/query_service.py`: Fix 2 `filter_by_pass` signature, Fix 4 `_friendly_pass_name` helper, Fix 5 topology enum name
+- Unit tests covering all 5 fixes (mock-only, no GPU required)
+- GPU regression tests on `hello_triangle.rdc` confirming each fix
+
+### Out of scope
+- Any new CLI options or commands
+- Changes to JSON-RPC schema or VFS routes
+- Pass dependency graphs or diff features
+- Changes to `rdc passes` display format beyond name friendliness

--- a/openspec/changes/2026-02-21-phase2.7-bug-filters/tasks.md
+++ b/openspec/changes/2026-02-21-phase2.7-bug-filters/tasks.md
@@ -1,0 +1,138 @@
+# Tasks: phase2.7-bug-filters
+
+## Phase A: Tests first
+
+### Fix 1: shaders stage filter
+- [ ] In `tests/unit/test_pipeline_daemon.py`, add `test_shaders_stage_filter_applied`: mock `shader_inventory` returning rows with `stages="vs"`, `"ps"`, `"vs,ps"`; call handler with `params={"stage": "vs"}`; assert response `rows` contains only the `vs` and `vs,ps` entries
+- [ ] Add `test_shaders_stage_filter_case_insensitive`: `params={"stage": "VS"}` matches `stages="vs"` rows
+- [ ] Add `test_shaders_stage_filter_no_match`: `params={"stage": "cs"}` returns `{"rows": []}`, no error
+- [ ] Add `test_shaders_no_stage_filter`: `params={}` returns all rows unmodified (regression guard)
+
+### Fix 2: filter_by_pass EID-range
+- [ ] In `tests/unit/test_query_service.py`, add `test_filter_by_pass_eid_range_semantic_name`: build a mock action tree with BeginPass at EID 3 (API name `"vkCmdBeginRenderPass(C=Load)"`), draws at EIDs 5, 7, 9, EndPass at EID 10; call `filter_by_pass(flat, "Colour Pass #1", actions=actions)`; assert all three draw FlatActions returned
+- [ ] Add `test_filter_by_pass_eid_range_marker_name`: mock tree with marker group `"Opaque objects"` under a BeginPass; `filter_by_pass(flat, "Opaque objects", actions=actions)` returns only draws within that marker's EID range
+- [ ] Add `test_filter_by_pass_name_not_found_fallback`: no matching pass in `_build_pass_list`; function falls back to `a.pass_name` string comparison; empty result when no action has matching `pass_name`
+- [ ] Add `test_filter_by_pass_no_actions_legacy`: call without `actions` arg; uses original string match; asserts backward-compatible behavior
+- [ ] In `tests/unit/test_draws_daemon.py`, add `test_draws_pass_filter_forwards_actions`: monkeypatch `filter_by_pass` in `daemon_server`; call `_handle_draws` with `params={"pass": "Opaque objects"}`; assert monkeypatched `filter_by_pass` was called with non-None `actions` and `sf`
+
+### Fix 3: summary from filtered stats
+- [ ] In `tests/unit/test_draws_daemon.py`, add `test_draws_summary_reflects_filtered_count`: mock 10 draws total, pass filter yields 3; assert `summary` starts with `"3 draw calls"`, not `"10"`
+- [ ] Add `test_draws_summary_no_filter_equals_total`: no pass filter; summary count equals total draw count in `all_flat`
+- [ ] Add `test_draws_summary_type_filter`: all_flat has mixed types; after `filter_by_type("draw")` yields 4 draws; summary starts with `"4 draw calls"`
+
+### Fix 4: friendly pass names
+- [ ] In `tests/unit/test_query_service.py`, add `test_friendly_pass_name_single_color`: `_friendly_pass_name("vkCmdBeginRenderPass(C=Load)", 0)` == `"Colour Pass #1 (1 Target)"`
+- [ ] Add `test_friendly_pass_name_multi_color_with_depth`: `_friendly_pass_name("vkCmdBeginRenderPass(C=Load, C=Clear, D=Clear)", 2)` == `"Colour Pass #3 (2 Targets + Depth)"`
+- [ ] Add `test_friendly_pass_name_depth_only`: `_friendly_pass_name("vkCmdBeginRenderPass(D=Clear)", 0)` == `"Colour Pass #1 (Depth)"`
+- [ ] Add `test_friendly_pass_name_unknown_api`: `_friendly_pass_name("UnknownPassType()", 0)` == `"Colour Pass #1"` (no crash, no suffix)
+- [ ] Add `test_build_pass_list_friendly_name_no_markers`: mock action tree with BeginPass named `"vkCmdBeginRenderPass(C=Load, D=Clear)"` and no marker children; `_build_pass_list` result has `name == "Colour Pass #1 (1 Target + Depth)"`
+- [ ] Add `test_build_pass_list_preserves_marker_name`: marker group `"Opaque objects"` present; `_build_pass_list` result uses `"Opaque objects"`, not a friendly pass name
+
+### Fix 5: topology enum name
+- [ ] In `tests/unit/test_query_service.py`, add `test_pipeline_row_topology_enum_name`: mock `GetPrimitiveTopology()` returns object with `.name = "TriangleList"`; `pipeline_row` returns `{"topology": "TriangleList", ...}`
+- [ ] Add `test_pipeline_row_topology_int_fallback`: mock returns plain `int` `3`; `pipeline_row` returns `{"topology": "3"}`, no exception
+- [ ] Add `test_pipeline_row_topology_intenum`: mock returns `IntEnum` value `TriangleList=3`; `pipeline_row` returns `{"topology": "TriangleList"}`
+
+## Phase B: Implementation
+
+### Fix 1: daemon_server.py — shaders stage filter
+- [ ] In `src/rdc/daemon_server.py`, after `rows = shader_inventory(pipe_states)` (line 365), add:
+  ```python
+  stage_filter = params.get("stage")
+  if stage_filter:
+      stage_filter = stage_filter.lower()
+      rows = [r for r in rows if stage_filter in r["stages"].lower().split(",")]
+  ```
+- [ ] Verify `test_shaders_stage_filter_applied` and all Fix 1 tests pass: `pixi run test -k test_shaders`
+
+### Fix 2a: query_service.py — extend filter_by_pass signature
+- [ ] In `src/rdc/services/query_service.py`, update `filter_by_pass` (lines 142-145) to:
+  ```python
+  def filter_by_pass(
+      flat: list[FlatAction],
+      pass_name: str,
+      actions: list[Any] | None = None,
+      sf: Any = None,
+  ) -> list[FlatAction]:
+      if actions is not None:
+          passes = _build_pass_list(actions, sf)
+          target = next((p for p in passes if p["name"].lower() == pass_name.lower()), None)
+          if target:
+              return [a for a in flat if target["begin_eid"] <= a.eid <= target["end_eid"]]
+      lower = pass_name.lower()
+      return [a for a in flat if a.pass_name.lower() == lower]
+  ```
+
+### Fix 2b: daemon_server.py — pass actions+sf to filter_by_pass
+- [ ] In `src/rdc/daemon_server.py`, replace lines 1858-1860:
+  ```python
+  if pass_name:
+      flat = filter_by_pass(flat, pass_name)
+  ```
+  with:
+  ```python
+  if pass_name:
+      _actions = state.adapter.get_root_actions()
+      _sf = state.structured_file
+      flat = filter_by_pass(flat, pass_name, actions=_actions, sf=_sf)
+  ```
+- [ ] Verify all Fix 2 tests pass: `pixi run test -k "filter_by_pass or test_draws_pass"`
+
+### Fix 3: daemon_server.py — summary from filtered stats
+- [ ] In `src/rdc/daemon_server.py`, restructure `_handle_draws` (lines 1855-1883):
+  - Move pass filter BEFORE `filter_by_type("draw")`, apply to `all_flat`
+  - Compute `stats = aggregate_stats(all_flat)` after pass filter but before type filter
+  - Then `flat = filter_by_type(all_flat, "draw")` on the pass-filtered list
+  - Summary uses `stats` (which includes dispatches/clears within the filtered pass)
+  ```python
+  all_flat = _get_flat_actions(state)
+  pass_name = params.get("pass")
+  if pass_name:
+      actions = state.adapter.get_root_actions()
+      sf = state.structured_file
+      all_flat = filter_by_pass(all_flat, pass_name, actions=actions, sf=sf)
+  stats = aggregate_stats(all_flat)
+  flat = filter_by_type(all_flat, "draw")
+  ```
+- [ ] Verify all Fix 3 tests pass: `pixi run test -k test_draws_summary`
+
+### Fix 4: query_service.py — friendly pass names
+- [ ] In `src/rdc/services/query_service.py`, add `_friendly_pass_name(api_name: str, index: int) -> str` private function before `_build_pass_list_recursive`
+- [ ] In `_build_pass_list_recursive` (line 533), introduce a local `_pass_index` counter scoped to the current level (start at 0, increment each time a pass entry is appended)
+- [ ] In the children-of-BeginPass branch (line 558): when `not marker_groups` and has draws, use `_subtree_stats(a, sf)` but override `"name"` key with `_friendly_pass_name(name, _pass_index)` before appending
+- [ ] In the flat-sibling branch (line 576): `_window_stats(a, window, sf)` result — override `"name"` with `_friendly_pass_name(name, _pass_index)` before appending
+- [ ] When marker groups ARE present, do not apply `_friendly_pass_name` (preserve marker group name)
+- [ ] Verify all Fix 4 tests pass: `pixi run test -k "friendly_pass or build_pass_list"`
+
+### Fix 5: query_service.py — topology enum name
+- [ ] In `src/rdc/services/query_service.py`, line 326, replace:
+  ```python
+  "topology": str(pipe_state.GetPrimitiveTopology()),
+  ```
+  with:
+  ```python
+  "topology": getattr(pipe_state.GetPrimitiveTopology(), "name", str(pipe_state.GetPrimitiveTopology())),
+  ```
+- [ ] Verify all Fix 5 tests pass: `pixi run test -k test_pipeline_row_topology`
+
+## Phase C: Integration
+
+- [ ] Run full unit test suite: `pixi run test` — all tests green, coverage ≥ 80%
+- [ ] Run lint and type check: `pixi run lint` — zero ruff errors, zero mypy strict errors
+- [ ] GPU test Fix 1: call `shaders` handler with `params={"stage": "vs"}` on `hello_triangle.rdc`; assert all returned rows have `"vs"` in their `stages` field; assert result is non-empty
+- [ ] GPU test Fix 2: call `passes` on `hello_triangle.rdc` to get actual pass names; call `draws` with `params={"pass": <first_pass_name>}`; assert returned draws list is non-empty and all draws have EIDs within the pass range
+- [ ] GPU test Fix 3: call `draws` with a pass filter on `hello_triangle.rdc`; assert `summary` count matches `len(draws)` in response
+- [ ] GPU test Fix 4: call `passes` on a markerless capture (`hello_triangle.rdc`); assert no pass name matches `"vkCmd"` prefix pattern; assert all names match `"Colour Pass #\d+"` pattern
+- [ ] GPU test Fix 5: call `pipeline` on any draw EID in `hello_triangle.rdc`; assert `topology` field is not purely numeric (i.e. `not response["topology"].isdigit()`)
+- [ ] Run GPU tests: `RENDERDOC_PYTHON_PATH=/home/jim_z/Dev/renderdoc-src/build-py314/lib pixi run test-gpu -k bug_filters`
+
+## Phase D: Verify
+
+- [ ] `pixi run check` passes (= lint + typecheck + test, all green)
+- [ ] Manual: `rdc shaders --stage vs` on a real capture returns only vertex shader rows
+- [ ] Manual: `rdc draws --pass "<name from rdc passes>"` returns non-empty draw list
+- [ ] Manual: `rdc draws --pass "<name>"` summary count matches number of rows printed
+- [ ] Manual: `rdc passes` on `hello_triangle.rdc` shows `"Colour Pass #1"` style names
+- [ ] Manual: `rdc pipeline <eid>` shows `TOPOLOGY: TriangleList`, not `TOPOLOGY: 3`
+- [ ] Archive: move `openspec/changes/2026-02-21-phase2.7-bug-filters/` → `openspec/changes/archive/`
+- [ ] Update `进度跟踪.md` in Obsidian vault

--- a/openspec/changes/2026-02-21-phase2.7-bug-filters/test-plan.md
+++ b/openspec/changes/2026-02-21-phase2.7-bug-filters/test-plan.md
@@ -1,0 +1,163 @@
+# Test Plan: phase2.7-bug-filters
+
+## Scope
+
+### In scope
+- Fix 1: `shaders` daemon handler applies `stage` filter post-`shader_inventory`
+- Fix 2: `filter_by_pass` EID-range path when `actions` arg is provided; daemon call-site passes `actions` + `sf`
+- Fix 3: `draws` daemon handler summary computed from post-filter `flat` list
+- Fix 4: `_friendly_pass_name` helper produces readable names; applied in `_build_pass_list_recursive` for marker-free passes
+- Fix 5: `pipeline_row` topology field serializes SWIG enum name via `getattr(..., "name", str(...))`
+- Mock coverage for all 5 fixes (no GPU required for unit tests)
+- GPU regression on `hello_triangle.rdc` for all 5 fixes
+
+### Out of scope
+- New CLI options, commands, or JSON-RPC methods
+- VFS router or tree cache changes
+- Performance benchmarking of `filter_by_pass` on large captures
+
+## Test Matrix
+
+| Layer | Scope | File |
+|-------|-------|------|
+| Unit | Fix 1: shaders stage filter in daemon handler | `tests/unit/test_pipeline_daemon.py` |
+| Unit | Fix 2: `filter_by_pass` with `actions` arg (EID-range path) | `tests/unit/test_query_service.py` |
+| Unit | Fix 2: daemon `_handle_draws` passes `actions`+`sf` to `filter_by_pass` | `tests/unit/test_draws_daemon.py` |
+| Unit | Fix 3: summary reflects filtered `flat`, not `all_flat` | `tests/unit/test_draws_daemon.py` |
+| Unit | Fix 4: `_friendly_pass_name` output for various API name patterns | `tests/unit/test_query_service.py` |
+| Unit | Fix 4: `_build_pass_list` uses friendly names when no marker groups | `tests/unit/test_query_service.py` |
+| Unit | Fix 5: `pipeline_row` topology is enum name string, not integer | `tests/unit/test_query_service.py` |
+| GPU | Fix 1: `shaders --stage vs` returns only VS rows on real capture | `tests/integration/test_daemon_handlers_real.py` |
+| GPU | Fix 2: `draws --pass <name>` matches semantic name from `rdc passes` | `tests/integration/test_daemon_handlers_real.py` |
+| GPU | Fix 3: filtered summary count matches `len(draws)` in response | `tests/integration/test_daemon_handlers_real.py` |
+| GPU | Fix 4: `passes` list on markerless capture has readable names | `tests/integration/test_daemon_handlers_real.py` |
+| GPU | Fix 5: topology field is non-numeric string on real pipeline state | `tests/integration/test_daemon_handlers_real.py` |
+
+## Cases
+
+### Fix 1: shaders stage filter
+
+1. **Happy path — stage filter applied**: call `shaders` handler with `params={"stage": "vs"}`;
+   mock `shader_inventory` returns rows with `stages` values of `"vs"`, `"ps"`, and `"vs,ps"`;
+   assert response `rows` contains only the `"vs"` and `"vs,ps"` entries.
+2. **Stage filter case-insensitive**: `params={"stage": "VS"}` matches rows with `stages="vs"`.
+3. **Stage filter with no matches**: `params={"stage": "cs"}` against a graphics-only capture;
+   response `rows` is empty list, not an error.
+4. **No stage filter**: `params={}` returns all rows unfiltered (existing behavior preserved).
+5. **Invalid stage value**: `params={"stage": "zz"}` yields empty `rows` (post-filter, no match),
+   not a daemon error.
+
+### Fix 2: `filter_by_pass` EID-range path
+
+6. **EID-range match via semantic name**: pass a mock action tree with a BeginPass node named
+   `"vkCmdBeginRenderPass(C=Load)"` containing draws at EIDs 5, 7, 9; call
+   `filter_by_pass(flat, "Colour Pass #1", actions=actions, sf=None)`;
+   assert all three FlatActions are returned.
+7. **Semantic marker name match**: mock tree has a marker group named `"Opaque objects"` under
+   a BeginPass; `filter_by_pass(flat, "Opaque objects", actions=actions)` returns only draws
+   within that marker's EID range.
+8. **Name not found in pass list — fallback**: no pass in `_build_pass_list` matches the given
+   name; function falls back to `a.pass_name` string comparison; returns matching items if any,
+   empty list if none.
+9. **`actions=None` — legacy path**: `filter_by_pass(flat, "vkCmdBeginRenderPass(C=Load)")` with
+   no `actions` arg uses original string match; behavior unchanged from pre-fix.
+10. **Daemon call-site forwards `actions`+`sf`**: monkeypatch `filter_by_pass` to assert it
+    receives non-None `actions` and `sf` when `pass_name` param is set in `_handle_draws`.
+
+### Fix 3: Summary from filtered stats
+
+11. **Pass filter reduces summary count**: mock `all_flat` has 10 draws total; after
+    `filter_by_pass` yields 3 draws; summary string starts with `"3 draw calls"`, not `"10"`.
+12. **Type filter reduces summary count**: `filter_by_type(all_flat, "draw")` yields 4 draws
+    from 10 mixed events; summary starts with `"4 draw calls"`.
+13. **No filter — summary equals total**: no `pass` or `type` params; summary count equals
+    `len(all_flat)` draw actions.
+14. **Combined filter**: `--pass` + `--sort` applied; summary reflects the post-pass-filter
+    list (sort does not change count).
+
+### Fix 4: `_friendly_pass_name` helper
+
+15. **Single color target, no depth**: `_friendly_pass_name("vkCmdBeginRenderPass(C=Load)", 0)`
+    → `"Colour Pass #1 (1 Target)"`.
+16. **Multiple color targets with depth**: `_friendly_pass_name("vkCmdBeginRenderPass(C=Load, C=Clear, D=Clear)", 2)`
+    → `"Colour Pass #3 (2 Targets + Depth)"`.
+17. **Depth only, no color**: `_friendly_pass_name("vkCmdBeginRenderPass(D=Clear)", 0)`
+    → `"Colour Pass #1 (Depth)"`.
+18. **Unrecognized API name**: `_friendly_pass_name("UnknownPassType()", 0)` → `"Colour Pass #1"`
+    (no suffix, no crash).
+19. **`_build_pass_list` uses friendly name for markerless pass**: mock action tree with BeginPass
+    API name `"vkCmdBeginRenderPass(C=Load, D=Clear)"` and no marker children; result from
+    `_build_pass_list` has `name == "Colour Pass #1 (1 Target + Depth)"`, not the raw API string.
+20. **`_build_pass_list` preserves marker group names**: when marker groups are present, the
+    marker group's own name is used, not the friendly pass name.
+
+### Fix 5: Topology enum name
+
+21. **SWIG enum with `.name`**: mock `GetPrimitiveTopology()` returns an object with
+    `.name = "TriangleList"`; `pipeline_row` `"topology"` field is `"TriangleList"`.
+22. **Fallback for plain int**: mock returns `3` (no `.name` attribute); `pipeline_row`
+    `"topology"` field is `"3"` (not crash).
+23. **Mock enum via IntEnum**: `MockPrimitiveTopology(IntEnum)` with `TriangleList = 3`;
+    `getattr(v, "name", str(v))` → `"TriangleList"`.
+24. **GPU real API**: `pipeline_row` on a real Vulkan capture returns `"TriangleList"` string,
+    not `"3"` or `"Topology.TriangleList"`.
+
+### Regression
+
+25. **`shaders` without `--stage` returns same result as before**: existing test assertions
+    for unfiltered shaders list remain green.
+26. **`draws` without `--pass` returns same result as before**: existing draws tests pass.
+27. **`filter_by_pass` with no `actions` arg is backward-compatible**: all existing call sites
+    that do not pass `actions` continue to work identically.
+
+## Assertions
+
+### Exit codes
+- 0: success for all filtered queries, including zero-result cases
+- 1: runtime error (no session, no adapter loaded)
+- 2: CLI argument error (invalid stage name rejected by Click choices, if applicable)
+
+### `shaders` response contract
+- `rows` is always a list (may be empty)
+- When `stage` filter is active, every row's `"stages"` field contains the requested stage
+  as a comma-separated element (case-insensitive)
+- No error is returned for a valid filter that matches zero rows
+
+### `draws` response contract
+- `draws` list length and `summary` count are consistent: summary must reflect
+  `len(draws)` draw-type actions (not the unfiltered frame total)
+- `summary` format: `"<N> draw calls (<I> indexed, <D> dispatches, <C> clears)"`
+
+### `filter_by_pass` contract
+- With `actions` provided: match is EID-range based, case-insensitive on name
+- Without `actions`: match is exact `a.pass_name` string comparison (unchanged)
+- Return type is always `list[FlatAction]`
+
+### `_friendly_pass_name` contract
+- Return value is always a non-empty string
+- Format: `"Colour Pass #<N>"` with optional ` (<attachments>)` suffix
+- `N` is 1-based (`index + 1`)
+- Color count is the number of `"C="` occurrences in the API name
+- Depth is present if `"D="` appears in the API name
+- No exception for any string input
+
+### `pipeline_row` topology contract
+- `"topology"` field is always a non-empty string
+- Must not be a plain decimal integer string for any SWIG-wrapped enum value
+- Must match the enum's `.name` attribute when available
+
+### Error response (JSON-RPC)
+- `-32002` when `state.adapter is None` for any handler
+- `"message"` field is non-empty string
+- Error output on stderr, nothing on stdout
+
+## Risks & Rollback
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| `stages` field format changes in `shader_inventory` output | Fix 1 filter breaks silently | Assert field format in unit test; use `in row["stages"].lower().split(",")` not substring match |
+| `state.structured_file` is None for mock-only states | Fix 2 `_build_pass_list` receives `sf=None` | `_build_pass_list` already handles `sf=None`; `GetName(None)` falls back to `_name` attr in mocks |
+| `_build_pass_list` returns empty for a capture style not yet tested | Fix 2 fallback never triggers | Unit test the fallback path explicitly; GPU test on markerless capture (hello_triangle) |
+| `_friendly_pass_name` index counter diverges from actual pass list index | Pass #N label is wrong | Maintain explicit counter in `_build_pass_list_recursive`; unit-test multi-pass sequences |
+| `getattr(v, "name", str(v))` called twice (once for check, once for value) | Minor performance | Use a single `v = pipe_state.GetPrimitiveTopology(); getattr(v, "name", str(v))` |
+| Rollback | — | Revert branch; no master changes until PR squash-merge |

--- a/tests/unit/test_draws_daemon.py
+++ b/tests/unit/test_draws_daemon.py
@@ -1,0 +1,168 @@
+"""Tests for draws daemon handler: pass filter call-site and summary stats (phase2.7 Fixes 2+3)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
+
+import mock_renderdoc as rd
+
+from rdc.adapter import RenderDocAdapter
+from rdc.daemon_server import DaemonState, _handle_request
+from rdc.services.query_service import FlatAction
+
+
+def _build_actions(pass_name: str = "vkCmdBeginRenderPass(C=Load)") -> list:
+    begin = rd.ActionDescription(
+        eventId=1,
+        flags=rd.ActionFlags.BeginPass | rd.ActionFlags.PassBoundary,
+        _name=pass_name,
+    )
+    draws = [
+        rd.ActionDescription(
+            eventId=i,
+            flags=rd.ActionFlags.Drawcall,
+            numIndices=3,
+            _name=f"draw{i}",
+        )
+        for i in range(2, 12)
+    ]
+    end = rd.ActionDescription(
+        eventId=12,
+        flags=rd.ActionFlags.EndPass | rd.ActionFlags.PassBoundary,
+        _name="EndPass",
+    )
+    return [begin, *draws, end]
+
+
+def _make_state(actions: list | None = None) -> DaemonState:
+    ctrl = rd.MockReplayController()
+    ctrl._actions = actions or _build_actions()
+    state = DaemonState(capture="x.rdc", current_eid=0, token="tok")
+    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
+    state.api_name = "Vulkan"
+    state.max_eid = 100
+    state.structured_file = SimpleNamespace(chunks=[])
+    return state
+
+
+def _req(method: str, **params: Any) -> dict[str, Any]:
+    p: dict[str, Any] = {"_token": "tok"}
+    p.update(params)
+    return {"id": 1, "method": method, "params": p}
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 call-site: _handle_draws passes actions+sf to filter_by_pass
+# ---------------------------------------------------------------------------
+
+
+class TestDrawsPassFilterCallSite:
+    def test_filter_by_pass_receives_actions(self) -> None:
+        """filter_by_pass is called with non-None actions when pass param is set."""
+        state = _make_state()
+        captured: dict[str, Any] = {}
+
+        def _spy_fbp(flat, pass_name, actions=None, sf=None):
+            captured["actions"] = actions
+            captured["sf"] = sf
+            return flat  # pass everything through
+
+        with patch("rdc.services.query_service.filter_by_pass", side_effect=_spy_fbp):
+            _handle_request(_req("draws", **{"pass": "Colour Pass #1"}), state)
+
+        assert "actions" in captured, "filter_by_pass was not called"
+        assert captured["actions"] is not None
+        assert captured["sf"] is not None
+
+    def test_filter_by_pass_not_called_without_pass_param(self) -> None:
+        """filter_by_pass is not called when no pass param is supplied."""
+        state = _make_state()
+        call_count = 0
+
+        def _spy_fbp(flat, pass_name, actions=None, sf=None):
+            nonlocal call_count
+            call_count += 1
+            return flat
+
+        with patch("rdc.services.query_service.filter_by_pass", side_effect=_spy_fbp):
+            _handle_request(_req("draws"), state)
+
+        assert call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: summary reflects filtered flat, not all_flat
+# ---------------------------------------------------------------------------
+
+
+def _make_flat(n: int, flags: int = 0x0002) -> list[FlatAction]:
+    return [FlatAction(eid=i, name=f"d{i}", flags=flags) for i in range(n)]
+
+
+class TestDrawsSummaryFiltered:
+    def test_pass_filter_reduces_summary(self) -> None:
+        """After pass filter yields 3 draws, summary starts with '3 draw calls'."""
+        all_flat = _make_flat(10)
+        filtered = _make_flat(3)
+
+        state = _make_state()
+
+        with (
+            patch("rdc.daemon_server._get_flat_actions", return_value=all_flat),
+            patch("rdc.services.query_service.filter_by_pass", return_value=filtered),
+        ):
+            resp, _ = _handle_request(_req("draws", **{"pass": "SomePass"}), state)
+
+        summary = resp["result"]["summary"]
+        assert summary.startswith("3 draw calls"), f"Got: {summary!r}"
+
+    def test_no_filter_summary_equals_total(self) -> None:
+        """No pass filter: summary draw count equals total draw actions."""
+        all_flat = _make_flat(7)
+        state = _make_state()
+
+        with patch("rdc.daemon_server._get_flat_actions", return_value=all_flat):
+            resp, _ = _handle_request(_req("draws"), state)
+
+        summary = resp["result"]["summary"]
+        assert summary.startswith("7 draw calls"), f"Got: {summary!r}"
+
+    def test_summary_count_matches_draws_list(self) -> None:
+        """Summary count equals len(draws) in the response."""
+        state = _make_state()
+        resp, _ = _handle_request(_req("draws"), state)
+        result = resp["result"]
+        draws = result["draws"]
+        summary = result["summary"]
+        expected_prefix = f"{len(draws)} draw calls"
+        assert summary.startswith(expected_prefix), f"summary={summary!r}, draws={len(draws)}"
+
+    def test_summary_includes_dispatches_and_clears(self) -> None:
+        """Summary format includes dispatches and clears counts."""
+        state = _make_state()
+        resp, _ = _handle_request(_req("draws"), state)
+        summary = resp["result"]["summary"]
+        assert "dispatches" in summary
+        assert "clears" in summary
+
+    def test_type_filter_does_not_affect_summary(self) -> None:
+        """Summary is based on post-pass-filter all_flat, not post-type-filter flat."""
+        # Build all_flat with 5 draws + 2 dispatches
+        draws_flat = _make_flat(5, flags=0x0002)
+        dispatch_flat = _make_flat(2, flags=0x0004)
+        all_flat = draws_flat + dispatch_flat
+
+        state = _make_state()
+        with patch("rdc.daemon_server._get_flat_actions", return_value=all_flat):
+            resp, _ = _handle_request(_req("draws"), state)
+
+        summary = resp["result"]["summary"]
+        # 5 draws, 2 dispatches — summary must report all 5 draws, not 7
+        assert summary.startswith("5 draw calls"), f"Got: {summary!r}"
+        assert "2 dispatches" in summary

--- a/tests/unit/test_pipeline_daemon.py
+++ b/tests/unit/test_pipeline_daemon.py
@@ -1,0 +1,87 @@
+"""Tests for shaders daemon handler stage filter (phase2.7-bug-filters Fix 1)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
+
+import mock_renderdoc as rd
+
+from rdc.adapter import RenderDocAdapter
+from rdc.daemon_server import DaemonState, _handle_request
+
+
+def _make_state() -> DaemonState:
+    ctrl = rd.MockReplayController()
+    a = rd.ActionDescription(eventId=10, flags=rd.ActionFlags.Drawcall)
+    ctrl._actions = [a]
+    vs_id = rd.ResourceId(1)
+    ps_id = rd.ResourceId(2)
+    ctrl._pipe_state._shaders[rd.ShaderStage.Vertex] = vs_id
+    ctrl._pipe_state._shaders[rd.ShaderStage.Pixel] = ps_id
+    state = DaemonState(capture="x.rdc", current_eid=0, token="tok")
+    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
+    state.api_name = "Vulkan"
+    state.max_eid = 100
+    return state
+
+
+def _req(method: str, **params: Any) -> dict[str, Any]:
+    p: dict[str, Any] = {"_token": "tok"}
+    p.update(params)
+    return {"id": 1, "method": method, "params": p}
+
+
+_MOCK_ROWS = [
+    {"shader": 1, "stages": "vs", "uses": 2},
+    {"shader": 2, "stages": "ps", "uses": 2},
+    {"shader": 3, "stages": "vs,ps", "uses": 1},
+]
+
+
+class TestShadersStageFilter:
+    def test_stage_filter_applied(self) -> None:
+        state = _make_state()
+        with patch("rdc.services.query_service.shader_inventory", return_value=list(_MOCK_ROWS)):
+            resp, _ = _handle_request(_req("shaders", stage="vs"), state)
+        rows = resp["result"]["rows"]
+        assert len(rows) == 2
+        for r in rows:
+            assert "vs" in r["stages"].lower().split(",")
+
+    def test_stage_filter_case_insensitive(self) -> None:
+        state = _make_state()
+        with patch("rdc.services.query_service.shader_inventory", return_value=list(_MOCK_ROWS)):
+            resp, _ = _handle_request(_req("shaders", stage="VS"), state)
+        rows = resp["result"]["rows"]
+        assert len(rows) == 2
+        for r in rows:
+            assert "vs" in r["stages"].lower().split(",")
+
+    def test_stage_filter_no_match(self) -> None:
+        state = _make_state()
+        with patch("rdc.services.query_service.shader_inventory", return_value=list(_MOCK_ROWS)):
+            resp, _ = _handle_request(_req("shaders", stage="cs"), state)
+        assert resp["result"]["rows"] == []
+
+    def test_no_stage_filter_returns_all(self) -> None:
+        state = _make_state()
+        with patch("rdc.services.query_service.shader_inventory", return_value=list(_MOCK_ROWS)):
+            resp, _ = _handle_request(_req("shaders"), state)
+        assert len(resp["result"]["rows"]) == 3
+
+    def test_invalid_stage_returns_empty_not_error(self) -> None:
+        state = _make_state()
+        with patch("rdc.services.query_service.shader_inventory", return_value=list(_MOCK_ROWS)):
+            resp, _ = _handle_request(_req("shaders", stage="zz"), state)
+        assert "error" not in resp
+        assert resp["result"]["rows"] == []
+
+    def test_no_adapter_returns_error(self) -> None:
+        state = DaemonState(capture="x.rdc", current_eid=0, token="tok")
+        resp, _ = _handle_request(_req("shaders", stage="vs"), state)
+        assert resp["error"]["code"] == -32002


### PR DESCRIPTION
## Summary
- Fix `shaders --stage` filter being silently ignored by daemon handler
- Fix `draws --pass` filter using API name instead of semantic pass name (now uses EID-range matching)
- Fix `draws` summary showing unfiltered stats when pass/type filters are active
- Add friendly pass names when no debug markers exist (e.g. "Colour Pass #1 (1 Target + Depth)")
- Fix topology field showing raw integer instead of enum name

## Test plan
- [x] 27 unit tests covering all 5 fixes (happy path, edge cases, regression)
- [x] 9 GPU integration tests on real captures
- [x] `pixi run check` passes (759 tests, 93% coverage)
- [ ] GPU test with Vulkan Samples sweep
- [ ] Manual verification with various captures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shader filtering by stage with case-insensitive matching for better shader inventory searches.
  * Enhanced pass filtering with EID-range support for more precise capture navigation.

* **Bug Fixes**
  * Summary statistics now accurately reflect filtered results when applying pass filters.
  * Pass names display as human-readable text instead of raw API strings when debug markers are absent.
  * Topology field now displays enum names instead of raw integer values for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->