### PR TITLE
feat(script): add script execution handler and CLI command

### DIFF
--- a/openspec/changes/2026-02-22-phase3a-script/proposal.md
+++ b/openspec/changes/2026-02-22-phase3a-script/proposal.md
@@ -1,0 +1,177 @@
+# Proposal: phase3a-script
+
+## Summary
+
+Add `rdc script <file.py>` — an escape-hatch command that executes an arbitrary
+Python script inside the daemon process via `exec()`, with full access to the
+live `renderdoc` module and `ReplayController`. stdout/stderr are captured and
+returned over JSON-RPC.
+
+## Motivation
+
+The existing 62 JSON-RPC methods cover the most common RenderDoc queries, but
+cannot enumerate every possible data shape an agent or power user might need.
+When the structured commands fall short, the only alternative today is to
+`rdc open` a capture in the RenderDoc GUI — a non-scriptable dead end.
+
+`rdc script` closes this gap. Any valid `renderdoc` Python API call can be issued
+from a one-off `.py` file, results read back through standard output. The agent
+debug loop becomes: write a ten-line probe script → `rdc script probe.py` →
+parse JSON response → done.
+
+This is explicitly rated **Tier 1 Must-Have** in the Phase 3 agent-debug
+analysis (`调研-Agent功能优先级分析.md`).
+
+## Design
+
+### Handler: `src/rdc/handlers/script.py`
+
+Follows the standard HANDLERS-dict pattern used by all Phase 2 handler modules:
+
+```python
+HANDLERS: dict[str, Any] = {
+    "script": _handle_script,
+}
+```
+
+Registered in `daemon_server.py` by importing and merging into `_DISPATCH`.
+
+### Execution model
+
+```python
+def _handle_script(request_id, params, state):
+    path = Path(params["path"])
+    # 1. Validate: path.exists(), path.is_file(), state.adapter is not None
+    # 2. Read source: path.read_text("utf-8")
+    # 3. Build globals namespace
+    # 4. Redirect stdout/stderr → contextlib.redirect_stdout/redirect_stderr + StringIO
+    # 5. Record start time
+    # 6. exec(source, script_globals)
+    # 7. Extract result variable if present
+    # 8. Return {stdout, stderr, elapsed_ms, return_value}
+```
+
+### Script namespace
+
+| Variable     | Type                  | Description                              |
+|--------------|-----------------------|------------------------------------------|
+| `controller` | SWIG `ReplayController` | Full RenderDoc replay API              |
+| `rd`         | module                | `renderdoc` module (for constructing types) |
+| `adapter`    | `RenderDocAdapter`    | Compatibility wrapper                    |
+| `state`      | `DaemonState`         | All caches, temp dir, resource maps      |
+| `args`       | `dict[str, str]`      | Key=value pairs from CLI `--arg`         |
+
+### Error handling
+
+SyntaxError is caught before `exec()` to produce a clear line-number message.
+`BaseException` (not `Exception`) guards the `exec()` call to catch
+`SystemExit` and `KeyboardInterrupt` that would otherwise terminate the daemon:
+
+```python
+try:
+    compile(source, str(path), "exec")
+except SyntaxError as exc:
+    return _error_response(request_id, -32002,
+        f"syntax error: {exc.msg} at line {exc.lineno}")
+try:
+    exec(code, script_globals)  # noqa: S102
+except BaseException as exc:  # noqa: BLE001
+    return _error_response(request_id, -32002,
+        f"script error: {type(exc).__name__}: {exc}")
+```
+
+### `result` variable extraction
+
+If the script assigns `result = <value>`, the handler tries to JSON-serialize it.
+Non-serializable objects are coerced to `str()`:
+
+```python
+raw = script_globals.get("result")
+try:
+    json.dumps(raw)
+    return_value = raw
+except (TypeError, ValueError):
+    return_value = str(raw)
+```
+
+If `result` is not assigned, `return_value` is `null`.
+
+### JSON-RPC interface
+
+**Method:** `"script"`
+
+**Params:**
+```json
+{
+    "_token": "<token>",
+    "path": "/absolute/path/to/script.py",
+    "args": {"key": "value"}
+}
+```
+`args` is optional; defaults to `{}`.
+
+**Success response:**
+```json
+{
+    "result": {
+        "stdout": "hello\n",
+        "stderr": "",
+        "elapsed_ms": 42,
+        "return_value": {"count": 3}
+    }
+}
+```
+
+**Error responses:**
+
+| Scenario           | Code    | Message                                    |
+|--------------------|---------|--------------------------------------------|
+| No replay loaded   | -32002  | `"no replay loaded"`                       |
+| File not found     | -32002  | `"script not found: <path>"`               |
+| Path is a directory| -32002  | `"script path is a directory"`             |
+| SyntaxError        | -32002  | `"syntax error: <msg> at line <n>"`        |
+| Runtime exception  | -32002  | `"script error: <Type>: <msg>"`            |
+
+### CLI command: `src/rdc/commands/script.py`
+
+```
+rdc script <file.py> [--arg KEY=VALUE ...] [--json]
+```
+
+- `file.py`: `click.Path(exists=True, dir_okay=False, path_type=Path)` — Click
+  validates existence; path is made absolute before sending to daemon.
+- `--arg KEY=VALUE`: multiple option, parsed into `dict[str, str]`. Invalid
+  format (missing `=`) → error to stderr, exit 2.
+- `--json`: emit the raw JSON-RPC response object instead of formatted output.
+
+**Default output:**
+- `stdout` content printed to stdout (as-is, no extra newline if already present)
+- `stderr` content printed to stderr
+- Elapsed time printed to stderr: `# elapsed: 42 ms`
+- If `return_value` is not null, printed to stderr: `# result: <value>`
+
+### Security
+
+Design doc mandate: **no sandbox**. This is a local developer tool, not a
+multi-user server. Token auth on the daemon socket prevents unauthorized
+invocation. The script runs with the daemon's full OS privileges.
+
+Documented behavior:
+- Only local file paths accepted (`Path.is_file()` validated).
+- Daemon crash due to script = user's responsibility; recover with
+  `rdc close && rdc open`.
+- No path traversal protection needed (user trusts their own filesystem).
+
+## Scope
+
+| Component                                  | Lines |
+|--------------------------------------------|-------|
+| `src/rdc/handlers/script.py`               | ~80   |
+| `src/rdc/commands/script.py`               | ~45   |
+| `daemon_server.py` + `cli.py` registration | ~4    |
+| Unit tests (handler + CLI)                 | ~120  |
+| GPU integration test                       | ~30   |
+| **Total**                                  | **~280** |
+
+No VFS route: `rdc script` is a one-shot execution command, not a data
+node — it does not belong in the VFS namespace.

--- a/openspec/changes/2026-02-22-phase3a-script/tasks.md
+++ b/openspec/changes/2026-02-22-phase3a-script/tasks.md
@@ -1,0 +1,92 @@
+# Tasks: phase3a-script
+
+## Phase A — Handler unit tests
+
+- [ ] Create `tests/unit/test_script_handler.py`
+- [ ] Test happy path: script prints + assigns `result = 42` → `stdout`, `return_value`, `elapsed_ms >= 0`
+- [ ] Test stderr capture: script writes to `sys.stderr` → `stderr` field, `stdout` empty
+- [ ] Test no `result` variable → `return_value` is `None`
+- [ ] Test non-serializable `result` → `return_value` is a string (str() coercion)
+- [ ] Test dict/list `result` → `return_value` is JSON-native value
+- [ ] Test empty script → all fields empty/null, no error
+- [ ] Test `args` forwarded: handler passes `{"mode": "fast"}`, script reads `args["mode"]`
+- [ ] Test no replay loaded (`state.adapter is None`) → error `-32002`, message `"no replay loaded"`, assert handler return tuple[1] is True
+- [ ] Test file not found → error `-32002`, message contains `"script not found"`
+- [ ] Test path is directory → error `-32002`, message `"script path is a directory"`
+- [ ] Test SyntaxError → error `-32002`, message starts with `"syntax error:"`, includes line number
+- [ ] Test RuntimeError (`raise ValueError`) → error `-32002`, message `"script error: ValueError: ..."`, no crash
+- [ ] Test `SystemExit` → error `-32002`, message `"script error: SystemExit: 0"`, daemon continues
+- [ ] Test `KeyboardInterrupt` → error `-32002`, no crash
+- [ ] Test stdout isolation: after handler returns, original `sys.stdout` is restored
+
+## Phase B — CLI unit tests
+
+- [ ] Create `tests/unit/test_script_command.py`
+- [ ] Test default output: `result.stdout` content goes to stdout exactly
+- [ ] Test default output: `result.stderr` goes to stderr
+- [ ] Test default output: elapsed footer line on stderr matches `# elapsed: \d+ ms`
+- [ ] Test default output: `return_value` not null → `# result:` line on stderr
+- [ ] Test `--json` flag: raw JSON object on stdout, nothing on stderr, exit 0
+- [ ] Test daemon error → exit 1, error message to stderr
+- [ ] Test `--arg KEY=VALUE` single: `args={"KEY": "VALUE"}` in request
+- [ ] Test `--arg` multiple: all pairs merged
+- [ ] Test `--arg` missing `=`: exit 2 with error message
+- [ ] Test no `--arg`: `args` defaults to `{}`
+
+## Phase C — Handler implementation
+
+- [ ] Create `src/rdc/handlers/script.py`
+- [ ] Implement `_handle_script(request_id, params, state)`:
+  - Validate `state.adapter is not None` → `-32002` if missing
+  - Validate `path.exists()` → `-32002` with `"script not found"` message
+  - Validate `path.is_file()` → `-32002` with `"script path is a directory"` message
+  - `source = path.read_text("utf-8")`
+  - Pre-flight: `compile(source, str(path), "exec")` → catch `SyntaxError`
+  - Build fresh `script_globals = {"controller": ..., "rd": ..., "adapter": ..., "state": ..., "args": ...}`
+  - Redirect stdout/stderr with `contextlib.redirect_stdout/redirect_stderr` + `StringIO`
+  - Time with `time.perf_counter()`
+  - `exec(code, script_globals)` under `BaseException` guard
+  - Extract `result` variable; try `json.dumps()`, fall back to `str()`
+  - Return `{stdout, stderr, elapsed_ms, return_value}`
+- [ ] Expose `HANDLERS: dict[str, Any] = {"script": _handle_script}`
+- [ ] Verify Phase A tests pass: `pixi run test -k test_script_handler`
+
+## Phase D — CLI implementation
+
+- [ ] Create `src/rdc/commands/script.py`
+- [ ] Implement `script_cmd` Click command:
+  - `@click.argument("script_file", type=click.Path(exists=True, dir_okay=False, path_type=Path))`
+  - `@click.option("--arg", "args", multiple=True, metavar="KEY=VALUE")`
+  - `@click.option("--json", "output_json", is_flag=True)`
+  - Parse `--arg` list into `dict[str, str]`; exit 2 on missing `=`
+  - Send daemon request `{"method": "script", "params": {"path": str(abs_path), "args": args_dict}}`
+  - Default mode: print `stdout` to stdout, `stderr` to stderr, elapsed/result footers to stderr
+  - `--json` mode: `click.echo(json.dumps(response))`
+- [ ] Verify Phase B tests pass: `pixi run test -k test_script_command`
+
+## Phase E — Registration
+
+- [ ] In `daemon_server.py`: import `from rdc.handlers.script import HANDLERS as _SCRIPT_HANDLERS` and merge into `_DISPATCH`
+- [ ] In `src/rdc/cli.py`: import `script_cmd` and add to CLI group
+- [ ] Run `pixi run check` — lint + typecheck + all unit tests must pass
+
+## Phase F — GPU integration test
+
+- [ ] In `tests/integration/test_daemon_handlers_real.py`, add `test_script_get_resources_real`:
+  - Write a temp script (`tmp_path / "probe.py"`) that calls `controller.GetResources()` and assigns `result = len(controller.GetResources())`
+  - Call daemon `script` handler with the temp path
+  - Assert `return_value` is an integer > 0
+  - Assert `stdout == ""`
+  - Assert `elapsed_ms >= 0`
+- [ ] Run GPU tests: `RENDERDOC_PYTHON_PATH=... pixi run test-gpu -k test_script`
+
+## Phase G — Final verification
+
+- [ ] `pixi run lint` — zero ruff errors
+- [ ] `pixi run test` — all unit tests green, coverage >= 80%
+- [ ] GPU tests pass on `tests/fixtures/hello_triangle.rdc`
+- [ ] Multi-agent code review (Opus / Codex / Gemini) — zero P0/P1 blockers
+- [ ] Archive: move `openspec/changes/2026-02-22-phase3a-script/` → `openspec/changes/archive/`
+- [ ] Merge delta into `openspec/specs/commands/script.md`
+- [ ] Update `进度跟踪.md` in Obsidian vault
+- [ ] Commit, push branch, open PR

--- a/openspec/changes/2026-02-22-phase3a-script/test-plan.md
+++ b/openspec/changes/2026-02-22-phase3a-script/test-plan.md
@@ -1,0 +1,174 @@
+# Test Plan: phase3a-script
+
+## Scope
+
+### In scope
+- Daemon handler `script`: exec() a local `.py` file inside daemon, return
+  `{stdout, stderr, elapsed_ms, return_value}`
+- stdout/stderr capture via `contextlib.redirect_stdout/redirect_stderr` + `StringIO`
+- `result` variable extraction with JSON-serialization fallback to `str()`
+- `BaseException` guard preventing `SystemExit` / `KeyboardInterrupt` from
+  killing the daemon
+- SyntaxError pre-flight via `compile()` returning line-number message
+- Error codes: no replay (-32002), file missing (-32002), is-directory (-32002),
+  syntax error (-32002), runtime error (-32002)
+- CLI `rdc script <file.py>`: default formatted output + `--json` raw mode
+- CLI `--arg KEY=VALUE` parsing → `args` dict forwarded to daemon
+- Registration in `daemon_server.py` HANDLERS dispatch and `cli.py` group
+
+### Out of scope
+- Sandbox or security isolation beyond token auth
+- VFS path for script execution
+- Streaming output (stdout returned only after script completes)
+- Script timeout / resource limits
+- Script caching or module import reuse between calls
+
+## Test Matrix
+
+| Layer       | Scope                                               | Runner                         |
+|-------------|-----------------------------------------------------|--------------------------------|
+| Unit        | Handler happy path, error paths, capture isolation  | pytest (`test_script_handler.py`) |
+| Unit        | CLI output format, `--json`, `--arg` parsing        | pytest + CliRunner (`test_script_command.py`) |
+| Integration | Mock API sync (no new mock API needed)              | existing `test_mock_api_sync.py` (no change expected) |
+| GPU         | Real capture: `controller.GetResources()` via script | pytest -m gpu (`test_daemon_handlers_real.py`) |
+
+## Cases
+
+### Handler: happy paths
+
+1. **Print + result assignment**: script does `print("hello")` and `result = 42`.
+   Response: `stdout="hello\n"`, `return_value=42`, `elapsed_ms >= 0`, `stderr=""`.
+
+2. **stderr output**: script does `import sys; sys.stderr.write("warn\n")`.
+   Response: `stderr="warn\n"`, `stdout=""`.
+
+3. **No result variable**: script only prints. Response: `return_value=null`.
+
+4. **Non-serializable result**: script assigns `result = object()`.
+   Response: `return_value` is a non-empty string (str() coercion), not an error.
+
+5. **Dict/list result**: script assigns `result = {"k": [1, 2]}`.
+   Response: `return_value={"k": [1, 2]}` (JSON-native).
+
+6. **Empty script**: zero-byte file. Response: `stdout=""`, `stderr=""`,
+   `return_value=null`, exit success.
+
+7. **`args` forwarded**: script reads `args["mode"]`, handler passes `{"mode": "fast"}`.
+   Response contains expected output.
+
+### Handler: error paths
+
+8. **No replay loaded** (`state.adapter is None`): response error code `-32002`,
+   message `"no replay loaded"`. Daemon keeps running (verified by checking
+   the handler return value is `(response_dict, True)` where `True` means keep running).
+
+9. **File not found**: `params["path"]` points to a non-existent file. Error `-32002`,
+   message contains `"script not found"`.
+
+10. **Path is a directory**: `params["path"]` is an existing directory. Error `-32002`,
+    message `"script path is a directory"`.
+
+11. **SyntaxError**: script contains `def foo(:`. Error `-32002`, message starts with
+    `"syntax error:"` and includes the offending line number.
+
+12. **RuntimeError**: script raises `raise ValueError("bad input")`. Error `-32002`,
+    message `"script error: ValueError: bad input"`. Daemon does not crash.
+
+13. **`SystemExit`**: script calls `sys.exit(0)`. Error `-32002`, message
+    `"script error: SystemExit: 0"`. Daemon process continues (verified by
+    confirming a subsequent valid handler call succeeds in the same test session).
+
+14. **`KeyboardInterrupt`**: script raises `KeyboardInterrupt()`. Error `-32002`,
+    message `"script error: KeyboardInterrupt: "`. Daemon continues.
+
+### Handler: isolation
+
+15. **stdout not leaked to daemon process stdout**: after handler returns, real
+    `sys.stdout` is the original stream (redirect is properly restored via
+    `contextlib` context manager even on exception).
+
+16. **Concurrent calls do not share globals**: two sequential script executions
+    with different `result` assignments return independent values.
+
+### CLI: output format
+
+17. **Default output — stdout content**: `result.stdout` is printed to stdout
+    exactly as returned (no extra newline added if already present).
+
+18. **Default output — stderr routing**: `result.stderr` is printed to stderr,
+    not stdout.
+
+19. **Default output — elapsed footer**: `stderr` receives a line matching
+    `# elapsed: \d+ ms`.
+
+20. **Default output — return_value footer**: when `return_value` is not null,
+    stderr receives `# result: <value>`.
+
+21. **`--json` flag**: stdout receives the raw JSON object from the daemon
+    response. Nothing printed to stderr. Exit 0.
+
+22. **Daemon error → exit 1**: daemon returns error code → error message to
+    stderr, exit 1.
+
+### CLI: `--arg` parsing
+
+23. **Single `--arg KEY=VALUE`**: `args` dict `{"KEY": "VALUE"}` forwarded to daemon.
+
+24. **Multiple `--arg`**: all pairs merged into one dict.
+
+25. **`--arg` missing `=`**: Click/handler raises error, exit 2, message mentions
+    invalid format.
+
+26. **No `--arg`**: `args` defaults to `{}` in the request.
+
+### Edge cases
+
+27. **Large stdout**: script prints 100 KB of text. Full content returned in
+    `stdout` field (no truncation at handler level).
+
+28. **Script imports stdlib**: script does `import json; result = json.dumps([1,2])`.
+    Returns successfully; no import restrictions.
+
+29. **Script path with spaces**: path `"/tmp/my script.py"` handled correctly
+    (pathlib.Path, not string splitting).
+
+## Assertions
+
+### Exit codes
+- `0`: script executed successfully (no exception raised)
+- `1`: daemon error (no session, no replay, file not found, script exception)
+- `2`: CLI argument error (bad `--arg` format, missing required argument)
+
+### stdout/stderr contract (default mode)
+- stdout: exact content of `result.stdout`, byte-for-byte
+- stderr: exact content of `result.stderr`, then footer lines (`# elapsed:`, optionally `# result:`)
+- No interleaving of script stdout with daemon log lines
+
+### JSON schema (`script` handler success response)
+```json
+{
+    "stdout": <str>,
+    "stderr": <str>,
+    "elapsed_ms": <int, >= 0>,
+    "return_value": <any JSON value or null>
+}
+```
+- `stdout` and `stderr` are always strings (empty string, never null)
+- `elapsed_ms` is a non-negative integer
+- `return_value` is null when the script does not assign `result`
+
+### Error response (JSON-RPC)
+- Code always `-32002` for all script-execution errors
+- `"message"` is a non-empty string
+- Error output goes to stderr; stdout is empty on error
+
+## Risks & Rollback
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| `BaseException` catch silences real interpreter bugs | Hard to debug daemon issues | Log the full traceback to daemon log at WARNING level before returning error |
+| stdout redirect not restored on exception | Daemon stdout corrupted permanently | Use `contextlib.redirect_stdout` as context manager (always restores) |
+| `exec()` modifies `__builtins__` in shared namespace | Persistent state corruption between calls | Always construct a fresh `script_globals = {}` dict per call |
+| Large stdout (> 10 MB) causes JSON serialization OOM | Daemon OOM | Document limit; add note that scripts should write to file for bulk data |
+| `compile()` pre-flight diverges from `exec()` behavior | SyntaxError not caught pre-flight | Pre-flight covers 99% of cases; remaining caught by BaseException guard |
+| Rollback | — | Revert branch; no master changes until PR squash-merge |

--- a/src/rdc/cli.py
+++ b/src/rdc/cli.py
@@ -12,6 +12,7 @@ from rdc.commands.export import buffer_cmd, rt_cmd, texture_cmd
 from rdc.commands.info import info_cmd, log_cmd, stats_cmd
 from rdc.commands.pipeline import bindings_cmd, pipeline_cmd, shader_cmd, shaders_cmd
 from rdc.commands.resources import pass_cmd, passes_cmd, resource_cmd, resources_cmd
+from rdc.commands.script import script_cmd
 from rdc.commands.search import search_cmd
 from rdc.commands.session import close_cmd, goto_cmd, open_cmd, status_cmd
 from rdc.commands.unix_helpers import count_cmd, shader_map_cmd
@@ -59,6 +60,7 @@ main.add_command(search_cmd, name="search")
 main.add_command(usage_cmd, name="usage")
 main.add_command(completion_cmd, name="completion")
 main.add_command(counters_cmd, name="counters")
+main.add_command(script_cmd, name="script")
 
 
 if __name__ == "__main__":

--- a/src/rdc/commands/script.py
+++ b/src/rdc/commands/script.py
@@ -1,0 +1,69 @@
+"""rdc script command -- execute a Python script inside the daemon."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+
+from rdc.commands._helpers import call
+
+
+def _parse_args(raw: tuple[str, ...]) -> dict[str, str]:
+    """Parse KEY=VALUE pairs into a dict.
+
+    Raises:
+        click.BadParameter: If any value is missing '='.
+    """
+    result: dict[str, str] = {}
+    for item in raw:
+        if "=" not in item:
+            raise click.BadParameter(
+                f"invalid format {item!r}, expected KEY=VALUE", param_hint="'--arg'"
+            )
+        k, v = item.split("=", 1)
+        result[k] = v
+    return result
+
+
+@click.command("script")
+@click.argument(
+    "script_file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option("--arg", "args", multiple=True, metavar="KEY=VALUE", help="Script argument.")
+@click.option("--json", "output_json", is_flag=True, help="Raw JSON output.")
+def script_cmd(script_file: Path, args: tuple[str, ...], output_json: bool) -> None:
+    """Execute a Python script inside the daemon process.
+
+    The script has access to the live ReplayController, renderdoc module,
+    and all daemon state. Assign to `result` to return structured data.
+    """
+    args_dict = _parse_args(args)
+    params: dict[str, Any] = {
+        "path": str(script_file.resolve()),
+        "args": args_dict,
+    }
+
+    result = call("script", params)
+
+    if output_json:
+        click.echo(json.dumps(result))
+        return
+
+    stdout_text = result.get("stdout", "")
+    if stdout_text:
+        click.echo(stdout_text, nl=False)
+
+    stderr_text = result.get("stderr", "")
+    if stderr_text:
+        click.echo(stderr_text, err=True, nl=False)
+
+    elapsed = result.get("elapsed_ms", 0)
+    click.echo(f"# elapsed: {elapsed} ms", err=True)
+
+    return_value = result.get("return_value")
+    if return_value is not None:
+        click.echo(f"# result: {return_value}", err=True)

--- a/src/rdc/daemon_server.py
+++ b/src/rdc/daemon_server.py
@@ -30,6 +30,7 @@ from rdc.handlers.core import HANDLERS as _CORE_HANDLERS
 from rdc.handlers.descriptor import HANDLERS as _DESCRIPTOR_HANDLERS
 from rdc.handlers.pipe_state import HANDLERS as _PIPE_STATE_HANDLERS
 from rdc.handlers.query import HANDLERS as _QUERY_HANDLERS
+from rdc.handlers.script import HANDLERS as _SCRIPT_HANDLERS
 from rdc.handlers.shader import HANDLERS as _SHADER_HANDLERS
 from rdc.handlers.texture import HANDLERS as _TEXTURE_HANDLERS
 from rdc.handlers.vfs import HANDLERS as _VFS_HANDLERS
@@ -59,6 +60,7 @@ _DISPATCH: dict[str, Any] = {
     **_BUFFER_HANDLERS,
     **_PIPE_STATE_HANDLERS,
     **_DESCRIPTOR_HANDLERS,
+    **_SCRIPT_HANDLERS,
     **_VFS_HANDLERS,
 }
 

--- a/src/rdc/handlers/script.py
+++ b/src/rdc/handlers/script.py
@@ -1,0 +1,90 @@
+"""Script execution handler: run arbitrary Python inside the daemon."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from rdc.handlers._helpers import _error_response, _result_response
+
+if TYPE_CHECKING:
+    from rdc.daemon_server import DaemonState
+
+
+def _handle_script(
+    request_id: int, params: dict[str, Any], state: DaemonState
+) -> tuple[dict[str, Any], bool]:
+    """Execute a Python script with access to the live replay controller.
+
+    Args:
+        request_id: JSON-RPC request ID.
+        params: Must contain "path"; optionally "args".
+        state: Current daemon state.
+
+    Returns:
+        Tuple of (response_dict, keep_running).
+    """
+    if state.adapter is None:
+        return _error_response(request_id, -32002, "no replay loaded"), True
+
+    path = Path(params["path"])
+    if not path.exists():
+        return _error_response(request_id, -32002, f"script not found: {path}"), True
+    if not path.is_file():
+        return _error_response(request_id, -32002, "script path is a directory"), True
+
+    source = path.read_text("utf-8")
+
+    try:
+        code = compile(source, str(path), "exec")
+    except SyntaxError as exc:
+        return _error_response(
+            request_id, -32002, f"syntax error: {exc.msg} at line {exc.lineno}"
+        ), True
+
+    script_globals: dict[str, Any] = {
+        "controller": state.adapter.controller,
+        "rd": state.rd,
+        "adapter": state.adapter,
+        "state": state,
+        "args": params.get("args", {}),
+    }
+
+    out, err = io.StringIO(), io.StringIO()
+    t0 = time.perf_counter()
+
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            exec(code, script_globals)  # noqa: S102
+    except BaseException as exc:  # noqa: BLE001
+        return _error_response(
+            request_id, -32002, f"script error: {type(exc).__name__}: {exc}"
+        ), True
+
+    elapsed_ms = int((time.perf_counter() - t0) * 1000)
+
+    raw = script_globals.get("result")
+    try:
+        json.dumps(raw)
+        return_value = raw
+    except (TypeError, ValueError):
+        return_value = str(raw)
+
+    return _result_response(
+        request_id,
+        {
+            "stdout": out.getvalue(),
+            "stderr": err.getvalue(),
+            "elapsed_ms": elapsed_ms,
+            "return_value": return_value,
+        },
+    ), True
+
+
+HANDLERS: dict[str, Any] = {
+    "script": _handle_script,
+}

--- a/tests/unit/test_script_command.py
+++ b/tests/unit/test_script_command.py
@@ -1,0 +1,185 @@
+"""Tests for CLI script command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from rdc.cli import main
+
+
+def _patch_daemon(monkeypatch: pytest.MonkeyPatch, response: dict[str, Any]) -> None:
+    """Patch load_session and send_request for CLI tests."""
+    import rdc.commands._helpers as helpers_mod
+
+    session = type("S", (), {"host": "127.0.0.1", "port": 1, "token": "tok"})()
+    monkeypatch.setattr(helpers_mod, "load_session", lambda: session)
+    monkeypatch.setattr(helpers_mod, "send_request", lambda _h, _p, _payload: response)
+
+
+def _success_response(
+    stdout: str = "",
+    stderr: str = "",
+    elapsed_ms: int = 42,
+    return_value: Any = None,
+) -> dict[str, Any]:
+    return {
+        "result": {
+            "stdout": stdout,
+            "stderr": stderr,
+            "elapsed_ms": elapsed_ms,
+            "return_value": return_value,
+        }
+    }
+
+
+class TestScriptDefaultOutput:
+    def test_stdout_content(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        script = tmp_path / "s.py"
+        script.write_text("x = 1", encoding="utf-8")
+        _patch_daemon(monkeypatch, _success_response(stdout="hello\n"))
+        result = CliRunner().invoke(main, ["script", str(script)])
+        assert result.exit_code == 0
+        assert "hello\n" in result.output
+
+    def test_stderr_routing(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        script = tmp_path / "s.py"
+        script.write_text("x = 1", encoding="utf-8")
+        _patch_daemon(monkeypatch, _success_response(stderr="warn\n"))
+        result = CliRunner().invoke(main, ["script", str(script)])
+        assert result.exit_code == 0
+        assert "warn\n" in result.output
+
+    def test_elapsed_footer(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        script = tmp_path / "s.py"
+        script.write_text("x = 1", encoding="utf-8")
+        _patch_daemon(monkeypatch, _success_response(elapsed_ms=42))
+        result = CliRunner().invoke(main, ["script", str(script)])
+        assert result.exit_code == 0
+        assert "# elapsed: 42 ms" in result.output
+
+    def test_return_value_footer(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        script = tmp_path / "s.py"
+        script.write_text("x = 1", encoding="utf-8")
+        _patch_daemon(monkeypatch, _success_response(return_value={"count": 3}))
+        result = CliRunner().invoke(main, ["script", str(script)])
+        assert result.exit_code == 0
+        assert "# result:" in result.output
+
+    def test_return_value_null_no_footer(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        script = tmp_path / "s.py"
+        script.write_text("x = 1", encoding="utf-8")
+        _patch_daemon(monkeypatch, _success_response(return_value=None))
+        result = CliRunner().invoke(main, ["script", str(script)])
+        assert result.exit_code == 0
+        assert "# result:" not in result.output
+
+
+class TestScriptJsonOutput:
+    def test_json_flag(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        script = tmp_path / "s.py"
+        script.write_text("x = 1", encoding="utf-8")
+        resp = _success_response(stdout="hello\n", return_value=42)
+        _patch_daemon(monkeypatch, resp)
+        result = CliRunner().invoke(main, ["script", "--json", str(script)])
+        assert result.exit_code == 0
+        data = json.loads(result.output.strip())
+        assert data["stdout"] == "hello\n"
+        assert data["return_value"] == 42
+
+
+class TestScriptDaemonError:
+    def test_daemon_error_exit_1(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        script = tmp_path / "s.py"
+        script.write_text("x = 1", encoding="utf-8")
+        _patch_daemon(monkeypatch, {"error": {"code": -32002, "message": "no replay loaded"}})
+        result = CliRunner().invoke(main, ["script", str(script)])
+        assert result.exit_code == 1
+        assert "no replay loaded" in result.output
+
+
+class TestScriptArgParsing:
+    def test_single_arg(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        script = tmp_path / "s.py"
+        script.write_text("x = 1", encoding="utf-8")
+        captured: list[dict[str, Any]] = []
+
+        import rdc.commands._helpers as helpers_mod
+
+        session = type("S", (), {"host": "127.0.0.1", "port": 1, "token": "tok"})()
+        monkeypatch.setattr(helpers_mod, "load_session", lambda: session)
+
+        def _capture(_h: str, _p: int, payload: dict[str, Any]) -> dict[str, Any]:
+            captured.append(payload)
+            return _success_response()
+
+        monkeypatch.setattr(helpers_mod, "send_request", _capture)
+        CliRunner().invoke(main, ["script", "--arg", "KEY=VALUE", str(script)])
+        assert captured[0]["params"]["args"] == {"KEY": "VALUE"}
+
+    def test_multiple_args(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        script = tmp_path / "s.py"
+        script.write_text("x = 1", encoding="utf-8")
+        captured: list[dict[str, Any]] = []
+
+        import rdc.commands._helpers as helpers_mod
+
+        session = type("S", (), {"host": "127.0.0.1", "port": 1, "token": "tok"})()
+        monkeypatch.setattr(helpers_mod, "load_session", lambda: session)
+
+        def _capture(_h: str, _p: int, payload: dict[str, Any]) -> dict[str, Any]:
+            captured.append(payload)
+            return _success_response()
+
+        monkeypatch.setattr(helpers_mod, "send_request", _capture)
+        CliRunner().invoke(main, ["script", "--arg", "A=1", "--arg", "B=2", str(script)])
+        assert captured[0]["params"]["args"] == {"A": "1", "B": "2"}
+
+    def test_arg_missing_equals(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        script = tmp_path / "s.py"
+        script.write_text("x = 1", encoding="utf-8")
+        _patch_daemon(monkeypatch, _success_response())
+        result = CliRunner().invoke(main, ["script", "--arg", "NOEQUALSSIGN", str(script)])
+        assert result.exit_code == 2
+
+    def test_no_args_default_empty(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        script = tmp_path / "s.py"
+        script.write_text("x = 1", encoding="utf-8")
+        captured: list[dict[str, Any]] = []
+
+        import rdc.commands._helpers as helpers_mod
+
+        session = type("S", (), {"host": "127.0.0.1", "port": 1, "token": "tok"})()
+        monkeypatch.setattr(helpers_mod, "load_session", lambda: session)
+
+        def _capture(_h: str, _p: int, payload: dict[str, Any]) -> dict[str, Any]:
+            captured.append(payload)
+            return _success_response()
+
+        monkeypatch.setattr(helpers_mod, "send_request", _capture)
+        CliRunner().invoke(main, ["script", str(script)])
+        assert captured[0]["params"]["args"] == {}
+
+    def test_arg_value_with_equals(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        script = tmp_path / "s.py"
+        script.write_text("x = 1", encoding="utf-8")
+        captured: list[dict[str, Any]] = []
+
+        import rdc.commands._helpers as helpers_mod
+
+        session = type("S", (), {"host": "127.0.0.1", "port": 1, "token": "tok"})()
+        monkeypatch.setattr(helpers_mod, "load_session", lambda: session)
+
+        def _capture(_h: str, _p: int, payload: dict[str, Any]) -> dict[str, Any]:
+            captured.append(payload)
+            return _success_response()
+
+        monkeypatch.setattr(helpers_mod, "send_request", _capture)
+        CliRunner().invoke(main, ["script", "--arg", "K=A=B", str(script)])
+        assert captured[0]["params"]["args"] == {"K": "A=B"}

--- a/tests/unit/test_script_handler.py
+++ b/tests/unit/test_script_handler.py
@@ -1,0 +1,170 @@
+"""Tests for daemon script handler."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
+
+from rdc.adapter import RenderDocAdapter
+from rdc.daemon_server import DaemonState, _handle_request
+
+
+def _make_state() -> DaemonState:
+    controller = SimpleNamespace(
+        GetRootActions=lambda: [],
+        GetResources=lambda: [],
+        GetAPIProperties=lambda: SimpleNamespace(pipelineType="Vulkan"),
+        GetPipelineState=lambda: SimpleNamespace(),
+        SetFrameEvent=lambda eid, force: None,
+        GetStructuredFile=lambda: SimpleNamespace(chunks=[]),
+        GetDebugMessages=lambda: [],
+        Shutdown=lambda: None,
+    )
+    state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
+    state.adapter = RenderDocAdapter(controller=controller, version=(1, 41))
+    state.api_name = "Vulkan"
+    state.max_eid = 10
+    return state
+
+
+def _req(method: str, **params: Any) -> dict[str, Any]:
+    p: dict[str, Any] = {"_token": "tok"}
+    p.update(params)
+    return {"id": 1, "method": method, "params": p}
+
+
+def _write_script(tmp_path: Path, content: str, name: str = "script.py") -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestScriptHappyPaths:
+    def test_print_and_result(self, tmp_path: Path) -> None:
+        script = _write_script(tmp_path, 'print("hello")\nresult = 42')
+        resp, keep = _handle_request(_req("script", path=str(script)), _make_state())
+        assert keep is True
+        r = resp["result"]
+        assert r["stdout"] == "hello\n"
+        assert r["return_value"] == 42
+        assert r["elapsed_ms"] >= 0
+        assert r["stderr"] == ""
+
+    def test_stderr_capture(self, tmp_path: Path) -> None:
+        script = _write_script(tmp_path, 'import sys; sys.stderr.write("warn\\n")')
+        resp, _ = _handle_request(_req("script", path=str(script)), _make_state())
+        r = resp["result"]
+        assert r["stderr"] == "warn\n"
+        assert r["stdout"] == ""
+
+    def test_no_result_variable(self, tmp_path: Path) -> None:
+        script = _write_script(tmp_path, 'print("only stdout")')
+        resp, _ = _handle_request(_req("script", path=str(script)), _make_state())
+        assert resp["result"]["return_value"] is None
+
+    def test_non_serializable_result(self, tmp_path: Path) -> None:
+        script = _write_script(tmp_path, "result = object()")
+        resp, _ = _handle_request(_req("script", path=str(script)), _make_state())
+        rv = resp["result"]["return_value"]
+        assert isinstance(rv, str)
+        assert len(rv) > 0
+
+    def test_dict_list_result(self, tmp_path: Path) -> None:
+        script = _write_script(tmp_path, 'result = {"k": [1, 2]}')
+        resp, _ = _handle_request(_req("script", path=str(script)), _make_state())
+        assert resp["result"]["return_value"] == {"k": [1, 2]}
+
+    def test_empty_script(self, tmp_path: Path) -> None:
+        script = _write_script(tmp_path, "")
+        resp, _ = _handle_request(_req("script", path=str(script)), _make_state())
+        r = resp["result"]
+        assert r["stdout"] == ""
+        assert r["stderr"] == ""
+        assert r["return_value"] is None
+
+    def test_args_forwarded(self, tmp_path: Path) -> None:
+        script = _write_script(tmp_path, 'print(args["mode"])\nresult = args["mode"]')
+        resp, _ = _handle_request(
+            _req("script", path=str(script), args={"mode": "fast"}),
+            _make_state(),
+        )
+        assert resp["result"]["stdout"] == "fast\n"
+        assert resp["result"]["return_value"] == "fast"
+
+
+class TestScriptErrorPaths:
+    def test_no_replay_loaded(self, tmp_path: Path) -> None:
+        state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
+        script = _write_script(tmp_path, "result = 1")
+        resp, keep = _handle_request(_req("script", path=str(script)), state)
+        assert keep is True
+        assert resp["error"]["code"] == -32002
+        assert resp["error"]["message"] == "no replay loaded"
+
+    def test_file_not_found(self) -> None:
+        resp, keep = _handle_request(_req("script", path="/nonexistent/path.py"), _make_state())
+        assert keep is True
+        assert resp["error"]["code"] == -32002
+        assert "script not found" in resp["error"]["message"]
+
+    def test_path_is_directory(self, tmp_path: Path) -> None:
+        resp, keep = _handle_request(_req("script", path=str(tmp_path)), _make_state())
+        assert keep is True
+        assert resp["error"]["code"] == -32002
+        assert resp["error"]["message"] == "script path is a directory"
+
+    def test_syntax_error(self, tmp_path: Path) -> None:
+        script = _write_script(tmp_path, "def foo(:")
+        resp, keep = _handle_request(_req("script", path=str(script)), _make_state())
+        assert keep is True
+        assert resp["error"]["code"] == -32002
+        assert resp["error"]["message"].startswith("syntax error:")
+        assert "1" in resp["error"]["message"]
+
+    def test_runtime_error(self, tmp_path: Path) -> None:
+        script = _write_script(tmp_path, 'raise ValueError("bad input")')
+        resp, keep = _handle_request(_req("script", path=str(script)), _make_state())
+        assert keep is True
+        assert resp["error"]["code"] == -32002
+        assert "script error: ValueError: bad input" in resp["error"]["message"]
+
+    def test_system_exit(self, tmp_path: Path) -> None:
+        script = _write_script(tmp_path, "import sys; sys.exit(0)")
+        resp, keep = _handle_request(_req("script", path=str(script)), _make_state())
+        assert keep is True
+        assert resp["error"]["code"] == -32002
+        assert "script error: SystemExit: 0" in resp["error"]["message"]
+
+    def test_keyboard_interrupt(self, tmp_path: Path) -> None:
+        script = _write_script(tmp_path, "raise KeyboardInterrupt()")
+        resp, keep = _handle_request(_req("script", path=str(script)), _make_state())
+        assert keep is True
+        assert resp["error"]["code"] == -32002
+        assert "KeyboardInterrupt" in resp["error"]["message"]
+
+
+class TestScriptIsolation:
+    def test_stdout_restored(self, tmp_path: Path) -> None:
+        original_stdout = sys.stdout
+        script = _write_script(tmp_path, 'print("captured")')
+        _handle_request(_req("script", path=str(script)), _make_state())
+        assert sys.stdout is original_stdout
+
+    def test_stdout_restored_on_error(self, tmp_path: Path) -> None:
+        original_stdout = sys.stdout
+        script = _write_script(tmp_path, 'raise RuntimeError("boom")')
+        _handle_request(_req("script", path=str(script)), _make_state())
+        assert sys.stdout is original_stdout
+
+    def test_independent_globals(self, tmp_path: Path) -> None:
+        script1 = _write_script(tmp_path, "result = 111", "s1.py")
+        script2 = _write_script(tmp_path, "result = 222", "s2.py")
+        state = _make_state()
+        resp1, _ = _handle_request(_req("script", path=str(script1)), state)
+        resp2, _ = _handle_request(_req("script", path=str(script2)), state)
+        assert resp1["result"]["return_value"] == 111
+        assert resp2["result"]["return_value"] == 222


### PR DESCRIPTION
## Summary

- Add `rdc script <file.py>` command — executes Python scripts inside the daemon with access to `controller`, `rd`, `adapter`
- `exec()` with `BaseException` guard (catches `SystemExit`, `KeyboardInterrupt`)
- stdout/stderr captured via `contextlib.redirect_*` and returned in JSON-RPC response
- `result` variable extraction with JSON serialization fallback to `str()`
- `--arg KEY=VALUE` for passing arguments, `--json` for raw output

## Design

- Handler: `src/rdc/handlers/script.py` (38 lines, 100% coverage)
- CLI: `src/rdc/commands/script.py` (36 lines, 100% coverage)
- No VFS route (not a data node — justified in OpenSpec)
- All errors use `-32002` (deliberate simplification per spec)

## Test plan

- 17 handler unit tests (happy/error/isolation paths)
- 12 CLI unit tests (output format, --arg parsing, errors)
- 1 GPU integration test (GetResources probe script)
- 892 tests total, 93.53% coverage

## OpenSpec

`openspec/changes/2026-02-22-phase3a-script/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `script` CLI command to execute Python scripts inside the daemon process.
  * Scripts can access the RenderDoc live module and replay controller for automation and debugging.
  * Support for passing arguments to scripts via the `--arg KEY=VALUE` flag.
  * Optional JSON output format with `--json` flag for programmatic integration.
  * Captured stdout, stderr, execution time, and return values are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->