### PR TITLE
feat(assert): add CI assertion commands

### DIFF
--- a/src/rdc/cli.py
+++ b/src/rdc/cli.py
@@ -5,6 +5,12 @@ import os
 import click
 
 from rdc import __version__
+from rdc.commands.assert_ci import (
+    assert_clean_cmd,
+    assert_count_cmd,
+    assert_pixel_cmd,
+    assert_state_cmd,
+)
 from rdc.commands.assert_image import assert_image_cmd
 from rdc.commands.capture import capture_cmd
 from rdc.commands.completion import completion_cmd
@@ -92,6 +98,10 @@ main.add_command(script_cmd, name="script")
 main.add_command(pixel_cmd, name="pixel")
 main.add_command(diff_cmd, name="diff")
 main.add_command(assert_image_cmd, name="assert-image")
+main.add_command(assert_pixel_cmd, name="assert-pixel")
+main.add_command(assert_clean_cmd, name="assert-clean")
+main.add_command(assert_count_cmd, name="assert-count")
+main.add_command(assert_state_cmd, name="assert-state")
 
 
 if __name__ == "__main__":

--- a/src/rdc/commands/assert_ci.py
+++ b/src/rdc/commands/assert_ci.py
@@ -1,0 +1,313 @@
+"""CI assertion commands: assert-pixel, assert-clean, assert-count, assert-state."""
+
+from __future__ import annotations
+
+import json
+import operator
+import sys
+from typing import Any
+
+import click
+
+from rdc.commands.unix_helpers import _COUNT_TARGETS
+from rdc.daemon_client import send_request
+from rdc.protocol import _request
+from rdc.session_state import load_session
+
+_SEVERITY_RANK: dict[str, int] = {"HIGH": 0, "MEDIUM": 1, "LOW": 2, "INFO": 3, "UNKNOWN": 4}
+
+_OPS: dict[str, Any] = {
+    "eq": operator.eq,
+    "gt": operator.gt,
+    "lt": operator.lt,
+    "ge": operator.ge,
+    "le": operator.le,
+}
+
+_VALID_SECTIONS: frozenset[str] = frozenset(
+    {
+        "topology",
+        "viewport",
+        "scissor",
+        "blend",
+        "stencil",
+        "rasterizer",
+        "depth-stencil",
+        "msaa",
+        "vbuffers",
+        "ibuffer",
+        "samplers",
+        "push-constants",
+        "vinputs",
+        "vs",
+        "hs",
+        "ds",
+        "gs",
+        "ps",
+        "cs",
+    }
+)
+
+_HYPHENATED_SECTIONS: frozenset[str] = frozenset({"depth-stencil", "push-constants"})
+
+
+def _assert_call(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    """JSON-RPC call with exit(2) on any error."""
+    session = load_session()
+    if session is None:
+        click.echo("error: no active session", err=True)
+        sys.exit(2)
+    payload = _request(method, 1, {"_token": session.token, **(params or {})}).to_dict()
+    try:
+        resp = send_request(session.host, session.port, payload)
+    except Exception as exc:
+        click.echo(f"error: daemon unreachable: {exc}", err=True)
+        sys.exit(2)
+    if "error" in resp:
+        click.echo(f"error: {resp['error']['message']}", err=True)
+        sys.exit(2)
+    return resp["result"]  # type: ignore[no-any-return]
+
+
+def _parse_key_path(key_path: str) -> tuple[str, list[str]]:
+    """Split key-path into (section, field_path) handling hyphenated sections."""
+    for hs in _HYPHENATED_SECTIONS:
+        if key_path == hs or key_path.startswith(hs + "."):
+            rest = key_path[len(hs) + 1 :] if len(key_path) > len(hs) else ""
+            return hs, rest.split(".") if rest else []
+    parts = key_path.split(".")
+    return parts[0], parts[1:]
+
+
+def _traverse_path(data: Any, path: list[str]) -> Any:
+    """Walk nested dict/list by path segments; exit(2) on invalid path."""
+    for seg in path:
+        if isinstance(data, list):
+            try:
+                data = data[int(seg)]
+            except (ValueError, IndexError):
+                click.echo(f"error: invalid path segment '{seg}'", err=True)
+                sys.exit(2)
+        elif isinstance(data, dict):
+            if seg not in data:
+                click.echo(f"error: key '{seg}' not found", err=True)
+                sys.exit(2)
+            data = data[seg]
+        else:
+            click.echo(f"error: cannot traverse into {type(data).__name__}", err=True)
+            sys.exit(2)
+    return data
+
+
+def _normalize_value(v: Any) -> str:
+    """Normalize a value to string for comparison; booleans lowercased."""
+    if isinstance(v, bool):
+        return str(v).lower()
+    return str(v)
+
+
+# ---------------------------------------------------------------------------
+# assert-pixel
+# ---------------------------------------------------------------------------
+
+
+@click.command("assert-pixel")
+@click.argument("eid", type=int)
+@click.argument("x", type=int)
+@click.argument("y", type=int)
+@click.option("--expect", required=True, help="Expected RGBA as 4 space-separated floats.")
+@click.option("--tolerance", default=0.01, type=float, help="Per-channel tolerance.")
+@click.option("--target", default=0, type=int, help="Render target index.")
+@click.option("--json", "output_json", is_flag=True, help="JSON output.")
+def assert_pixel_cmd(
+    eid: int, x: int, y: int, expect: str, tolerance: float, target: int, output_json: bool
+) -> None:
+    """Assert pixel RGBA at (x, y) matches expected value within tolerance."""
+    parts = expect.split()
+    if len(parts) != 4:
+        click.echo("error: --expect must have exactly 4 floats (R G B A)", err=True)
+        sys.exit(2)
+    try:
+        expected = [float(v) for v in parts]
+    except ValueError:
+        click.echo("error: --expect values must be numeric", err=True)
+        sys.exit(2)
+
+    result = _assert_call("pixel_history", {"eid": eid, "x": x, "y": y, "target": target})
+    mods = result.get("modifications", [])
+    passing = [m for m in mods if m.get("passed")]
+    if not passing:
+        click.echo("error: no passing modification found", err=True)
+        sys.exit(2)
+
+    last = passing[-1]
+    pm = last["post_mod"]
+    actual = [pm["r"], pm["g"], pm["b"], pm["a"]]
+
+    passed = all(round(abs(a - e), 10) <= tolerance for a, e in zip(actual, expected, strict=True))
+
+    if output_json:
+        click.echo(
+            json.dumps(
+                {
+                    "pass": passed,
+                    "expected": expected,
+                    "actual": actual,
+                    "tolerance": tolerance,
+                    "eid": eid,
+                    "x": x,
+                    "y": y,
+                }
+            )
+        )
+    elif passed:
+        fmt = " ".join(f"{v:.4f}" for v in actual)
+        click.echo(f"pass: pixel ({x}, {y}) = {fmt}")
+    else:
+        efmt = " ".join(f"{v:.4f}" for v in expected)
+        afmt = " ".join(f"{v:.4f}" for v in actual)
+        click.echo(f"fail: pixel ({x}, {y}) expected {efmt}, got {afmt}")
+
+    sys.exit(0 if passed else 1)
+
+
+# ---------------------------------------------------------------------------
+# assert-clean
+# ---------------------------------------------------------------------------
+
+
+@click.command("assert-clean")
+@click.option(
+    "--min-severity",
+    default="HIGH",
+    type=click.Choice(["HIGH", "MEDIUM", "LOW", "INFO"], case_sensitive=False),
+    help="Minimum severity threshold.",
+)
+@click.option("--json", "output_json", is_flag=True, help="JSON output.")
+def assert_clean_cmd(min_severity: str, output_json: bool) -> None:
+    """Assert capture log has no messages at or above given severity."""
+    min_severity = min_severity.upper()
+    result = _assert_call("log")
+    messages = result.get("messages", [])
+    threshold = _SEVERITY_RANK[min_severity]
+    violations = [
+        m for m in messages if _SEVERITY_RANK.get(m.get("level", "UNKNOWN"), 4) <= threshold
+    ]
+
+    passed = len(violations) == 0
+
+    if output_json:
+        click.echo(
+            json.dumps(
+                {
+                    "pass": passed,
+                    "min_severity": min_severity,
+                    "count": len(violations),
+                    "messages": violations,
+                }
+            )
+        )
+    elif passed:
+        click.echo(f"pass: no messages at severity >= {min_severity}")
+    else:
+        click.echo(f"fail: {len(violations)} message(s) at severity >= {min_severity}")
+        for m in violations:
+            click.echo(f"  [{m.get('level')}] eid={m.get('eid')}: {m.get('message')}", err=True)
+
+    sys.exit(0 if passed else 1)
+
+
+# ---------------------------------------------------------------------------
+# assert-count
+# ---------------------------------------------------------------------------
+
+
+@click.command("assert-count")
+@click.argument("what", type=click.Choice(_COUNT_TARGETS, case_sensitive=False))
+@click.option("--expect", required=True, type=int, help="Expected count value.")
+@click.option(
+    "--op",
+    default="eq",
+    type=click.Choice(["eq", "gt", "lt", "ge", "le"]),
+    help="Comparison operator.",
+)
+@click.option("--pass", "pass_name", default=None, help="Filter by render pass name.")
+@click.option("--json", "output_json", is_flag=True, help="JSON output.")
+def assert_count_cmd(
+    what: str,
+    expect: int,
+    op: str,
+    pass_name: str | None,
+    output_json: bool,
+) -> None:
+    """Assert a capture metric satisfies a numeric comparison."""
+    params: dict[str, Any] = {"what": what}
+    if pass_name is not None:
+        params["pass"] = pass_name
+
+    result = _assert_call("count", params)
+    actual: int = result["value"]
+    passed = _OPS[op](actual, expect)
+
+    if output_json:
+        click.echo(
+            json.dumps(
+                {
+                    "pass": passed,
+                    "what": what,
+                    "actual": actual,
+                    "expected": expect,
+                    "op": op,
+                }
+            )
+        )
+    elif passed:
+        click.echo(f"pass: {what} = {actual} (expected {op} {expect})")
+    else:
+        click.echo(f"fail: {what} = {actual} (expected {op} {expect})")
+
+    sys.exit(0 if passed else 1)
+
+
+# ---------------------------------------------------------------------------
+# assert-state
+# ---------------------------------------------------------------------------
+
+
+@click.command("assert-state")
+@click.argument("eid", type=int)
+@click.argument("key_path", metavar="KEY_PATH")
+@click.option("--expect", required=True, help="Expected value.")
+@click.option("--json", "output_json", is_flag=True, help="JSON output.")
+def assert_state_cmd(eid: int, key_path: str, expect: str, output_json: bool) -> None:
+    """Assert pipeline state value at EID matches expected."""
+    section, field_path = _parse_key_path(key_path)
+    if section not in _VALID_SECTIONS:
+        click.echo(f"error: invalid section '{section}'", err=True)
+        sys.exit(2)
+
+    result = _assert_call("pipeline", {"eid": eid, "section": section})
+    actual_raw = _traverse_path(result, field_path)
+    actual_str = _normalize_value(actual_raw)
+    expect_str = expect.lower() if expect.lower() in ("true", "false") else expect
+
+    passed = actual_str == expect_str
+
+    if output_json:
+        click.echo(
+            json.dumps(
+                {
+                    "pass": passed,
+                    "eid": eid,
+                    "key_path": key_path,
+                    "expected": expect_str,
+                    "actual": actual_str,
+                }
+            )
+        )
+    elif passed:
+        click.echo(f"pass: {key_path} = {actual_str}")
+    else:
+        click.echo(f"fail: {key_path} = {actual_str} (expected {expect_str})")
+
+    sys.exit(0 if passed else 1)

--- a/tests/unit/test_assert_ci_commands.py
+++ b/tests/unit/test_assert_ci_commands.py
@@ -1,0 +1,552 @@
+"""Tests for CI assertion commands."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from rdc.cli import main
+from rdc.commands import assert_ci as mod
+
+# ---------------------------------------------------------------------------
+# _assert_call helper tests
+# ---------------------------------------------------------------------------
+
+_ERR_RESP: dict[str, Any] = {
+    "error": {"message": "no capture loaded"},
+}
+
+
+def test_assert_call_no_session(monkeypatch: Any) -> None:
+    monkeypatch.setattr(mod, "load_session", lambda: None)
+    with pytest.raises(SystemExit, match="2"):
+        mod._assert_call("count")
+
+
+def test_assert_call_rpc_error(monkeypatch: Any) -> None:
+    session = MagicMock(host="localhost", port=9876, token="tok")
+    monkeypatch.setattr(mod, "load_session", lambda: session)
+    monkeypatch.setattr(
+        mod,
+        "send_request",
+        lambda *a, **kw: _ERR_RESP,
+    )
+    with pytest.raises(SystemExit, match="2"):
+        mod._assert_call("count")
+
+
+def test_assert_call_success(monkeypatch: Any) -> None:
+    session = MagicMock(host="localhost", port=9876, token="tok")
+    monkeypatch.setattr(mod, "load_session", lambda: session)
+    monkeypatch.setattr(
+        mod,
+        "send_request",
+        lambda *a, **kw: {"result": {"value": 42}},
+    )
+    assert mod._assert_call("count") == {"value": 42}
+
+
+# ---------------------------------------------------------------------------
+# Shared test helpers
+# ---------------------------------------------------------------------------
+
+_captured: dict[str, Any] = {}
+
+
+def _patch(monkeypatch: Any, response: dict[str, Any]) -> None:
+    def fake(
+        method: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        _captured.clear()
+        _captured["method"] = method
+        _captured["params"] = params
+        return response
+
+    monkeypatch.setattr(mod, "_assert_call", fake)
+
+
+def _run(*args: str) -> Any:
+    return CliRunner().invoke(main, list(args))
+
+
+# ---------------------------------------------------------------------------
+# assert-pixel
+# ---------------------------------------------------------------------------
+
+_EXPECT = "0.5 0.3 0.1 1.0"
+_PX = ["assert-pixel", "88", "512", "384"]
+
+
+def _pixel_resp(
+    mods: list[tuple[int, bool, dict[str, float]]],
+) -> dict[str, Any]:
+    return {
+        "modifications": [
+            {"eid": eid, "passed": passed, "post_mod": pm} for eid, passed, pm in mods
+        ],
+    }
+
+
+_RGBA_A = {"r": 0.5, "g": 0.3, "b": 0.1, "a": 1.0}
+_RGBA_B = {"r": 0.8, "g": 0.6, "b": 0.4, "a": 1.0}
+
+
+def test_assert_pixel_exact_match(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _pixel_resp([(88, True, _RGBA_A)]))
+    r = _run(*_PX, "--expect", _EXPECT, "--tolerance", "0")
+    assert r.exit_code == 0
+    assert r.output.startswith("pass:")
+
+
+def test_assert_pixel_within_tolerance(monkeypatch: Any) -> None:
+    pm = {"r": 0.505, "g": 0.305, "b": 0.105, "a": 1.005}
+    _patch(monkeypatch, _pixel_resp([(88, True, pm)]))
+    r = _run(*_PX, "--expect", _EXPECT, "--tolerance", "0.01")
+    assert r.exit_code == 0
+
+
+def test_assert_pixel_outside_tolerance(monkeypatch: Any) -> None:
+    pm = {"r": 0.52, "g": 0.3, "b": 0.1, "a": 1.0}
+    _patch(monkeypatch, _pixel_resp([(88, True, pm)]))
+    r = _run(*_PX, "--expect", _EXPECT, "--tolerance", "0.01")
+    assert r.exit_code == 1
+    assert r.output.startswith("fail:")
+
+
+def test_assert_pixel_tolerance_boundary(monkeypatch: Any) -> None:
+    pm = {"r": 0.51, "g": 0.3, "b": 0.1, "a": 1.0}
+    _patch(monkeypatch, _pixel_resp([(88, True, pm)]))
+    r = _run(*_PX, "--expect", _EXPECT, "--tolerance", "0.01")
+    assert r.exit_code == 0
+
+
+def test_assert_pixel_no_passing_mod(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _pixel_resp([(88, False, _RGBA_A)]))
+    r = _run(*_PX, "--expect", _EXPECT)
+    assert r.exit_code == 2
+    assert "no passing modification" in r.output
+
+
+def test_assert_pixel_empty_modifications(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"modifications": []})
+    r = _run(*_PX, "--expect", _EXPECT)
+    assert r.exit_code == 2
+    assert "no passing modification" in r.output
+
+
+def test_assert_pixel_last_passing_used(monkeypatch: Any) -> None:
+    _patch(
+        monkeypatch,
+        _pixel_resp(
+            [
+                (80, True, _RGBA_A),
+                (90, False, _RGBA_A),
+                (100, True, _RGBA_B),
+            ]
+        ),
+    )
+    r = _run(
+        "assert-pixel",
+        "100",
+        "512",
+        "384",
+        "--expect",
+        "0.8 0.6 0.4 1.0",
+        "--tolerance",
+        "0",
+    )
+    assert r.exit_code == 0
+
+
+def test_assert_pixel_json_pass(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _pixel_resp([(88, True, _RGBA_A)]))
+    r = _run(*_PX, "--expect", _EXPECT, "--tolerance", "0", "--json")
+    assert r.exit_code == 0
+    data = json.loads(r.output)
+    assert data["pass"] is True
+    assert "expected" in data
+    assert "actual" in data
+    assert "tolerance" in data
+
+
+def test_assert_pixel_json_fail(monkeypatch: Any) -> None:
+    pm = {"r": 0.9, "g": 0.3, "b": 0.1, "a": 1.0}
+    _patch(monkeypatch, _pixel_resp([(88, True, pm)]))
+    r = _run(
+        *_PX,
+        "--expect",
+        _EXPECT,
+        "--tolerance",
+        "0",
+        "--json",
+    )
+    assert r.exit_code == 1
+    data = json.loads(r.output)
+    assert data["pass"] is False
+
+
+def test_assert_pixel_target_forwarded(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _pixel_resp([(88, True, _RGBA_A)]))
+    _run(*_PX, "--expect", _EXPECT, "--target", "1")
+    assert _captured["params"]["target"] == 1
+
+
+def test_assert_pixel_bad_expect_nonnumeric(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _pixel_resp([(88, True, _RGBA_A)]))
+    r = _run(*_PX, "--expect", "red green blue alpha")
+    assert r.exit_code == 2
+    assert "numeric" in r.output
+
+
+# ---------------------------------------------------------------------------
+# assert-clean
+# ---------------------------------------------------------------------------
+
+
+def test_assert_clean_no_messages(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"messages": []})
+    r = _run("assert-clean")
+    assert r.exit_code == 0
+    assert r.output.startswith("pass:")
+
+
+def test_assert_clean_below_threshold(monkeypatch: Any) -> None:
+    _patch(
+        monkeypatch,
+        {
+            "messages": [
+                {"level": "INFO", "eid": 1, "message": "info msg"},
+                {"level": "INFO", "eid": 2, "message": "info msg 2"},
+            ]
+        },
+    )
+    r = _run("assert-clean", "--min-severity", "HIGH")
+    assert r.exit_code == 0
+
+
+def test_assert_clean_at_threshold(monkeypatch: Any) -> None:
+    _patch(
+        monkeypatch,
+        {
+            "messages": [
+                {"level": "HIGH", "eid": 1, "message": "high msg"},
+            ]
+        },
+    )
+    r = _run("assert-clean", "--min-severity", "HIGH")
+    assert r.exit_code == 1
+    assert r.output.startswith("fail:")
+
+
+def test_assert_clean_above_threshold(monkeypatch: Any) -> None:
+    _patch(
+        monkeypatch,
+        {
+            "messages": [
+                {"level": "HIGH", "eid": 1, "message": "high msg"},
+            ]
+        },
+    )
+    r = _run("assert-clean", "--min-severity", "MEDIUM")
+    assert r.exit_code == 1
+
+
+def test_assert_clean_mixed_severities(monkeypatch: Any) -> None:
+    _patch(
+        monkeypatch,
+        {
+            "messages": [
+                {"level": "HIGH", "eid": 1, "message": "high msg"},
+                {"level": "INFO", "eid": 2, "message": "info msg"},
+            ]
+        },
+    )
+    r = _run("assert-clean", "--min-severity", "MEDIUM")
+    assert r.exit_code == 1
+    assert "1 message(s)" in r.output
+
+
+def test_assert_clean_default_severity_high(monkeypatch: Any) -> None:
+    _patch(
+        monkeypatch,
+        {
+            "messages": [
+                {"level": "INFO", "eid": 1, "message": "info msg"},
+            ]
+        },
+    )
+    r = _run("assert-clean")
+    assert r.exit_code == 0
+
+
+def test_assert_clean_json_pass(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"messages": []})
+    r = _run("assert-clean", "--json")
+    assert r.exit_code == 0
+    data = json.loads(r.output)
+    assert data["pass"] is True
+    assert data["count"] == 0
+    assert data["messages"] == []
+
+
+def test_assert_clean_json_fail(monkeypatch: Any) -> None:
+    _patch(
+        monkeypatch,
+        {
+            "messages": [
+                {"level": "HIGH", "eid": 1, "message": "msg1"},
+                {"level": "HIGH", "eid": 2, "message": "msg2"},
+            ]
+        },
+    )
+    r = _run("assert-clean", "--json")
+    assert r.exit_code == 1
+    data = json.loads(r.output)
+    assert data["pass"] is False
+    assert data["count"] == 2
+    assert len(data["messages"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# assert-count
+# ---------------------------------------------------------------------------
+
+
+def test_assert_count_eq_pass(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"value": 42})
+    r = _run("assert-count", "draws", "--expect", "42", "--op", "eq")
+    assert r.exit_code == 0
+
+
+def test_assert_count_eq_fail(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"value": 42})
+    r = _run("assert-count", "draws", "--expect", "43", "--op", "eq")
+    assert r.exit_code == 1
+
+
+def test_assert_count_gt_pass(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"value": 10})
+    r = _run("assert-count", "draws", "--expect", "5", "--op", "gt")
+    assert r.exit_code == 0
+
+
+def test_assert_count_gt_fail_boundary(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"value": 5})
+    r = _run("assert-count", "draws", "--expect", "5", "--op", "gt")
+    assert r.exit_code == 1
+
+
+def test_assert_count_lt_pass(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"value": 3})
+    r = _run("assert-count", "draws", "--expect", "5", "--op", "lt")
+    assert r.exit_code == 0
+
+
+def test_assert_count_ge_pass_boundary(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"value": 5})
+    r = _run("assert-count", "draws", "--expect", "5", "--op", "ge")
+    assert r.exit_code == 0
+
+
+def test_assert_count_le_fail(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"value": 6})
+    r = _run("assert-count", "draws", "--expect", "5", "--op", "le")
+    assert r.exit_code == 1
+
+
+def test_assert_count_default_op_eq(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"value": 42})
+    r = _run("assert-count", "draws", "--expect", "42")
+    assert r.exit_code == 0
+
+
+def test_assert_count_pass_forwarded(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"value": 42})
+    _run(
+        "assert-count",
+        "draws",
+        "--expect",
+        "42",
+        "--pass",
+        "GBuffer",
+    )
+    assert _captured["params"]["pass"] == "GBuffer"
+
+
+def test_assert_count_json(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"value": 42})
+    r = _run("assert-count", "draws", "--expect", "42", "--json")
+    assert r.exit_code == 0
+    data = json.loads(r.output)
+    assert data["pass"] is True
+    assert data["what"] == "draws"
+    assert data["actual"] == 42
+    assert data["expected"] == 42
+    assert data["op"] == "eq"
+
+
+# ---------------------------------------------------------------------------
+# assert-state
+# ---------------------------------------------------------------------------
+
+_ST = ["assert-state", "120"]
+
+
+def test_assert_state_simple_match(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"topology": "TriangleList"})
+    r = _run(
+        *_ST,
+        "topology.topology",
+        "--expect",
+        "TriangleList",
+    )
+    assert r.exit_code == 0
+
+
+def test_assert_state_simple_mismatch(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"topology": "TriangleList"})
+    r = _run(*_ST, "topology.topology", "--expect", "LineList")
+    assert r.exit_code == 1
+
+
+def test_assert_state_nested_path(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"blends": [{"enabled": True}]})
+    r = _run(
+        *_ST,
+        "blend.blends.0.enabled",
+        "--expect",
+        "true",
+    )
+    assert r.exit_code == 0
+
+
+def test_assert_state_array_index(monkeypatch: Any) -> None:
+    _patch(
+        monkeypatch,
+        {
+            "blends": [
+                {"colorBlend": {"source": "One"}},
+                {"colorBlend": {"source": "Zero"}},
+            ],
+        },
+    )
+    r = _run(
+        *_ST,
+        "blend.blends.1.colorBlend.source",
+        "--expect",
+        "Zero",
+    )
+    assert r.exit_code == 0
+
+
+def test_assert_state_bool_case_insensitive(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"blends": [{"enabled": True}]})
+    for val in ["True", "true", "TRUE"]:
+        r = _run(
+            *_ST,
+            "blend.blends.0.enabled",
+            "--expect",
+            val,
+        )
+        assert r.exit_code == 0, f"Failed for --expect {val}"
+
+
+def test_assert_state_numeric_value(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"width": 1920})
+    r = _run(*_ST, "viewport.width", "--expect", "1920")
+    assert r.exit_code == 0
+
+
+def test_assert_state_invalid_section(monkeypatch: Any) -> None:
+    r = _run(*_ST, "nosuch.field", "--expect", "x")
+    assert r.exit_code == 2
+    assert "invalid section" in r.output
+
+
+def test_assert_state_key_not_found(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"blends": [{"enabled": True}]})
+    r = _run(*_ST, "blend.nosuchkey", "--expect", "x")
+    assert r.exit_code == 2
+    assert "not found" in r.output
+
+
+def test_assert_state_index_out_of_range(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"blends": [{"enabled": True}]})
+    r = _run(
+        *_ST,
+        "blend.blends.99.enabled",
+        "--expect",
+        "true",
+    )
+    assert r.exit_code == 2
+
+
+def test_assert_state_hyphenated_section(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"depthEnable": True})
+    r = _run(
+        *_ST,
+        "depth-stencil.depthEnable",
+        "--expect",
+        "true",
+    )
+    assert r.exit_code == 0
+    assert _captured["params"]["section"] == "depth-stencil"
+
+
+def test_assert_state_json_pass(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"topology": "TriangleList"})
+    r = _run(
+        *_ST,
+        "topology.topology",
+        "--expect",
+        "TriangleList",
+        "--json",
+    )
+    assert r.exit_code == 0
+    data = json.loads(r.output)
+    assert data["pass"] is True
+    assert data["key_path"] == "topology.topology"
+    assert data["eid"] == 120
+
+
+def test_assert_state_json_fail(monkeypatch: Any) -> None:
+    _patch(monkeypatch, {"topology": "TriangleList"})
+    r = _run(
+        *_ST,
+        "topology.topology",
+        "--expect",
+        "LineList",
+        "--json",
+    )
+    assert r.exit_code == 1
+    data = json.loads(r.output)
+    assert data["pass"] is False
+
+
+# ---------------------------------------------------------------------------
+# CLI registration
+# ---------------------------------------------------------------------------
+
+_ASSERT_CMDS = [
+    "assert-pixel",
+    "assert-clean",
+    "assert-count",
+    "assert-state",
+]
+
+
+def test_assert_commands_in_help() -> None:
+    r = _run("--help")
+    for cmd in _ASSERT_CMDS:
+        assert cmd in r.output, f"{cmd} not in --help"
+
+
+def test_assert_commands_help_exits_0() -> None:
+    for cmd in _ASSERT_CMDS:
+        r = _run(cmd, "--help")
+        assert r.exit_code == 0, f"{cmd} --help failed"


### PR DESCRIPTION
## Summary

- Add 4 CI assertion commands: `assert-pixel`, `assert-clean`, `assert-count`, `assert-state`
- All compose existing daemon JSON-RPC methods -- no new handlers
- Exit codes: 0=pass, 1=fail, 2=error (matching `assert-image` convention)
- Shared `_assert_call` helper with exit(2) semantics for errors
- `--json` flag on all commands for machine-readable output

## New files
- `src/rdc/commands/assert_ci.py` -- 4 commands + helpers (~150 LOC)
- `tests/unit/test_assert_ci_commands.py` -- 46 unit tests

## Test plan
- 1265 tests passing, 94.86% coverage
- Lint + typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new assertion commands for continuous integration: assert-pixel for color verification, assert-clean for log severity checks, assert-count for metric comparison, and assert-state for pipeline state validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->