### PR TITLE
feat(session): add --session flag and RDC_SESSION env var for named sessions

### DIFF
--- a/src/rdc/commands/session.py
+++ b/src/rdc/commands/session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import click
@@ -30,6 +31,7 @@ def status_cmd() -> None:
 
     payload = result
     assert isinstance(payload, dict)
+    click.echo(f"session: {os.environ.get('RDC_SESSION') or 'default'}")
     click.echo(f"capture: {payload['capture']}")
     click.echo(f"current_eid: {payload['current_eid']}")
     click.echo(f"opened_at: {payload['opened_at']}")

--- a/src/rdc/session_state.py
+++ b/src/rdc/session_state.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+
+SESSION_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
 
 
 @dataclass
@@ -23,7 +26,11 @@ def _session_dir() -> Path:
 
 
 def session_path() -> Path:
-    return _session_dir() / "default.json"
+    """Return the session file path, derived from RDC_SESSION env var."""
+    name = os.environ.get("RDC_SESSION") or "default"
+    if not SESSION_NAME_RE.match(name):
+        name = "default"
+    return _session_dir() / f"{name}.json"
 
 
 def load_session() -> SessionState | None:

--- a/tests/unit/test_cli_session_flag.py
+++ b/tests/unit/test_cli_session_flag.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from rdc.cli import main
+
+
+def test_session_flag_sets_env_var(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """--session NAME sets RDC_SESSION before subcommand runs."""
+    captured_env: dict[str, str] = {}
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RDC_SESSION", raising=False)
+
+    def fake_status() -> tuple[bool, object]:
+        captured_env["RDC_SESSION"] = os.environ.get("RDC_SESSION", "")
+        return False, "no session"
+
+    monkeypatch.setattr("rdc.commands.session.status_session", fake_status)
+    runner = CliRunner()
+    runner.invoke(main, ["--session", "baseline", "status"])
+    assert captured_env.get("RDC_SESSION") == "baseline"
+
+
+def test_session_flag_overrides_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """--session NAME overrides a pre-existing RDC_SESSION value."""
+    captured_env: dict[str, str] = {}
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("RDC_SESSION", "old")
+
+    def fake_status() -> tuple[bool, object]:
+        captured_env["RDC_SESSION"] = os.environ.get("RDC_SESSION", "")
+        return False, "no session"
+
+    monkeypatch.setattr("rdc.commands.session.status_session", fake_status)
+    runner = CliRunner()
+    runner.invoke(main, ["--session", "new", "status"])
+    assert captured_env.get("RDC_SESSION") == "new"
+
+
+def test_session_flag_invalid_slash(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Name containing '/' is rejected with exit code 2."""
+    monkeypatch.delenv("RDC_SESSION", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(main, ["--session", "a/b", "status"])
+    assert result.exit_code == 2
+    assert "session" in result.output.lower() or "invalid" in result.output.lower()
+
+
+def test_session_flag_invalid_too_long(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Name longer than 64 chars is rejected with exit code 2."""
+    monkeypatch.delenv("RDC_SESSION", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(main, ["--session", "a" * 65, "status"])
+    assert result.exit_code == 2
+
+
+def test_session_flag_valid_chars(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Names with hyphens and underscores are accepted."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RDC_SESSION", raising=False)
+
+    def fake_status() -> tuple[bool, object]:
+        return False, "no session"
+
+    for name in ("my-session", "session_1", "ABC"):
+        monkeypatch.setattr("rdc.commands.session.status_session", fake_status)
+        runner = CliRunner()
+        result = runner.invoke(main, ["--session", name, "status"])
+        assert result.exit_code != 2, f"name {name!r} should be valid"
+
+
+def test_two_sessions_isolated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Two named sessions return independent data from their respective files."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RDC_SESSION", raising=False)
+    monkeypatch.setattr("rdc.services.session_service._renderdoc_available", lambda: False)
+    runner = CliRunner()
+
+    # Open session "a"
+    monkeypatch.setenv("RDC_SESSION", "a")
+    result = runner.invoke(main, ["open", "alpha.rdc"])
+    assert result.exit_code == 0
+    assert (tmp_path / ".rdc" / "sessions" / "a.json").exists()
+
+    # Open session "b"
+    monkeypatch.setenv("RDC_SESSION", "b")
+    result = runner.invoke(main, ["open", "beta.rdc"])
+    assert result.exit_code == 0
+    assert (tmp_path / ".rdc" / "sessions" / "b.json").exists()
+
+    # Status for "a" shows alpha.rdc
+    monkeypatch.setenv("RDC_SESSION", "a")
+    result = runner.invoke(main, ["status"])
+    assert result.exit_code == 0
+    assert "alpha.rdc" in result.output
+    assert "beta.rdc" not in result.output
+
+    # Status for "b" shows beta.rdc
+    monkeypatch.setenv("RDC_SESSION", "b")
+    result = runner.invoke(main, ["status"])
+    assert result.exit_code == 0
+    assert "beta.rdc" in result.output
+    assert "alpha.rdc" not in result.output

--- a/tests/unit/test_session_commands.py
+++ b/tests/unit/test_session_commands.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from rdc.cli import main
@@ -11,8 +12,9 @@ def _session_file(home: Path) -> Path:
     return home / ".rdc" / "sessions" / "default.json"
 
 
-def test_open_status_goto_close_flow(monkeypatch, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+def test_open_status_goto_close_flow(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RDC_SESSION", raising=False)
     monkeypatch.setattr("rdc.services.session_service._renderdoc_available", lambda: False)
     runner = CliRunner()
 
@@ -37,27 +39,58 @@ def test_open_status_goto_close_flow(monkeypatch, tmp_path: Path) -> None:  # ty
     assert not _session_file(tmp_path).exists()
 
 
-def test_goto_without_session_fails(monkeypatch, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+def test_goto_without_session_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RDC_SESSION", raising=False)
     runner = CliRunner()
 
     result = runner.invoke(main, ["goto", "1"])
     assert result.exit_code == 1
 
 
-def test_close_without_session_fails(monkeypatch, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+def test_close_without_session_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RDC_SESSION", raising=False)
     runner = CliRunner()
 
     result = runner.invoke(main, ["close"])
     assert result.exit_code == 1
 
 
-def test_goto_rejects_negative_eid(monkeypatch, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+def test_goto_rejects_negative_eid(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RDC_SESSION", raising=False)
     monkeypatch.setattr("rdc.services.session_service._renderdoc_available", lambda: False)
     runner = CliRunner()
 
     runner.invoke(main, ["open", "capture.rdc"])
     result = runner.invoke(main, ["goto", "-1"])
     assert result.exit_code != 0
+
+
+def test_status_shows_session_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """rdc status first line is 'session: <name>' matching active RDC_SESSION."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("RDC_SESSION", "mytest")
+    monkeypatch.setattr("rdc.services.session_service._renderdoc_available", lambda: False)
+    runner = CliRunner()
+
+    runner.invoke(main, ["open", "capture.rdc"])
+    result = runner.invoke(main, ["status"])
+    assert result.exit_code == 0
+    lines = result.output.splitlines()
+    assert lines[0] == "session: mytest"
+
+
+def test_status_shows_default_session_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Without --session, status first line is 'session: default'."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RDC_SESSION", raising=False)
+    monkeypatch.setattr("rdc.services.session_service._renderdoc_available", lambda: False)
+    runner = CliRunner()
+
+    runner.invoke(main, ["open", "capture.rdc"])
+    result = runner.invoke(main, ["status"])
+    assert result.exit_code == 0
+    lines = result.output.splitlines()
+    assert lines[0] == "session: default"

--- a/tests/unit/test_session_service.py
+++ b/tests/unit/test_session_service.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from rdc.services import session_service
 
 
-def test_open_session_rejects_existing_live_session(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_open_session_rejects_existing_live_session(monkeypatch: pytest.MonkeyPatch) -> None:
     class DummyState:
         pid = 123
 
@@ -23,7 +25,43 @@ def test_goto_session_rejects_negative_eid() -> None:
     assert "eid must be >= 0" in msg
 
 
-def test_close_session_without_state(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_close_session_without_state(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(session_service, "load_session", lambda: None)
     ok, _msg = session_service.close_session()
     assert ok is False
+
+
+def test_open_session_cross_name_no_conflict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Opening session 'b' while 'a' is alive succeeds (conflict is per-name)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(session_service, "_renderdoc_available", lambda: False)
+
+    # Open session "a"
+    monkeypatch.setenv("RDC_SESSION", "a")
+    ok_a, _ = session_service.open_session(Path("alpha.rdc"))
+    assert ok_a is True
+
+    # Opening session "b" must succeed even though "a" is alive
+    monkeypatch.setenv("RDC_SESSION", "b")
+    ok_b, msg_b = session_service.open_session(Path("beta.rdc"))
+    assert ok_b is True, f"expected success but got: {msg_b}"
+
+
+def test_open_session_same_name_alive_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Opening the same session name twice (alive pid) returns error."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("RDC_SESSION", "alpha")
+    monkeypatch.setattr(session_service, "_renderdoc_available", lambda: False)
+
+    ok1, _ = session_service.open_session(Path("alpha.rdc"))
+    assert ok1 is True
+
+    # Second open with same name and live pid must fail
+    monkeypatch.setattr(session_service, "is_pid_alive", lambda pid: True)
+    ok2, msg2 = session_service.open_session(Path("alpha.rdc"))
+    assert ok2 is False
+    assert "active session exists" in msg2

--- a/tests/unit/test_session_state.py
+++ b/tests/unit/test_session_state.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
-from rdc.session_state import is_pid_alive
+import pytest
+
+from rdc.session_state import is_pid_alive, session_path
 
 
 def test_is_pid_alive_for_current_process() -> None:
@@ -11,3 +14,27 @@ def test_is_pid_alive_for_current_process() -> None:
 
 def test_is_pid_alive_for_invalid_pid() -> None:
     assert is_pid_alive(-1) is False
+
+
+def test_session_path_reads_env_var(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("RDC_SESSION", "foo")
+    assert session_path() == tmp_path / ".rdc" / "sessions" / "foo.json"
+
+
+def test_session_path_default_no_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("RDC_SESSION", raising=False)
+    assert session_path() == tmp_path / ".rdc" / "sessions" / "default.json"
+
+
+def test_session_path_default_empty_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("RDC_SESSION", "")
+    assert session_path() == tmp_path / ".rdc" / "sessions" / "default.json"
+
+
+def test_session_path_rejects_traversal(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("RDC_SESSION", "../../etc/evil")
+    assert session_path() == tmp_path / ".rdc" / "sessions" / "default.json"


### PR DESCRIPTION
## Summary

- Add `RDC_SESSION` env var and `--session NAME` CLI flag for named sessions
- `session_path()` routes to `~/.rdc/sessions/<name>.json` (default: `default.json`)
- Name validation: `[a-zA-Z0-9_-]{1,64}` with defense-in-depth in both CLI and `session_path()`
- `rdc status` shows active session name as first output line
- ~25 LOC production delta across 3 files, 23 new tests

## Design

- `--session` on main Click group: `expose_value=False, is_eager=True` callback sets `os.environ["RDC_SESSION"]`
- Zero subcommand signature changes (31 commands untouched)
- Backward compatible: no env var → `default.json` (identical path)

## Test plan

- Unit: env var routing (set/unset/empty/traversal), CLI flag validation, cross-session isolation, status output
- E2E: 26/26 passed
- Coverage: 93.50% (877 tests)

## OpenSpec

`openspec/changes/2026-02-22-phase3a-session-name/`