### PR TITLE
feat(mesh): add mesh export command with OBJ output

### DIFF
--- a/openspec/changes/2026-02-22-phase4c-mesh-export/proposal.md
+++ b/openspec/changes/2026-02-22-phase4c-mesh-export/proposal.md
@@ -1,0 +1,58 @@
+# Phase 4C-1: Mesh Export — Proposal
+
+## Summary
+
+Add `mesh_data` daemon method and `rdc mesh` CLI command to export post-transform vertex data as OBJ format.
+
+## Motivation
+
+The existing `postvs` handler returns only metadata (resourceId, stride, numIndices, topology). Exporting mesh geometry for debugging requires decoded vertex positions from `GetBufferData()` + struct unpacking — daemon-side work since it needs the controller.
+
+## Scope
+
+- 1 new daemon method: `mesh_data`
+- 1 new CLI command: `rdc mesh [EID] [--stage vs-out|gs-out] [-o FILE] [--json] [--no-header]`
+
+## Design
+
+### Daemon Handler: `_handle_mesh_data`
+
+Location: `src/rdc/handlers/buffer.py`
+
+Params: `{eid?, stage?}` — stage defaults to `"vs-out"`
+
+Logic:
+1. Map stage string to MeshDataStage enum value (`vs-out`→1, `gs-out`→2)
+2. `GetPostVSData(0, 0, stage_val)` → MeshFormat
+3. Read vertex buffer via `GetBufferData(mesh.vertexResourceId, offset, size)`
+4. Decode float32 vertices using stride + format info
+5. Read index buffer if `indexResourceId != 0`
+6. Return structured JSON with vertices, indices, topology
+
+Response shape:
+```json
+{
+  "eid": 142, "stage": "vs-out", "topology": "TriangleList",
+  "vertex_count": 36, "comp_count": 4, "stride": 16,
+  "vertices": [[x,y,z,w], ...],
+  "index_count": 0, "indices": []
+}
+```
+
+### CLI Command: `rdc mesh`
+
+Location: `src/rdc/commands/mesh.py` (new file)
+
+Default output: OBJ format (v lines + f lines). Uses first 3 components for vertex positions. No perspective divide by default (preserves clip-space data).
+
+Face generation by topology:
+- TriangleList: sequential triples
+- TriangleStrip: alternating winding
+- TriangleFan: pivot on vertex 0
+- PointList/LineList: no faces
+
+## Non-Goals
+
+- `vs-in` stage (already available via `vbuffer_decode`)
+- Normal/UV extraction (future enhancement)
+- Perspective divide (users post-process if needed)

--- a/openspec/changes/2026-02-22-phase4c-mesh-export/tasks.md
+++ b/openspec/changes/2026-02-22-phase4c-mesh-export/tasks.md
@@ -1,0 +1,28 @@
+# Phase 4C-1: Mesh Export — Tasks
+
+## Implementation
+
+- [x] T1: Create openspec
+- [ ] T2: Update mock — enhance GetPostVSData, add MeshDataStage, wire GetBufferData
+- [ ] T3: Implement `_handle_mesh_data` in `buffer.py`, register in HANDLERS
+- [ ] T4: Implement `mesh_cmd` in new `src/rdc/commands/mesh.py` with OBJ formatter
+- [ ] T5: Register `mesh_cmd` in `cli.py`
+- [ ] T6: Write handler unit tests (`test_mesh_handler.py`)
+- [ ] T7: Write CLI unit tests (`test_mesh_commands.py`)
+- [ ] T8: Add GPU integration tests
+- [ ] T9: `pixi run lint && pixi run test` — zero failures
+- [ ] T10: Code review
+- [ ] T11: Commit + Push + PR
+
+## Files
+
+### New
+- `src/rdc/commands/mesh.py`
+- `tests/unit/test_mesh_handler.py`
+- `tests/unit/test_mesh_commands.py`
+
+### Modified
+- `src/rdc/handlers/buffer.py` — add handler + HANDLERS entry
+- `src/rdc/cli.py` — register mesh_cmd
+- `tests/mocks/mock_renderdoc.py` — GetPostVSData enhancement
+- `tests/integration/test_daemon_handlers_real.py` — GPU tests

--- a/openspec/changes/2026-02-22-phase4c-mesh-export/test-plan.md
+++ b/openspec/changes/2026-02-22-phase4c-mesh-export/test-plan.md
@@ -1,0 +1,39 @@
+# Phase 4C-1: Mesh Export — Test Plan
+
+## Handler Tests (`tests/unit/test_mesh_handler.py`)
+
+| # | Test | Assertion |
+|---|------|-----------|
+| 1 | `test_mesh_data_triangle_list` | 3 vertices decoded, topology=TriangleList |
+| 2 | `test_mesh_data_indexed` | index buffer decoded, indices=[0,2,1] |
+| 3 | `test_mesh_data_gs_out` | stage=gs-out forwarded correctly |
+| 4 | `test_mesh_data_default_stage` | stage defaults to vs-out |
+| 5 | `test_mesh_data_no_postvs` | vertexResourceId=0 → -32001 |
+| 6 | `test_mesh_data_no_adapter` | no adapter → -32002 |
+| 7 | `test_mesh_data_uses_current_eid` | omit eid → uses state.current_eid |
+
+## CLI Tests (`tests/unit/test_mesh_commands.py`)
+
+| # | Test | Assertion |
+|---|------|-----------|
+| 1 | `test_mesh_default_obj` | stdout contains `v` and `f` lines |
+| 2 | `test_mesh_json_output` | --json returns valid JSON with all fields |
+| 3 | `test_mesh_file_output` | -o writes file, stderr has summary |
+| 4 | `test_mesh_no_header` | --no-header suppresses # comment |
+| 5 | `test_mesh_stage_forwarded` | --stage gs-out in daemon params |
+| 6 | `test_mesh_help` | --help shows EID, --stage, -o |
+| 7 | `test_mesh_in_main_help` | rdc --help lists mesh |
+| 8 | `test_obj_triangle_list_faces` | f lines correct for TriangleList |
+| 9 | `test_obj_triangle_strip_faces` | alternating winding |
+| 10 | `test_obj_triangle_fan_faces` | pivot vertex 0 |
+| 11 | `test_obj_point_list_no_faces` | no f lines for PointList |
+| 12 | `test_obj_1_indexed` | f indices start at 1 |
+| 13 | `test_obj_indexed_mesh` | uses index buffer for faces |
+
+## GPU Integration Tests (`tests/integration/test_daemon_handlers_real.py`)
+
+| # | Test | Assertion |
+|---|------|-----------|
+| 1 | `test_mesh_data_real` | non-zero vertices returned |
+| 2 | `test_mesh_data_vertex_count` | vertex_count == len(vertices) |
+| 3 | `test_mesh_data_topology_string` | topology is str, not int |

--- a/src/rdc/cli.py
+++ b/src/rdc/cli.py
@@ -21,6 +21,7 @@ from rdc.commands.doctor import doctor_cmd
 from rdc.commands.events import draw_cmd, draws_cmd, event_cmd, events_cmd
 from rdc.commands.export import buffer_cmd, rt_cmd, texture_cmd
 from rdc.commands.info import info_cmd, log_cmd, stats_cmd
+from rdc.commands.mesh import mesh_cmd
 from rdc.commands.pipeline import bindings_cmd, pipeline_cmd, shader_cmd, shaders_cmd
 from rdc.commands.pixel import pixel_cmd
 from rdc.commands.resources import pass_cmd, passes_cmd, resource_cmd, resources_cmd
@@ -99,6 +100,7 @@ main.add_command(complete_cmd, name="_complete")
 main.add_command(texture_cmd, name="texture")
 main.add_command(rt_cmd, name="rt")
 main.add_command(buffer_cmd, name="buffer")
+main.add_command(mesh_cmd, name="mesh")
 main.add_command(search_cmd, name="search")
 main.add_command(usage_cmd, name="usage")
 main.add_command(completion_cmd, name="completion")

--- a/src/rdc/commands/mesh.py
+++ b/src/rdc/commands/mesh.py
@@ -1,0 +1,119 @@
+"""rdc mesh -- export post-transform mesh as OBJ."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import click
+
+from rdc.commands.info import _daemon_call
+from rdc.formatters.json_fmt import write_json
+
+
+@click.command("mesh")
+@click.argument("eid", type=int, required=False, default=None)
+@click.option(
+    "--stage",
+    type=click.Choice(["vs-out", "gs-out"]),
+    default="vs-out",
+    help="Mesh data stage (default: vs-out)",
+)
+@click.option("-o", "--output", type=click.Path(), default=None, help="Write to file")
+@click.option("--json", "use_json", is_flag=True, help="JSON output")
+@click.option("--no-header", is_flag=True, help="Suppress OBJ header comment")
+def mesh_cmd(
+    eid: int | None,
+    stage: str,
+    output: str | None,
+    use_json: bool,
+    no_header: bool,
+) -> None:
+    """Export post-transform mesh as OBJ."""
+    params: dict[str, Any] = {"stage": stage}
+    if eid is not None:
+        params["eid"] = eid
+
+    result = _daemon_call("mesh_data", params)
+
+    if use_json:
+        faces = _generate_faces(result["vertex_count"], result["indices"], result["topology"])
+        result["faces"] = faces
+        result["face_count"] = len(faces)
+        write_json(result)
+        return
+
+    positions = _extract_positions(result["vertices"])
+    faces = _generate_faces(result["vertex_count"], result["indices"], result["topology"])
+    obj_text = _format_obj(
+        positions,
+        faces,
+        eid=result["eid"],
+        stage=result["stage"],
+        topology=result["topology"],
+        no_header=no_header,
+    )
+
+    if output:
+        Path(output).write_text(obj_text)
+        click.echo(f"mesh: {len(positions)} vertices, {len(faces)} faces -> {output}", err=True)
+    else:
+        click.echo(obj_text, nl=False)
+
+
+def _extract_positions(vertices: list[list[float]]) -> list[tuple[float, float, float]]:
+    """Extract xyz from vertex data (no perspective divide)."""
+    positions = []
+    for v in vertices:
+        x = v[0] if len(v) > 0 else 0.0
+        y = v[1] if len(v) > 1 else 0.0
+        z = v[2] if len(v) > 2 else 0.0
+        positions.append((x, y, z))
+    return positions
+
+
+def _generate_faces(vertex_count: int, indices: list[int], topology: str) -> list[list[int]]:
+    """Generate triangle faces from topology. Returns 0-indexed triples."""
+    idx = indices if indices else list(range(vertex_count))
+    n = len(idx)
+    faces: list[list[int]] = []
+    match topology:
+        case "TriangleList":
+            for i in range(0, n - 2, 3):
+                faces.append([idx[i], idx[i + 1], idx[i + 2]])
+        case "TriangleStrip":
+            for i in range(n - 2):
+                if i % 2 == 0:
+                    faces.append([idx[i], idx[i + 1], idx[i + 2]])
+                else:
+                    faces.append([idx[i + 1], idx[i], idx[i + 2]])
+        case "TriangleFan":
+            for i in range(1, n - 1):
+                faces.append([idx[0], idx[i], idx[i + 1]])
+        case _:
+            pass
+    return faces
+
+
+def _format_obj(
+    positions: list[tuple[float, float, float]],
+    faces: list[list[int]],
+    *,
+    eid: int,
+    stage: str,
+    topology: str,
+    no_header: bool = False,
+) -> str:
+    """Format vertex positions and faces as OBJ text."""
+    lines: list[str] = []
+    if not no_header:
+        lines.append(
+            f"# rdc mesh export: eid={eid} stage={stage} "
+            f"vertices={len(positions)} faces={len(faces)} "
+            f"topology={topology}"
+        )
+    for x, y, z in positions:
+        lines.append(f"v {x:.6f} {y:.6f} {z:.6f}")
+    for face in faces:
+        lines.append("f " + " ".join(str(i + 1) for i in face))
+    return "\n".join(lines) + "\n"

--- a/tests/mocks/mock_renderdoc.py
+++ b/tests/mocks/mock_renderdoc.py
@@ -319,6 +319,12 @@ class CompType(IntEnum):
     UNormSRGB = 9
 
 
+class MeshDataStage(IntEnum):
+    VSIn = 0
+    VSOut = 1
+    GSOut = 2
+
+
 class ShaderEncoding(IntEnum):
     Unknown = 0
     DXBC = 1
@@ -1243,6 +1249,7 @@ class MockReplayController:
         self._debug_pixel_map: dict[tuple[int, int], ShaderDebugTrace] = {}
         self._debug_vertex_map: dict[int, ShaderDebugTrace] = {}
         self._debug_states: dict[int, list[list[ShaderDebugState]]] = {}
+        self._mesh_data: dict[int, MeshFormat] = {}
         self._target_encodings: list[int] = [3, 2]
         self._built_counter: int = 1000
         self._replacements: dict[int, int] = {}
@@ -1305,8 +1312,8 @@ class MockReplayController:
         return self._cbuffer_variables.get((int(stage), idx), [])
 
     def GetPostVSData(self, instance: int, view: int, stage: Any) -> MeshFormat:
-        """Mock GetPostVSData -- returns dummy mesh format."""
-        return MeshFormat()
+        """Mock GetPostVSData -- returns configured or empty mesh format."""
+        return self._mesh_data.get(int(stage), MeshFormat())
 
     def GetDisassemblyTargets(self, with_pipeline: bool) -> list[str]:
         """Mock GetDisassemblyTargets -- returns default target list."""

--- a/tests/unit/test_mesh_commands.py
+++ b/tests/unit/test_mesh_commands.py
@@ -1,0 +1,149 @@
+"""Tests for rdc mesh CLI command and OBJ formatter."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from click.testing import CliRunner
+
+from rdc.cli import main
+from rdc.commands.mesh import _format_obj, _generate_faces, mesh_cmd
+
+_MESH_RESPONSE: dict[str, Any] = {
+    "eid": 142,
+    "stage": "vs-out",
+    "topology": "TriangleList",
+    "vertex_count": 3,
+    "comp_count": 4,
+    "stride": 16,
+    "vertices": [[0.0, 0.5, 0.0, 1.0], [-0.5, -0.5, 0.0, 1.0], [0.5, -0.5, 0.0, 1.0]],
+    "index_count": 0,
+    "indices": [],
+}
+
+
+class TestMeshCmd:
+    def test_mesh_default_obj(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr("rdc.commands.mesh._daemon_call", lambda m, p: _MESH_RESPONSE)
+        runner = CliRunner()
+        result = runner.invoke(mesh_cmd, [])
+        assert result.exit_code == 0
+        lines = result.output.strip().split("\n")
+        assert lines[0].startswith("# rdc mesh export:")
+        v_lines = [ln for ln in lines if ln.startswith("v ")]
+        f_lines = [ln for ln in lines if ln.startswith("f ")]
+        assert len(v_lines) == 3
+        assert len(f_lines) == 1
+        assert "f 1 2 3" in result.output
+
+    def test_mesh_json_output(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr("rdc.commands.mesh._daemon_call", lambda m, p: dict(_MESH_RESPONSE))
+        runner = CliRunner()
+        result = runner.invoke(mesh_cmd, ["--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["vertices"] == _MESH_RESPONSE["vertices"]
+        assert data["faces"] == [[0, 1, 2]]
+        assert data["face_count"] == 1
+
+    def test_mesh_file_output(self, monkeypatch: Any, tmp_path: Any) -> None:
+        monkeypatch.setattr("rdc.commands.mesh._daemon_call", lambda m, p: _MESH_RESPONSE)
+        out = tmp_path / "mesh.obj"
+        runner = CliRunner()
+        result = runner.invoke(mesh_cmd, ["-o", str(out)])
+        assert result.exit_code == 0
+        assert out.exists()
+        content = out.read_text()
+        assert "v 0.000000 0.500000 0.000000" in content
+        assert "f 1 2 3" in content
+        assert "3 vertices" in result.output  # stderr summary
+
+    def test_mesh_no_header(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr("rdc.commands.mesh._daemon_call", lambda m, p: _MESH_RESPONSE)
+        runner = CliRunner()
+        result = runner.invoke(mesh_cmd, ["--no-header"])
+        assert result.exit_code == 0
+        lines = result.output.strip().split("\n")
+        assert not any(ln.startswith("#") for ln in lines)
+        assert lines[0].startswith("v ")
+
+    def test_mesh_stage_forwarded(self, monkeypatch: Any) -> None:
+        calls: list[tuple[str, dict[str, Any]]] = []
+
+        def mock_call(method: str, params: dict[str, Any]) -> dict[str, Any]:
+            calls.append((method, params))
+            return _MESH_RESPONSE
+
+        monkeypatch.setattr("rdc.commands.mesh._daemon_call", mock_call)
+        runner = CliRunner()
+        result = runner.invoke(mesh_cmd, ["--stage", "gs-out"])
+        assert result.exit_code == 0
+        assert calls[0][1]["stage"] == "gs-out"
+
+    def test_mesh_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(mesh_cmd, ["--help"])
+        assert result.exit_code == 0
+        assert "EID" in result.output
+        assert "--stage" in result.output
+        assert "-o" in result.output
+
+    def test_mesh_in_main_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+        assert "mesh" in result.output
+
+
+class TestObjFormatter:
+    def test_obj_triangle_list_faces(self) -> None:
+        faces = _generate_faces(6, [], "TriangleList")
+        assert len(faces) == 2
+        assert faces[0] == [0, 1, 2]
+        assert faces[1] == [3, 4, 5]
+
+    def test_obj_triangle_strip_faces(self) -> None:
+        faces = _generate_faces(4, [], "TriangleStrip")
+        assert len(faces) == 2
+        # even: [0,1,2], odd: [2,1,3] (swapped winding)
+        assert faces[0] == [0, 1, 2]
+        assert faces[1] == [2, 1, 3]
+
+    def test_obj_triangle_fan_faces(self) -> None:
+        faces = _generate_faces(4, [], "TriangleFan")
+        assert len(faces) == 2
+        assert all(f[0] == 0 for f in faces)
+        assert faces[0] == [0, 1, 2]
+        assert faces[1] == [0, 2, 3]
+
+    def test_obj_point_list_no_faces(self) -> None:
+        faces = _generate_faces(5, [], "PointList")
+        assert faces == []
+        obj = _format_obj(
+            [(0.0, 0.0, 0.0)] * 5,
+            faces,
+            eid=1,
+            stage="vs-out",
+            topology="PointList",
+        )
+        assert "f " not in obj
+
+    def test_obj_1_indexed(self) -> None:
+        positions = [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+        faces = [[0, 1, 2]]
+        obj = _format_obj(
+            positions,
+            faces,
+            eid=1,
+            stage="vs-out",
+            topology="TriangleList",
+        )
+        assert "f 1 2 3" in obj
+        assert "f 0" not in obj
+
+    def test_obj_indexed_mesh(self) -> None:
+        # 4 vertices, 6 indices forming 2 triangles (shared vertices)
+        faces = _generate_faces(4, [0, 1, 2, 0, 2, 3], "TriangleList")
+        assert len(faces) == 2
+        assert faces[0] == [0, 1, 2]
+        assert faces[1] == [0, 2, 3]

--- a/tests/unit/test_mesh_handler.py
+++ b/tests/unit/test_mesh_handler.py
@@ -1,0 +1,187 @@
+"""Tests for mesh_data daemon handler (phase4c-mesh-export)."""
+
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
+
+import mock_renderdoc as mock_rd
+from mock_renderdoc import (
+    ActionDescription,
+    ActionFlags,
+    MeshFormat,
+    ResourceDescription,
+    ResourceFormat,
+    ResourceId,
+)
+
+from rdc.adapter import RenderDocAdapter
+from rdc.daemon_server import DaemonState, _handle_request
+from rdc.vfs.tree_cache import build_vfs_skeleton
+
+# 3 vertices: (x, y, z, w)
+_VERTS = [
+    (0.0, 0.5, 0.0, 1.0),
+    (-0.5, -0.5, 0.0, 1.0),
+    (0.5, -0.5, 0.0, 1.0),
+]
+_VBUF = b"".join(struct.pack("<4f", *v) for v in _VERTS)
+_IBUF = struct.pack("<3H", 0, 2, 1)
+
+
+def _build_actions() -> list[ActionDescription]:
+    return [
+        ActionDescription(
+            eventId=10,
+            flags=ActionFlags.Drawcall,
+            numIndices=3,
+            _name="Draw",
+        ),
+    ]
+
+
+def _build_resources() -> list[ResourceDescription]:
+    return [ResourceDescription(resourceId=ResourceId(1), name="res0")]
+
+
+def _req(method: str, **params: Any) -> dict[str, Any]:
+    p: dict[str, Any] = {"_token": "abcdef1234567890"}
+    p.update(params)
+    return {"id": 1, "method": method, "params": p}
+
+
+def _triangle_mesh(
+    *,
+    indexed: bool = False,
+    stage_val: int = 1,
+) -> MeshFormat:
+    """Build a MeshFormat for a 3-vertex triangle."""
+    m = MeshFormat(
+        vertexResourceId=ResourceId(800),
+        vertexByteStride=16,
+        vertexByteOffset=0,
+        vertexByteSize=len(_VBUF),
+        format=ResourceFormat(
+            name="R32G32B32A32_FLOAT",
+            compByteWidth=4,
+            compCount=4,
+        ),
+        numIndices=3,
+        topology="TriangleList",
+    )
+    if indexed:
+        m.indexResourceId = ResourceId(801)
+        m.indexByteStride = 2
+        m.indexByteOffset = 0
+        m.indexByteSize = len(_IBUF)
+    return m
+
+
+@pytest.fixture()
+def state() -> DaemonState:
+    actions = _build_actions()
+    resources = _build_resources()
+
+    def _get_buffer_data(resource_id: Any, offset: int, length: int) -> bytes:
+        rid = int(resource_id)
+        if rid == 800:
+            return _VBUF
+        if rid == 801:
+            return _IBUF
+        return b""
+
+    # Default: vs-out returns triangle mesh, gs-out returns empty
+    postvs: dict[int, MeshFormat] = {1: _triangle_mesh()}
+
+    def _get_postvs(inst: int, view: int, stage: Any) -> MeshFormat:
+        return postvs.get(int(stage), MeshFormat())
+
+    controller = SimpleNamespace(
+        GetRootActions=lambda: actions,
+        GetResources=lambda: resources,
+        GetAPIProperties=lambda: SimpleNamespace(pipelineType="Vulkan"),
+        SetFrameEvent=lambda eid, force: None,
+        GetStructuredFile=lambda: SimpleNamespace(chunks=[]),
+        GetPipelineState=lambda: SimpleNamespace(),
+        GetTextures=lambda: [],
+        GetBuffers=lambda: [],
+        GetDebugMessages=lambda: [],
+        GetPostVSData=_get_postvs,
+        GetBufferData=_get_buffer_data,
+        Shutdown=lambda: None,
+        _postvs=postvs,
+    )
+
+    s = DaemonState(capture="test.rdc", current_eid=0, token="abcdef1234567890")
+    s.adapter = RenderDocAdapter(controller=controller, version=(1, 41))
+    s.max_eid = 10
+    s.rd = mock_rd
+    s.vfs_tree = build_vfs_skeleton(actions, resources)
+    return s
+
+
+class TestMeshData:
+    def test_mesh_data_triangle_list(self, state: DaemonState) -> None:
+        """Non-indexed triangle returns 3 vertices with correct values."""
+        resp, _ = _handle_request(_req("mesh_data", eid=10), state)
+        r = resp["result"]
+        assert r["vertex_count"] == 3
+        assert r["topology"] == "TriangleList"
+        assert r["index_count"] == 0
+        assert r["indices"] == []
+        assert len(r["vertices"]) == 3
+        assert r["comp_count"] == 4
+        assert r["stride"] == 16
+        # Check first vertex
+        assert r["vertices"][0] == pytest.approx([0.0, 0.5, 0.0, 1.0])
+        assert r["vertices"][1] == pytest.approx([-0.5, -0.5, 0.0, 1.0])
+        assert r["vertices"][2] == pytest.approx([0.5, -0.5, 0.0, 1.0])
+
+    def test_mesh_data_indexed(self, state: DaemonState) -> None:
+        """Indexed triangle returns indices [0, 2, 1]."""
+        state.adapter.controller._postvs[1] = _triangle_mesh(indexed=True)
+        resp, _ = _handle_request(_req("mesh_data", eid=10), state)
+        r = resp["result"]
+        assert r["index_count"] == 3
+        assert r["indices"] == [0, 2, 1]
+        assert r["vertex_count"] == 3
+
+    def test_mesh_data_gs_out(self, state: DaemonState) -> None:
+        """stage=gs-out passes stage_val=2 to GetPostVSData."""
+        state.adapter.controller._postvs[2] = _triangle_mesh()
+        resp, _ = _handle_request(_req("mesh_data", eid=10, stage="gs-out"), state)
+        r = resp["result"]
+        assert r["stage"] == "gs-out"
+        assert r["vertex_count"] == 3
+
+    def test_mesh_data_default_stage(self, state: DaemonState) -> None:
+        """Omitting stage defaults to vs-out."""
+        resp, _ = _handle_request(_req("mesh_data", eid=10), state)
+        r = resp["result"]
+        assert r["stage"] == "vs-out"
+
+    def test_mesh_data_no_postvs(self, state: DaemonState) -> None:
+        """Empty MeshFormat (vertexResourceId=0) returns error -32001."""
+        state.adapter.controller._postvs.clear()
+        resp, _ = _handle_request(_req("mesh_data", eid=10), state)
+        assert resp["error"]["code"] == -32001
+
+    def test_mesh_data_no_adapter(self) -> None:
+        """No adapter loaded returns error -32002."""
+        s = DaemonState(capture="t.rdc", current_eid=0, token="abcdef1234567890")
+        resp, _ = _handle_request(_req("mesh_data", eid=10), s)
+        assert resp["error"]["code"] == -32002
+
+    def test_mesh_data_uses_current_eid(self, state: DaemonState) -> None:
+        """Omitting eid uses state.current_eid."""
+        state.current_eid = 10
+        resp, _ = _handle_request(_req("mesh_data"), state)
+        r = resp["result"]
+        assert r["eid"] == 10


### PR DESCRIPTION
## Summary

- Add `rdc mesh [EID]` command that exports post-transform vertex data as Wavefront OBJ
- New `mesh_data` daemon handler decodes PostVS vertex/index buffers via `GetPostVSData` + `GetBufferData`
- Supports TriangleList, TriangleStrip, TriangleFan topologies (indexed and non-indexed)
- Options: `--stage vs-out|gs-out`, `-o FILE`, `--json`, `--no-header`

## Changes

| File | Change |
|------|--------|
| `src/rdc/handlers/buffer.py` | `_handle_mesh_data` handler + registration |
| `src/rdc/commands/mesh.py` | CLI command + OBJ formatter (NEW) |
| `src/rdc/cli.py` | Register `mesh_cmd` |
| `tests/mocks/mock_renderdoc.py` | `MeshDataStage` enum + `_mesh_data` lookup |
| `tests/unit/test_mesh_handler.py` | 7 handler tests (NEW) |
| `tests/unit/test_mesh_commands.py` | 13 CLI + formatter tests (NEW) |
| `tests/integration/test_daemon_handlers_real.py` | 3 GPU integration tests |
| `openspec/changes/2026-02-22-phase4c-mesh-export/` | OpenSpec (proposal, test-plan, tasks) |

## Test plan

- [x] `pixi run lint` — all checks passed
- [x] `pixi run test` — 1364 passed, 94.86% coverage
- [ ] GPU integration: `pixi run test-gpu -k mesh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rdc mesh` command to export post-transform mesh data in OBJ or JSON format
  * Supports pipeline stage selection (vs-out/gs-out) and entity ID specification
  * Optional header suppression and flexible output modes (file or stdout)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->