### PR TITLE
fix(test): fix GPU integration test bugs from code review

### DIFF
--- a/tests/integration/test_daemon_handlers_real.py
+++ b/tests/integration/test_daemon_handlers_real.py
@@ -1381,7 +1381,12 @@ class TestDiffSessionExtendedReal:
             records_b = build_draw_records(resp_b["result"]["draws"])
             aligned = align_draws(records_a, records_b)
 
-            pair = next((a, b) for a, b in aligned if a is not None and b is not None)
+            pair = None
+            for a, b in aligned:
+                if a is not None and b is not None:
+                    pair = (a, b)
+                    break
+            assert pair is not None, "no aligned draw pairs found"
             rec_a, rec_b = pair
 
             calls_a = [(m, {"eid": rec_a.eid}) for m, _ in PIPE_SECTION_CALLS]
@@ -1398,8 +1403,14 @@ class TestDiffLibraryLevelReal:
     """GPU integration tests for diff library functions at the adapter level."""
 
     @pytest.fixture(autouse=True)
-    def _setup(self, vkcube_replay: tuple[Any, Any, Any], rd_module: Any) -> None:
+    def _setup(
+        self,
+        vkcube_replay: tuple[Any, Any, Any],
+        rd_module: Any,
+        tmp_path: Path,
+    ) -> None:
         self.state = _make_state(vkcube_replay, rd_module)
+        self.state.temp_dir = tmp_path
 
     def test_diff_stats_pass_names_nonempty(self) -> None:
         """Stats per_pass entries all have non-empty pass names."""


### PR DESCRIPTION
## Summary
- Fix `TestDiffLibraryLevelReal` missing `tmp_path` injection — `rt_export` test would fail with "temp directory not available" on real GPU runs
- Replace `next()` generator with explicit loop + `assert` in `test_diff_pipeline_session_field_count` for clearer failure messages

## Context
Code review of PR #55 (GPU integration tests) found 1 CRITICAL and 1 IMPORTANT issue. This PR fixes both.

## Test plan
- [x] `pixi run lint` clean
- [x] `pixi run test` — 1219 passed, 94.84% coverage
- [ ] `pixi run test-gpu` — manual verification on real GPU