### PR TITLE
feat(image): add image comparison module and assert-image command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,12 @@ classifiers = [
 ]
 dependencies = [
   "click>=8.1",
+  "Pillow>=10.0",
+  "numpy>=1.24",
 ]
 
 [project.optional-dependencies]
 rich = ["rich>=13.0"]
-imaging = ["Pillow>=10.0"]
-diff = ["Pillow>=10.0", "numpy>=1.24"]
 dev = [
   "pytest>=8.0",
   "pytest-cov>=5.0",

--- a/src/rdc/cli.py
+++ b/src/rdc/cli.py
@@ -5,6 +5,7 @@ import os
 import click
 
 from rdc import __version__
+from rdc.commands.assert_image import assert_image_cmd
 from rdc.commands.capture import capture_cmd
 from rdc.commands.completion import completion_cmd
 from rdc.commands.counters import counters_cmd
@@ -90,6 +91,7 @@ main.add_command(counters_cmd, name="counters")
 main.add_command(script_cmd, name="script")
 main.add_command(pixel_cmd, name="pixel")
 main.add_command(diff_cmd, name="diff")
+main.add_command(assert_image_cmd, name="assert-image")
 
 
 if __name__ == "__main__":

--- a/src/rdc/commands/assert_image.py
+++ b/src/rdc/commands/assert_image.py
@@ -1,0 +1,66 @@
+"""rdc assert-image command -- pixel-level image comparison."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from rdc.image_compare import CompareResult, compare_images
+
+
+def _json_output(result: CompareResult, threshold: float) -> str:
+    """Format CompareResult as JSON string."""
+    return json.dumps(
+        {
+            "identical": result.identical,
+            "diff_pixels": result.diff_pixels,
+            "total_pixels": result.total_pixels,
+            "diff_ratio": result.diff_ratio,
+            "diff_image": str(result.diff_image) if result.diff_image else None,
+            "threshold": threshold,
+        }
+    )
+
+
+@click.command("assert-image")
+@click.argument("expected", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("actual", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--threshold", default=0.0, type=float, help="Diff ratio threshold (%).")
+@click.option(
+    "--diff-output",
+    default=None,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Write diff visualization PNG.",
+)
+@click.option("--json", "output_json", is_flag=True, help="JSON output.")
+def assert_image_cmd(
+    expected: Path,
+    actual: Path,
+    threshold: float,
+    diff_output: Path | None,
+    output_json: bool,
+) -> None:
+    """Compare two images pixel-by-pixel.
+
+    Exit 0 if images match (within threshold), exit 1 if they differ,
+    exit 2 on error (size mismatch, invalid image).
+    """
+    try:
+        result = compare_images(expected, actual, threshold=threshold, diff_output=diff_output)
+    except (ValueError, OSError) as exc:
+        click.echo(f"error: {exc}", err=True)
+        sys.exit(2)
+
+    if output_json:
+        click.echo(_json_output(result, threshold))
+    elif result.identical:
+        click.echo("match")
+    else:
+        click.echo(
+            f"diff: {result.diff_pixels}/{result.total_pixels} pixels ({result.diff_ratio:.2f}%)"
+        )
+
+    sys.exit(0 if result.identical else 1)

--- a/tests/unit/test_assert_image_command.py
+++ b/tests/unit/test_assert_image_command.py
@@ -1,0 +1,115 @@
+"""Tests for CLI assert-image command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+from PIL import Image
+
+from rdc.cli import main
+
+
+def _solid(
+    tmp_path: Path,
+    name: str,
+    color: tuple[int, ...],
+    size: tuple[int, int] = (4, 4),
+) -> Path:
+    """Create a solid-color image and return its path."""
+    p = tmp_path / name
+    Image.new("RGBA", size, color).save(p)
+    return p
+
+
+class TestAssertImageExitCodes:
+    def test_identical_exit_0(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (0, 0, 0, 255))
+        b = _solid(tmp_path, "b.png", (0, 0, 0, 255))
+        result = CliRunner().invoke(main, ["assert-image", str(a), str(b)])
+        assert result.exit_code == 0
+        assert "match" in result.output
+
+    def test_differs_exit_1(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (0, 0, 0, 255))
+        b = _solid(tmp_path, "b.png", (255, 255, 255, 255))
+        result = CliRunner().invoke(main, ["assert-image", str(a), str(b)])
+        assert result.exit_code == 1
+        assert "diff:" in result.output
+        assert "pixels" in result.output
+
+    def test_size_mismatch_exit_2(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (0, 0, 0, 255), size=(4, 4))
+        b = _solid(tmp_path, "b.png", (0, 0, 0, 255), size=(8, 8))
+        result = CliRunner().invoke(main, ["assert-image", str(a), str(b)])
+        assert result.exit_code == 2
+        assert "error: size mismatch" in result.output
+
+
+class TestAssertImageThreshold:
+    def test_threshold_allows_diff(self, tmp_path: Path) -> None:
+        img = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
+        a = tmp_path / "a.png"
+        img.save(a)
+        img.putpixel((0, 0), (255, 0, 0, 255))
+        b = tmp_path / "b.png"
+        img.save(b)
+        result = CliRunner().invoke(main, ["assert-image", "--threshold", "10.0", str(a), str(b)])
+        assert result.exit_code == 0
+
+    def test_threshold_rejects_diff(self, tmp_path: Path) -> None:
+        img = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
+        a = tmp_path / "a.png"
+        img.save(a)
+        img.putpixel((0, 0), (255, 0, 0, 255))
+        b = tmp_path / "b.png"
+        img.save(b)
+        result = CliRunner().invoke(main, ["assert-image", "--threshold", "5.0", str(a), str(b)])
+        assert result.exit_code == 1
+
+
+class TestAssertImageDiffOutput:
+    def test_diff_file_written(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (0, 0, 0, 255))
+        b = _solid(tmp_path, "b.png", (255, 255, 255, 255))
+        diff = tmp_path / "diff.png"
+        result = CliRunner().invoke(
+            main, ["assert-image", "--diff-output", str(diff), str(a), str(b)]
+        )
+        assert result.exit_code == 1
+        assert diff.exists()
+
+
+class TestAssertImageJson:
+    def test_json_identical(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (0, 0, 0, 255))
+        b = _solid(tmp_path, "b.png", (0, 0, 0, 255))
+        result = CliRunner().invoke(main, ["assert-image", "--json", str(a), str(b)])
+        assert result.exit_code == 0
+        data = json.loads(result.output.strip())
+        assert data["identical"] is True
+        assert data["diff_pixels"] == 0
+
+    def test_json_differs(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (0, 0, 0, 255))
+        b = _solid(tmp_path, "b.png", (255, 255, 255, 255))
+        result = CliRunner().invoke(main, ["assert-image", "--json", str(a), str(b)])
+        assert result.exit_code == 1
+        data = json.loads(result.output.strip())
+        assert data["identical"] is False
+        assert data["threshold"] == 0.0
+
+    def test_json_error_exit_2(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (0, 0, 0, 255), size=(4, 4))
+        b = _solid(tmp_path, "b.png", (0, 0, 0, 255), size=(8, 8))
+        result = CliRunner().invoke(main, ["assert-image", "--json", str(a), str(b)])
+        assert result.exit_code == 2
+        assert "error:" in result.output
+
+
+class TestAssertImageHelp:
+    def test_help_exits_0(self) -> None:
+        result = CliRunner().invoke(main, ["assert-image", "--help"])
+        assert result.exit_code == 0
+        assert "assert-image" in result.output

--- a/tests/unit/test_image_compare.py
+++ b/tests/unit/test_image_compare.py
@@ -1,0 +1,154 @@
+"""Tests for image_compare module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from rdc.image_compare import compare_images
+
+
+def _solid(
+    tmp_path: Path,
+    name: str,
+    color: tuple[int, ...],
+    size: tuple[int, int] = (4, 4),
+    mode: str = "RGBA",
+) -> Path:
+    """Create a solid-color image and return its path."""
+    p = tmp_path / name
+    Image.new(mode, size, color).save(p)
+    return p
+
+
+class TestIdenticalImages:
+    def test_identical_rgba(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (255, 0, 0, 255))
+        b = _solid(tmp_path, "b.png", (255, 0, 0, 255))
+        r = compare_images(a, b)
+        assert r.identical is True
+        assert r.diff_pixels == 0
+        assert r.diff_ratio == 0.0
+        assert r.diff_image is None
+
+
+class TestDifferentImages:
+    def test_one_pixel_differs(self, tmp_path: Path) -> None:
+        img = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
+        a = tmp_path / "a.png"
+        img.save(a)
+        img.putpixel((0, 0), (255, 0, 0, 255))
+        b = tmp_path / "b.png"
+        img.save(b)
+        r = compare_images(a, b)
+        assert r.diff_pixels == 1
+        assert r.identical is False
+
+    def test_all_pixels_differ(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (0, 0, 0, 255))
+        b = _solid(tmp_path, "b.png", (255, 255, 255, 255))
+        r = compare_images(a, b)
+        assert r.diff_pixels == 16
+        assert r.diff_ratio == 100.0
+
+
+class TestSizeMismatch:
+    def test_width_mismatch(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (0, 0, 0, 255), size=(4, 4))
+        b = _solid(tmp_path, "b.png", (0, 0, 0, 255), size=(8, 4))
+        with pytest.raises(ValueError, match="size mismatch"):
+            compare_images(a, b)
+
+    def test_height_mismatch(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (0, 0, 0, 255), size=(4, 4))
+        b = _solid(tmp_path, "b.png", (0, 0, 0, 255), size=(4, 8))
+        with pytest.raises(ValueError, match="size mismatch"):
+            compare_images(a, b)
+
+
+class TestThreshold:
+    def test_within_threshold(self, tmp_path: Path) -> None:
+        """1/16 pixels differ = 6.25%, threshold 10.0 -> identical."""
+        img = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
+        a = tmp_path / "a.png"
+        img.save(a)
+        img.putpixel((0, 0), (255, 0, 0, 255))
+        b = tmp_path / "b.png"
+        img.save(b)
+        r = compare_images(a, b, threshold=10.0)
+        assert r.identical is True
+
+    def test_at_boundary(self, tmp_path: Path) -> None:
+        """1/16 pixels differ = 6.25%, threshold 6.25 -> identical (inclusive)."""
+        img = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
+        a = tmp_path / "a.png"
+        img.save(a)
+        img.putpixel((0, 0), (255, 0, 0, 255))
+        b = tmp_path / "b.png"
+        img.save(b)
+        r = compare_images(a, b, threshold=6.25)
+        assert r.identical is True
+
+    def test_above_threshold(self, tmp_path: Path) -> None:
+        """1/16 pixels differ = 6.25%, threshold 5.0 -> not identical."""
+        img = Image.new("RGBA", (4, 4), (0, 0, 0, 255))
+        a = tmp_path / "a.png"
+        img.save(a)
+        img.putpixel((0, 0), (255, 0, 0, 255))
+        b = tmp_path / "b.png"
+        img.save(b)
+        r = compare_images(a, b, threshold=5.0)
+        assert r.identical is False
+
+
+class TestDiffOutput:
+    def test_diff_image_written(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (0, 0, 0, 255))
+        b = _solid(tmp_path, "b.png", (255, 255, 255, 255))
+        diff_path = tmp_path / "diff.png"
+        r = compare_images(a, b, diff_output=diff_path)
+        assert r.diff_image == diff_path
+        assert diff_path.exists()
+        diff_img = Image.open(diff_path)
+        assert diff_img.size == (4, 4)
+
+    def test_no_diff_when_identical(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (0, 0, 0, 255))
+        b = _solid(tmp_path, "b.png", (0, 0, 0, 255))
+        diff_path = tmp_path / "diff.png"
+        r = compare_images(a, b, diff_output=diff_path)
+        assert r.diff_image is None
+        assert not diff_path.exists()
+
+
+class TestModeNormalization:
+    def test_rgb_vs_rgba(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (255, 0, 0), mode="RGB")
+        b = _solid(tmp_path, "b.png", (255, 0, 0, 255), mode="RGBA")
+        r = compare_images(a, b)
+        assert r.diff_pixels == 0
+        assert r.identical is True
+
+    def test_grayscale_mode(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", 128, mode="L")
+        b = _solid(tmp_path, "b.png", (128, 128, 128, 255), mode="RGBA")
+        r = compare_images(a, b)
+        assert r.diff_pixels == 0
+
+
+class TestErrorPaths:
+    def test_file_not_found(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (0, 0, 0, 255))
+        with pytest.raises(FileNotFoundError):
+            compare_images(a, tmp_path / "missing.png")
+
+    def test_invalid_image(self, tmp_path: Path) -> None:
+        a = _solid(tmp_path, "a.png", (0, 0, 0, 255))
+        bad = tmp_path / "bad.png"
+        bad.write_text("not an image")
+        from PIL import UnidentifiedImageError
+
+        with pytest.raises(UnidentifiedImageError):
+            compare_images(a, bad)

--- a/uv.lock
+++ b/uv.lock
@@ -646,6 +646,9 @@ version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
 ]
 
 [package.optional-dependencies]
@@ -655,14 +658,6 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
-diff = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pillow" },
-]
-imaging = [
-    { name = "pillow" },
-]
 rich = [
     { name = "rich" },
 ]
@@ -671,15 +666,14 @@ rich = [
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
-    { name = "numpy", marker = "extra == 'diff'", specifier = ">=1.24" },
-    { name = "pillow", marker = "extra == 'diff'", specifier = ">=10.0" },
-    { name = "pillow", marker = "extra == 'imaging'", specifier = ">=10.0" },
+    { name = "numpy", specifier = ">=1.24" },
+    { name = "pillow", specifier = ">=10.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "rich", marker = "extra == 'rich'", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
 ]
-provides-extras = ["rich", "imaging", "diff", "dev"]
+provides-extras = ["rich", "dev"]
 
 [[package]]
 name = "rich"


### PR DESCRIPTION
## Summary

- Add `compare_images()` utility with `CompareResult` dataclass using Pillow + numpy
- Pixel-level RGBA comparison with configurable threshold (percentage)
- Red-on-grayscale diff image generation
- Add `rdc assert-image` CLI: exit 0 = match, 1 = differs, 2 = error
- Supports `--threshold`, `--diff-output`, `--json` flags
- Promote Pillow and numpy to core dependencies
- Foundation for `rdc diff --framebuffer` (Phase 3B) and CI assertions (Phase 3C)

## Test plan

- [x] 14 tests for compare_images (identical, diff, threshold, size mismatch, diff output, mode normalization)
- [x] 10 tests for assert-image CLI (exit codes, JSON output, threshold, error handling)
- [x] `pixi run lint && pixi run test` — 967 tests pass, 94% coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI command for pixel-level image comparison with threshold control.
  * Optional visual diff file generation and JSON-formatted result output.

* **Chores**
  * Image-processing libraries (Pillow, numpy) promoted to core dependencies.

* **Tests**
  * Added comprehensive unit and CLI tests covering identical/differing images, size-mismatch and error cases, threshold behavior, diff output generation, JSON output, and help text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->