### PR TITLE
fix: resolve 6 design deviations — diff, shader API, VFS ls -l

### DIFF
--- a/openspec/changes/2026-02-22-design-deviation-diff-completeness/proposal.md
+++ b/openspec/changes/2026-02-22-design-deviation-diff-completeness/proposal.md
@@ -1,0 +1,108 @@
+# Proposal: diff-completeness — implement --draws, --passes, and summary mode
+
+## Problem
+
+Three modes of `rdc diff` are design deviations from `命令总览.md`:
+
+1. `rdc diff <a> <b> --draws` — exits with code 2 and "not yet implemented".
+2. `rdc diff <a> <b> --passes` — exits with code 2 and "not yet implemented".
+3. `rdc diff <a> <b>` (no mode flag) — falls through silently, exits 0 with no output.
+
+The design specifies all three as first-class Phase 3 features.
+
+## Solution
+
+Implement all three modes end-to-end:
+
+- **`--draws`**: query both daemons via the existing `draws` RPC, build `DrawRecord` lists, run `diff_draws()`, render output. Reuses the alignment and comparison logic already in `src/rdc/diff/draws.py`.
+- **`--passes`**: query both daemons via the existing `passes` RPC, extract the `per_pass` list from each, run `diff_stats()` (which already compares per-pass name/draws/triangles/dispatches). Wire the existing `src/rdc/diff/stats.py` renderers to the CLI.
+- **`summary` (no flag)**: query both daemons for `stats`, compute top-level deltas (event count, draw count, pass count, resource count), render a compact one-line-per-category output modelled on `git diff --stat`.
+
+No new daemon-side handler is needed for any of these — all required RPCs (`draws`, `passes`, `stats`) already exist.
+
+## Design
+
+### `--draws` mode
+
+**Data flow:**
+
+```
+CLI --draws
+  → query_both(ctx, "draws", {})           # existing RPC
+  → resp["result"]["draws"]                # list[dict] with eid/type/triangles/instances/pass/marker
+  → build_draw_records(draws)              # existing fn in rdc.diff.pipeline
+  → diff_draws(records_a, records_b)       # existing fn in rdc.diff.draws
+  → render_{tsv,unified,json,shortstat}    # existing renderers in rdc.diff.draws
+  → sys.exit(0 if all equal else 1)
+```
+
+`build_draw_records` (already in `src/rdc/diff/pipeline.py`) converts the RPC dict list to `DrawRecord` objects. The `marker` field from the `draws` RPC maps to `DrawRecord.marker_path`; `pass` maps to `DrawRecord.pass_name`.
+
+**Output formats:** TSV (default), `--format unified`, `--format json`, `--shortstat`. Same flags already wired for `--resources` and `--stats`.
+
+**TSV columns:** `STATUS`, `EID_A`, `EID_B`, `MARKER`, `TYPE`, `TRI_A`, `TRI_B`, `INST_A`, `INST_B`, `CONFIDENCE`
+
+**Exit codes:** 0 = no differences, 1 = differences found, 2 = error.
+
+### `--passes` mode
+
+**Data flow:**
+
+```
+CLI --passes
+  → query_both(ctx, "stats", {})           # existing RPC (returns per_pass list)
+  → resp["result"]["per_pass"]             # list[dict] with name/draws/triangles/dispatches
+  → diff_stats(passes_a, passes_b)         # existing fn in rdc.diff.stats
+  → render_{tsv,unified,json,shortstat}    # existing renderers in rdc.diff.stats
+  → sys.exit(0 if all equal else 1)
+```
+
+The `stats` RPC already returns `per_pass` with `name`, `draws`, `triangles`, `dispatches`. The `diff_stats()` function in `rdc.diff.stats` compares exactly this shape. No new RPC or module needed.
+
+**Output formats:** TSV (default), `--format unified`, `--format json`, `--shortstat`.
+
+**TSV columns:** `STATUS`, `PASS`, `DRAWS_A`, `DRAWS_B`, `DRAWS_DELTA`, `TRI_A`, `TRI_B`, `TRI_DELTA`, `DISP_A`, `DISP_B`, `DISP_DELTA`
+
+**Exit codes:** 0 = no differences, 1 = differences found, 2 = error.
+
+### `summary` mode (no flag)
+
+**Data flow:**
+
+```
+CLI (no mode flag)
+  → query_both(ctx, "stats", {})           # existing RPC
+  → compute deltas from top-level stats fields
+  → render compact text summary
+  → sys.exit(0 if all equal else 1)
+```
+
+The `stats` RPC response also has top-level aggregate fields (`total_draws`, `indexed_draws`, `dispatches`, `clears`, etc.) embedded in `per_pass` data. For the summary we derive:
+
+- **event count delta**: compare `max_eid` via a `status` RPC call on each daemon
+- **draw count delta**: sum of `per_pass[i].draws` across all passes for each side
+- **pass count delta**: `len(per_pass)` per side
+- **resource count delta**: from an additional `query_both(ctx, "resources", {})` call
+
+**Output format (text only, no `--format` needed for summary):**
+
+```
+draws:     42 → 45  (+3)
+passes:     4 →  4  (=)
+resources: 18 → 20  (+2)
+events:   180 → 195 (+15)
+```
+
+One line per category. If all deltas are zero, print `identical` and exit 0. Otherwise exit 1.
+
+`--json` flag outputs a JSON object with the same four keys plus raw a/b values.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/rdc/commands/diff.py` | Remove `_MODE_STUBS` set; add `_handle_draws()`, `_handle_passes()`, `_handle_summary()` functions; wire them in `diff_cmd` |
+| `src/rdc/diff/summary.py` | New module: `SummaryRow` dataclass, `diff_summary()`, `render_text()`, `render_json()` |
+| `tests/unit/test_diff_command.py` | Update tests #31, #33 to assert real output instead of stub errors; add format/shortstat variants |
+| `tests/unit/test_diff_summary.py` | New: unit tests for `diff_summary()` and renderers |
+| `tests/integration/test_daemon_handlers_real.py` | Add GPU integration tests for all three modes via real captures |

--- a/openspec/changes/2026-02-22-design-deviation-diff-completeness/tasks.md
+++ b/openspec/changes/2026-02-22-design-deviation-diff-completeness/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: diff-completeness — --draws, --passes, and summary mode
+
+## Tasks
+
+- [ ] Create `src/rdc/diff/summary.py` with `SummaryRow` dataclass, `diff_summary()`, `render_text()`, `render_json()`
+- [ ] Create `tests/unit/test_diff_summary.py` with tests S-01 through S-14
+- [ ] Implement `_handle_draws()` in `src/rdc/commands/diff.py` — query `draws` RPC, build records, diff, render
+- [ ] Implement `_handle_passes()` in `src/rdc/commands/diff.py` — query `stats` RPC, extract `per_pass`, diff via `diff_stats()`, render
+- [ ] Implement `_handle_summary()` in `src/rdc/commands/diff.py` — query `stats` RPC + `resources` RPC, compute four deltas, render
+- [ ] Remove `_MODE_STUBS` set and wire the three new handlers in `diff_cmd` dispatch block
+- [ ] Update `tests/unit/test_diff_command.py` — fix tests C-01/C-02 (remove stub assertions); add tests C-03 through C-20
+- [ ] Add GPU integration tests G-01 through G-07 in `tests/integration/test_daemon_handlers_real.py`
+- [ ] Run `pixi run lint && pixi run test` — zero failures

--- a/openspec/changes/2026-02-22-design-deviation-diff-completeness/test-plan.md
+++ b/openspec/changes/2026-02-22-design-deviation-diff-completeness/test-plan.md
@@ -1,0 +1,140 @@
+# Test Plan: diff-completeness — --draws, --passes, and summary mode
+
+## Unit Tests
+
+### `tests/unit/test_diff_summary.py` (new file)
+
+Tests for the new `src/rdc/diff/summary.py` module.
+
+**`TestDiffSummary`**
+
+| ID | Test | Assertion |
+|----|------|-----------|
+| S-01 | `diff_summary` — identical stats | all deltas zero, returns `{"draws": (n,n,0), ...}` |
+| S-02 | `diff_summary` — draw count increased | `draws` delta positive |
+| S-03 | `diff_summary` — pass removed | `passes` delta negative |
+| S-04 | `diff_summary` — resource count changed | `resources` delta non-zero |
+| S-05 | `diff_summary` — all categories changed simultaneously | all four deltas present |
+| S-06 | `diff_summary` — empty both sides | all zeros |
+
+**`TestRenderText`**
+
+| ID | Test | Assertion |
+|----|------|-----------|
+| S-07 | all-zero deltas → `"identical"` output | output is exactly `"identical"` |
+| S-08 | positive draw delta → `"+N"` formatted | `"draws"` line contains `(+N)` |
+| S-09 | negative pass delta → `"-N"` formatted | `"passes"` line contains `(-N)` |
+| S-10 | equal category shows `(=)` | lines with zero delta show `(=)` |
+| S-11 | four categories always emitted | output has exactly 4 non-empty lines when non-identical |
+
+**`TestRenderJsonSummary`**
+
+| ID | Test | Assertion |
+|----|------|-----------|
+| S-12 | JSON schema has `draws`, `passes`, `resources`, `events` keys | all four present |
+| S-13 | each key has `a`, `b`, `delta` sub-fields | sub-fields exist and are ints |
+| S-14 | empty input → valid JSON with all-zero values | parses without error |
+
+### `tests/unit/test_diff_command.py` (extend existing)
+
+**Update existing stubs to real behavior:**
+
+| ID | Test | Change |
+|----|------|--------|
+| C-01 | `test_diff_draws_mode` (was #31) | mock `query_both` to return draw lists; assert exit 0 or 1, not 2; assert output contains TSV header |
+| C-02 | `test_diff_default_summary` (was #33) | mock `query_both` to return stats; assert output non-empty and exit 0 or 1 |
+
+**New `--draws` mode tests:**
+
+| ID | Test | Assertion |
+|----|------|-----------|
+| C-03 | `--draws` with identical draws | exit 0, output contains `=` rows |
+| C-04 | `--draws` with differences | exit 1, output contains `~` or `+`/`-` rows |
+| C-05 | `--draws --shortstat` | exit 0/1, output matches `"N added, N deleted, N modified, N unchanged"` pattern |
+| C-06 | `--draws --format json` | exit 0/1, output is valid JSON array |
+| C-07 | `--draws --format unified` | exit 0/1, output starts with `--- a/` header |
+| C-08 | `--draws` when `query_both` returns None | exit 2, error message on stderr |
+| C-09 | `--draws --no-header` with TSV | output has no header line |
+
+**New `--passes` mode tests:**
+
+| ID | Test | Assertion |
+|----|------|-----------|
+| C-10 | `--passes` with identical passes | exit 0, TSV output with `=` status rows |
+| C-11 | `--passes` with pass added | exit 1, output contains `+` row |
+| C-12 | `--passes` with pass removed | exit 1, output contains `-` row |
+| C-13 | `--passes --shortstat` | exit 0/1, output matches shortstat pattern |
+| C-14 | `--passes --format json` | exit 0/1, valid JSON array |
+| C-15 | `--passes --format unified` | exit 0/1, starts with `--- a/` header |
+| C-16 | `--passes` when `query_both` returns None | exit 2, error on stderr |
+
+**New `summary` mode tests:**
+
+| ID | Test | Assertion |
+|----|------|-----------|
+| C-17 | no flag, all identical | exit 0, output is `"identical"` |
+| C-18 | no flag, draws differ | exit 1, output contains `draws:` line with delta |
+| C-19 | no flag `--json` | exit 0/1, valid JSON with four top-level keys |
+| C-20 | no flag, `query_both` fails | exit 2, error message |
+
+### `tests/unit/test_diff_draws.py` (no change needed)
+
+Existing tests cover `diff_draws()`, `compare_draw_pair()`, and all renderers. No additions required.
+
+### `tests/unit/test_diff_stats.py` (no change needed)
+
+Existing tests cover `diff_stats()` and all renderers — these are reused for `--passes`.
+
+## CLI Tests
+
+All CLI tests use `CliRunner` with monkeypatched `start_diff_session`, `stop_diff_session`, and `query_both` on `rdc.commands.diff`. This follows the existing pattern in `test_diff_command.py`.
+
+**Mock shape for `query_both` returning draws:**
+```python
+def mock_query_both(ctx, method, params, **kw):
+    if method == "draws":
+        draws = [{"eid": 10, "type": "DrawIndexed", "triangles": 100, "instances": 1,
+                  "pass": "GBuffer", "marker": "Floor"}]
+        resp = {"result": {"draws": draws, "summary": "1 draw calls"}}
+        return resp, resp, ""
+    return None, None, "unexpected method"
+```
+
+**Mock shape for `query_both` returning stats (for `--passes` and `summary`):**
+```python
+def mock_query_both(ctx, method, params, **kw):
+    if method == "stats":
+        per_pass = [{"name": "GBuffer", "draws": 10, "triangles": 5000, "dispatches": 0}]
+        resp = {"result": {"per_pass": per_pass, "top_draws": []}}
+        return resp, resp, ""
+    return None, None, "unexpected method"
+```
+
+## GPU Integration Tests
+
+Location: `tests/integration/test_daemon_handlers_real.py`, new class `TestDiffCompletenessReal`.
+
+These tests use two copies of the same `.rdc` file (self-diff), so all results should show no differences.
+
+**Setup pattern (same capture diffed against itself):**
+
+```python
+@pytest.fixture(scope="class")
+def self_diff_ctx(real_capture):
+    ctx, err = start_diff_session(str(real_capture), str(real_capture))
+    assert ctx is not None, err
+    yield ctx
+    stop_diff_session(ctx)
+```
+
+| ID | Test | Assertion |
+|----|------|-----------|
+| G-01 | `--draws` self-diff | all rows have status `=`; exit 0 |
+| G-02 | `--passes` self-diff | all rows have status `=`; exit 0 |
+| G-03 | `summary` self-diff | output is `"identical"`; exit 0 |
+| G-04 | `--draws` `--format json` self-diff | valid JSON; all `"status"` fields are `"="` |
+| G-05 | `--passes` `--shortstat` self-diff | shortstat shows all-zero deltas |
+| G-06 | `--draws` raw `draws` RPC → `build_draw_records` produces non-empty list | `DrawRecord` list has at least one entry |
+| G-07 | `--passes` raw `stats` RPC → `per_pass` list non-empty | at least one pass present |
+
+These tests are marked `@pytest.mark.gpu` and only run when `RENDERDOC_PYTHON_PATH` is set.

--- a/openspec/changes/2026-02-22-design-deviation-shader-api-fix/proposal.md
+++ b/openspec/changes/2026-02-22-design-deviation-shader-api-fix/proposal.md
@@ -1,0 +1,129 @@
+# Proposal: Fix Design Deviations in Shader Handlers
+
+## Problem
+
+Two handlers in `src/rdc/handlers/shader.py` deviate from their design specification.
+
+### Deviation 1: `shader_source` ignores debug info (P2)
+
+**Current behavior**: Always calls `controller.DisassembleShader()` and always returns
+`has_debug_info: False`, regardless of whether the shader has embedded source files.
+
+**Design spec** (`设计/命令总览.md` line 66): `rdc shader [eid] [stage] --source` should
+return "源码（需 debug info，否则 fallback 反汇编）". The handler must check whether debug
+info is present and return actual source files when available, falling back to disassembly
+only when not. The `has_debug_info` field must accurately reflect reality.
+
+### Deviation 2: `shader_constants` uses wrong API (P2)
+
+**Current behavior**: Calls `controller.GetConstantBuffer(stage_val, bind_point)` which
+returns raw binary data. The result is an opaque hex string with no variable names or
+types — useless for inspection.
+
+**Design spec** (`设计/API 实现映射.md`): Should use
+`controller.GetCBufferVariableContents(pipe, shader_id, stage, entry, cb_idx, resource,
+offset, size)` which returns a structured `ShaderVariable` list with names, types, and
+decoded values. This is the correct API for returning human-readable constant buffer
+contents.
+
+## Solution
+
+### `shader_source` fix
+
+Check `refl.debugInfo.files`. If the list is non-empty, return the source file contents
+concatenated (or a list of files), and set `has_debug_info: True`. If the list is empty,
+fall back to disassembly as before, with `has_debug_info: False`.
+
+For multi-file debug info, return a `files` list; for single-file or disassembly fallback,
+return a single `source` string. The `has_debug_info` flag drives the consumer's behavior.
+
+### `shader_constants` fix
+
+Replace the `GetConstantBuffer` call with `GetCBufferVariableContents` (8 params). For
+each cbuffer in `refl.constantBlocks`, resolve the bound descriptor via
+`pipe_state.GetConstantBlock(stage_val, idx, 0)` to get the `resource`, `byteOffset`,
+and `byteSize`. Then call `GetCBufferVariableContents` and recursively walk the returned
+`ShaderVariable` tree to produce structured output.
+
+## Design
+
+### Response shape — `shader_source`
+
+```json
+{
+  "eid": 10,
+  "stage": "ps",
+  "has_debug_info": true,
+  "files": [
+    {"filename": "shader.hlsl", "source": "..."}
+  ],
+  "source": ""
+}
+```
+
+When `has_debug_info` is `false`, `files` is `[]` and `source` contains the disassembly.
+When `has_debug_info` is `true`, `source` is `""` and `files` contains one or more entries.
+
+### Response shape — `shader_constants`
+
+```json
+{
+  "eid": 10,
+  "stage": "ps",
+  "constants": [
+    {
+      "name": "Globals",
+      "bind_point": 0,
+      "variables": [
+        {"name": "g_Color", "type": "float4", "rows": 1, "columns": 4,
+         "value": [1.0, 0.0, 0.0, 1.0]},
+        {"name": "g_Transform", "type": "float4x4", "rows": 4, "columns": 4,
+         "value": [1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0, ...]},
+        {"name": "g_Params", "type": "struct", "rows": 0, "columns": 0, "value": null,
+         "members": [...]}
+      ]
+    }
+  ]
+}
+```
+
+### `_flatten_shader_var` helper
+
+A module-private recursive function that converts a `ShaderVariable` (and its `.members`
+tree) to a dict. Value selection: if `var.members` is non-empty, recurse; otherwise pick
+from `var.value.f32v`, `var.value.u32v`, or `var.value.s32v` according to `var.type`
+(float/int/uint heuristic), and slice to `rows * columns` elements.
+
+### `GetCBufferVariableContents` call pattern
+
+```python
+pipe = get_pipeline_for_stage(pipe_state, stage_val)
+shader_id = pipe_state.GetShader(stage_val)
+entry = pipe_state.GetShaderEntryPoint(stage_val)
+
+for idx, cb_def in enumerate(refl.constantBlocks):
+    bound = pipe_state.GetConstantBlock(stage_val, idx, 0)
+    # GetConstantBlock returns a Descriptor directly — access .resource/.byteOffset/.byteSize
+    cbuffer_vars = controller.GetCBufferVariableContents(
+        pipe,
+        shader_id,
+        stage_val,
+        entry,
+        idx,
+        bound.resource,
+        bound.byteOffset,
+        bound.byteSize,
+    )
+    variables = [_flatten_shader_var(v) for v in cbuffer_vars]
+```
+
+## Files Changed
+
+### Modified
+- `src/rdc/handlers/shader.py` — fix `_handle_shader_source` and `_handle_shader_constants`
+- `tests/unit/test_daemon_shader_extended.py` — update `test_shader_constants` and
+  `test_shader_source` to assert new behavior
+- `tests/unit/test_daemon_shader_api_fix.py` — update to assert `has_debug_info` logic
+- `tests/mocks/mock_renderdoc.py` — verify `ShaderDebugInfo.files`, `SourceFile`,
+  `ShaderVariable`, `ShaderValue` are all already present (no changes expected)
+- `tests/integration/test_daemon_handlers_real.py` — add GPU tests for both fixes

--- a/openspec/changes/2026-02-22-design-deviation-shader-api-fix/tasks.md
+++ b/openspec/changes/2026-02-22-design-deviation-shader-api-fix/tasks.md
@@ -1,0 +1,71 @@
+# Tasks: Fix Design Deviations in Shader Handlers
+
+## Phase 1: Verify mock readiness
+
+- [ ] Confirm `ShaderDebugInfo`, `SourceFile`, `ShaderVariable`, `ShaderValue` in
+  `tests/mocks/mock_renderdoc.py` match the API reference (no changes expected)
+- [ ] Confirm `MockPipeState.GetConstantBlock(stage, slot, array_idx)` returns `Descriptor`
+  directly (not a wrapper) — check the Descriptor field layout vs real API
+- [ ] Confirm `MockReplayController.GetCBufferVariableContents` signature matches
+  the 8-param real API
+
+## Phase 2: Fix `shader_source` handler
+
+- [ ] In `_handle_shader_source`, after obtaining `refl`, check `refl.debugInfo.files`
+- [ ] If files non-empty: build `files` list `[{"filename": f.filename, "source": f.contents}]`,
+  set `has_debug_info = True`, set `source = ""`
+- [ ] If files empty: call `DisassembleShader` as before, set `has_debug_info = False`,
+  set `files = []`
+- [ ] Update response dict to include both `source` and `files` keys in all branches
+- [ ] Handle `refl is None` case: return `source=""`, `files=[]`, `has_debug_info=False`
+
+## Phase 3: Fix `shader_constants` handler
+
+- [ ] Add `_flatten_shader_var(var) -> dict` private helper in `shader.py`:
+  - If `var.members` non-empty: recurse, return `{"name": ..., "type": ..., "rows": ...,
+    "columns": ..., "value": None, "members": [...]}`
+  - Otherwise: select value array from `var.value` (f32v for float types, u32v for uint,
+    s32v for int), slice to `rows * columns` elements
+  - Return `{"name": ..., "type": ..., "rows": ..., "columns": ..., "value": [...]}`
+- [ ] In `_handle_shader_constants`, replace the `GetConstantBuffer` block with:
+  - Get `pipe = get_pipeline_for_stage(pipe_state, stage_val)`
+  - Get `shader_id = pipe_state.GetShader(stage_val)`
+  - Get `entry = pipe_state.GetShaderEntryPoint(stage_val)`
+  - Enumerate `refl.constantBlocks` with index `idx`
+  - For each: call `pipe_state.GetConstantBlock(stage_val, idx, 0)` → `bound`
+  - Call `controller.GetCBufferVariableContents(pipe, shader_id, stage_val, entry,
+    idx, bound.resource, bound.byteOffset, bound.byteSize)`
+  - Map results through `_flatten_shader_var`
+- [ ] Remove the `hasattr(controller, "GetConstantBuffer")` guard entirely
+- [ ] Remove `"data"` (hex) field from response; response has `"variables"` list instead
+- [ ] Keep `"name"` and `"bind_point"` fields on each cbuffer entry
+
+## Phase 4: Update unit tests
+
+- [ ] In `test_daemon_shader_extended.py`:
+  - Update `test_shader_constants` to assert `variables` list (not `data` hex field)
+  - Update `test_shader_source` to assert `files` key present in response
+- [ ] In `test_daemon_shader_api_fix.py`:
+  - Update `test_shader_source_uses_disassemble_shader` to also assert `files == []`
+  - Update `test_shader_source_no_reflection_returns_empty` to assert `files == []`
+  - Add `test_shader_source_with_debug_info_returns_files` (mock with `SourceFile`)
+  - Add `test_shader_source_with_multiple_debug_files`
+  - Add `test_shader_constants_returns_structured_variables` (mock `_cbuffer_variables`)
+  - Add `test_shader_constants_struct_variable_recurses`
+  - Add `test_shader_constants_empty_cbuffer`
+  - Add `test_shader_constants_multiple_cbuffers`
+  - Add `test_shader_constants_calls_get_cbuffer_variable_contents` (spy test)
+
+## Phase 5: GPU integration tests
+
+- [ ] In `tests/integration/test_daemon_handlers_real.py`:
+  - Add `test_shader_source_real_no_debug_info`
+  - Add `test_shader_source_real_fields_present`
+  - Add `test_shader_constants_real_structured`
+  - Add `test_shader_constants_real_no_hex_data`
+
+## Phase 6: Verify
+
+- [ ] `pixi run lint` — clean
+- [ ] `pixi run test` — all unit tests pass, zero regressions
+- [ ] `pixi run test-gpu` — GPU integration tests pass

--- a/openspec/changes/2026-02-22-design-deviation-shader-api-fix/test-plan.md
+++ b/openspec/changes/2026-02-22-design-deviation-shader-api-fix/test-plan.md
@@ -1,0 +1,121 @@
+# Test Plan: Fix Design Deviations in Shader Handlers
+
+## Scope
+
+- **In scope**: Unit tests for `shader_source` debug-info branching and `shader_constants`
+  structured variable output. GPU integration tests verifying both handlers against a real
+  capture.
+- **Out of scope**: Tests for other shader handlers (`shader_disasm`, `shader_reflect`,
+  `shader_targets`, `shader_all`, `shader_list_info`, `shader_list_disasm`). No changes
+  to those handlers.
+
+## Test Matrix
+
+| Layer | GPU? | File | What |
+|-------|------|------|------|
+| Unit | No | `test_daemon_shader_extended.py` | Update existing shader_source / shader_constants tests |
+| Unit | No | `test_daemon_shader_api_fix.py` | Update debug-info branching tests; add structured-vars tests |
+| Integration | Yes | `test_daemon_handlers_real.py` | GPU tests for both fixes against vkcube.rdc |
+
+## Unit Tests — `shader_source`
+
+### `test_shader_source_no_debug_info_returns_disasm`
+Setup: PS shader with `debugInfo.files = []`.
+Assert: `result["has_debug_info"] is False`, `result["source"]` contains disassembly text,
+`result["files"] == []`.
+
+### `test_shader_source_with_debug_info_returns_files`
+Setup: PS shader with `debugInfo.files = [SourceFile(filename="main.hlsl", contents="void main() {}")]`.
+Assert: `result["has_debug_info"] is True`, `result["files"]` has one entry with
+`filename == "main.hlsl"` and `source == "void main() {}"`, `result["source"] == ""`.
+
+### `test_shader_source_with_multiple_debug_files`
+Setup: PS shader with two `SourceFile` entries in `debugInfo.files`.
+Assert: `result["files"]` has length 2, both filenames present, `has_debug_info is True`.
+
+### `test_shader_source_no_reflection_returns_empty`
+(Existing test — must still pass unchanged: `source == ""`, `has_debug_info is False`.)
+
+### `test_shader_source_uses_disassemble_shader` (existing)
+Must still pass. With no debug files, disassembly path is taken.
+
+### `test_shader_source_compute_uses_compute_pipeline` (existing)
+Must still pass. No debug files in setup, so disassembly path.
+
+## Unit Tests — `shader_constants`
+
+### `test_shader_constants_returns_structured_variables`
+Setup: PS shader with one `ConstantBlock("Globals", fixedBindNumber=0)`. Pre-populate
+`ctrl._cbuffer_variables[(ShaderStage.Pixel, 0)]` with:
+```python
+[ShaderVariable(name="g_Color", type="float4", rows=1, columns=4,
+                value=ShaderValue(f32v=[1.0, 0.5, 0.0, 1.0] + [0.0]*12))]
+```
+Assert: `result["constants"][0]["name"] == "Globals"`,
+`result["constants"][0]["variables"][0]["name"] == "g_Color"`,
+`result["constants"][0]["variables"][0]["value"] == [1.0, 0.5, 0.0, 1.0]` (4 elements),
+`result["constants"][0]["variables"][0]["type"] == "float4"`.
+
+### `test_shader_constants_struct_variable_recurses`
+Setup: One cbuffer with a nested struct `ShaderVariable` (has `.members` with two child
+`ShaderVariable`s, no `.value`).
+Assert: top-level variable has `"members"` key with length 2; leaf members have `"value"`.
+
+### `test_shader_constants_empty_cbuffer`
+Setup: One `ConstantBlock` but `ctrl._cbuffer_variables` has no entry for that slot
+(returns `[]` from `GetCBufferVariableContents`).
+Assert: `result["constants"][0]["variables"] == []`.
+
+### `test_shader_constants_multiple_cbuffers`
+Setup: Two `ConstantBlock`s in `refl.constantBlocks`. Each has one variable in mock.
+Assert: `result["constants"]` has length 2, each entry has correct `name` and one variable.
+
+### `test_shader_constants_calls_get_cbuffer_variable_contents`
+Spy on `ctrl.GetCBufferVariableContents`. Verify it is called (not `GetConstantBuffer`).
+Assert: spy called at least once; `GetConstantBuffer` is NOT called.
+
+### `test_shader_constants_invalid_stage` (existing — must pass)
+### `test_shader_constants_no_adapter` (existing — must pass)
+
+## GPU Integration Tests
+
+Add to `TestDaemonHandlersReal` in `tests/integration/test_daemon_handlers_real.py`.
+Use the existing `vkcube.rdc` fixture. Find a draw EID with a PS shader bound.
+
+### `test_shader_source_real_no_debug_info`
+Call `shader_source` on a PS stage of vkcube.rdc. Since vkcube is compiled without debug
+info, assert: `result["has_debug_info"] is False`, `result["source"]` is non-empty string
+(disassembly), `result["files"] == []`.
+
+### `test_shader_source_real_fields_present`
+Assert response contains all required keys: `eid`, `stage`, `has_debug_info`, `source`,
+`files`.
+
+### `test_shader_constants_real_structured`
+Call `shader_constants` on a PS stage. Assert: `result["constants"]` is a list;
+each entry has `name`, `bind_point`, `variables`; `variables` is a list (may be empty
+if no cbuffer bound, but must not be a hex string).
+
+### `test_shader_constants_real_no_hex_data`
+Assert that no entry in `result["constants"]` contains a `"data"` key (old hex field
+must be gone entirely).
+
+## Mock Verification
+
+Confirm existing mock types suffice (no mock changes expected):
+- `ShaderDebugInfo` has `files: list` field
+- `SourceFile` has `filename: str` and `contents: str`
+- `ShaderVariable` has `name`, `type`, `rows`, `columns`, `value`, `members`
+- `ShaderValue` has `f32v`, `u32v`, `s32v` lists
+- `MockPipeState.GetConstantBlock(stage, slot, array_idx)` returns `Descriptor`
+- `MockReplayController.GetCBufferVariableContents(...)` returns from `_cbuffer_variables`
+- `MockReplayController` does NOT have `GetConstantBuffer` (so the old `hasattr` guard
+  will naturally test the fallback path if needed)
+
+## Regression Guard
+
+All tests in `test_daemon_shader_extended.py` and `test_daemon_shader_api_fix.py` must
+continue to pass. The `shader_disasm` handler is unchanged and its tests must pass without
+modification.
+
+Run: `pixi run lint && pixi run test`

--- a/openspec/changes/2026-02-22-design-deviation-vfs-ls-long/proposal.md
+++ b/openspec/changes/2026-02-22-design-deviation-vfs-ls-long/proposal.md
@@ -1,0 +1,128 @@
+# Proposal: VFS ls Long Format (-l flag)
+
+**Date:** 2026-02-22
+**Phase:** Design-deviation fix
+**Status:** Draft
+
+---
+
+## Problem
+
+`rdc ls` is missing the `-l` / `--long` flag specified in `设计/路径寻址设计.md`.
+
+Current behavior:
+- `rdc ls [path]` — bare names, one per line
+- `-F/--classify` appends `/`, `*`, `@` suffixes
+- `--json` emits the raw children array
+- No `-l` flag exists at all
+
+Design requires:
+```
+rdc ls -l /passes       # TSV: NAME  DRAWS  DISPATCHES  TRIANGLES
+rdc ls -l /draws        # TSV: EID  NAME  TYPE  TRIANGLES  INSTANCES
+rdc ls -l /resources    # TSV: ID  NAME  TYPE  SIZE
+rdc ls -l /shaders      # TSV: ID  STAGES  ENTRY  INPUTS  OUTPUTS
+```
+
+---
+
+## Solution
+
+**Option 1 (chosen):** Add `long: bool` to `vfs_ls` RPC. When `true`, the daemon enriches each child entry with context-specific metadata columns. The CLI passes `long=True` when `-l` is given and renders tab-separated output.
+
+**Option 2 (rejected):** CLI makes per-child sub-RPCs to fetch metadata (N+1 calls). Rejected: unacceptable latency for large directories.
+
+---
+
+## Design
+
+### RPC protocol change
+
+`vfs_ls` gains an optional boolean parameter:
+
+```json
+{ "method": "vfs_ls", "params": { "path": "/passes", "long": true } }
+```
+
+Response when `long=false` (existing, backward-compatible):
+```json
+{ "path": "/passes", "kind": "dir", "children": [{"name": "...", "kind": "dir"}] }
+```
+
+Response when `long=true`:
+```json
+{
+  "path": "/passes",
+  "kind": "dir",
+  "long": true,
+  "columns": ["NAME", "DRAWS", "DISPATCHES", "TRIANGLES"],
+  "children": [
+    {"name": "Pass#1", "kind": "dir", "draws": 42, "dispatches": 0, "triangles": 180000}
+  ]
+}
+```
+
+The `columns` array declares which metadata keys are present. The CLI uses it to build the header row.
+
+### Metadata by path context
+
+Path resolution is done by stripping the top-level segment from `path`:
+
+| Path prefix | Header columns | Daemon data source |
+|-------------|---------------|-------------------|
+| `/passes` | `NAME DRAWS DISPATCHES TRIANGLES` | `vfs_tree.pass_list` (already in `DaemonState`) |
+| `/draws` | `EID NAME TYPE TRIANGLES INSTANCES` | `walk_actions` flat action list |
+| `/events` | `EID NAME TYPE` | `walk_actions` flat action list |
+| `/resources` | `ID NAME TYPE SIZE` | `state.res_names`, `state.res_types`, `state.res_rid_map` |
+| `/textures` | `ID NAME WIDTH HEIGHT FORMAT` | `state.tex_map`, `state.res_names` |
+| `/buffers` | `ID NAME LENGTH` | `state.buf_map`, `state.res_names` |
+| `/shaders` | `ID STAGES ENTRY INPUTS OUTPUTS` | `state.shader_meta` (built lazily on first `/shaders` access) |
+| Other dirs | `NAME TYPE` | minimal: just child name + kind |
+
+For `/resources`, SIZE comes from `state.res_rid_map` attributes (`byteSize` or equivalent).
+
+For `/draws`, the flat list is obtained with `walk_actions(state.adapter.get_root_actions(), state.structured_file)` and filtered to draws-only (already in VFS tree). TRIANGLES = `(num_indices // 3) * num_instances`. TYPE uses the existing `_action_type_str(flags)` helper.
+
+For `/shaders`, the long format is only available after the shader cache is built. The handler calls `_build_shader_cache(state)` if needed before collecting metadata.
+
+INPUTS = count of `readOnlyResources`, OUTPUTS = count of `readWriteResources` from shader reflection stored in `state.shader_meta`. Extend `shader_meta` entries to store `inputs` and `outputs` counts alongside existing `stages`, `uses`, `first_eid`, `entry`.
+
+### CLI change
+
+`ls_cmd` gains a new option:
+
+```python
+@click.option("-l", "--long", "use_long", is_flag=True, help="Long format (TSV with metadata)")
+```
+
+When `-l` is set:
+1. Call `vfs_ls` with `{"path": path, "long": True}`
+2. If response has `long: true`, render with `render_ls_long(children, columns)` from `vfs/formatter.py`
+3. `--json` with `-l` emits the full enriched response as-is (children array with all metadata fields)
+
+`-F/--classify` and `-l` are mutually exclusive (print error and exit 1 if both given).
+
+### Formatter change
+
+Add `render_ls_long(children, columns)` to `src/rdc/vfs/formatter.py`:
+- Prints a TSV header line from `columns`
+- Prints one TSV row per child, substituting `-` for missing/None values
+
+### Backward compatibility
+
+- `long` parameter defaults to `false`; existing callers (including shell completion) are unaffected
+- Existing `children` entries always contain `name` and `kind`; new fields are additive
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/rdc/handlers/vfs.py` | Accept `long` param; dispatch to `_ls_long_children()` helper |
+| `src/rdc/handlers/_helpers.py` | `_build_shader_cache` stores `inputs`/`outputs` counts in `shader_meta` |
+| `src/rdc/commands/vfs.py` | Add `-l`/`--long` flag to `ls_cmd`; enforce `-F`/`-l` mutex; pass `long=True` to RPC |
+| `src/rdc/vfs/formatter.py` | Add `render_ls_long(children, columns)` |
+| `tests/unit/test_vfs_commands.py` | Tests for `-l` CLI flag (mock-based) |
+| `tests/unit/test_vfs_handlers.py` | Tests for `vfs_ls` with `long=True` daemon handler |
+| `tests/integration/test_daemon_handlers_real.py` | GPU integration tests for `-l` on real capture |

--- a/openspec/changes/2026-02-22-design-deviation-vfs-ls-long/tasks.md
+++ b/openspec/changes/2026-02-22-design-deviation-vfs-ls-long/tasks.md
@@ -1,0 +1,105 @@
+# Tasks: VFS ls Long Format (-l flag)
+
+## Agent Assignment
+
+Single worktree. All files are in one logical change with no conflicting parallel paths.
+
+| Commit | Files | Notes |
+|--------|-------|-------|
+| 1 — feat(vfs): extend vfs_ls RPC with long mode | `handlers/vfs.py`, `handlers/_helpers.py` | Daemon-only change |
+| 2 — feat(vfs): add -l flag to rdc ls and render_ls_long formatter | `commands/vfs.py`, `vfs/formatter.py` | CLI + formatter |
+| 3 — test: cover vfs_ls long mode (unit + integration) | test files | Tests only |
+
+---
+
+## Commit 1: `feat(vfs): extend vfs_ls RPC with long mode`
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `src/rdc/handlers/vfs.py` | Read `long = bool(params.get("long", False))` in `_handle_vfs_ls`; when true, call new `_ls_long_children(path, node, state)` helper; include `long=True` and `columns` in result |
+| `src/rdc/handlers/_helpers.py` | In `_build_shader_cache`, store `inputs` (len of `readOnlyResources`) and `outputs` (len of `readWriteResources`) into each `state.shader_meta[sid]` entry |
+
+### New internal helper in `handlers/vfs.py`
+
+`_ls_long_children(path: str, node: VfsNode, state: DaemonState) -> tuple[list[str], list[dict]]`
+
+Dispatches on top-level path segment:
+- `/passes` — iterate `state.vfs_tree.pass_list`; match child names; return draws/dispatches/triangles from pass stats
+- `/draws` — call `walk_actions` on root actions; build eid→FlatAction map; for each child EID look up name, flags, num_indices, num_instances; compute triangles and type string via `_action_type_str`
+- `/events` — same walk; return eid, name, type for all events
+- `/resources` — for each child name (resource ID): look up `state.res_names`, `state.res_types`, `state.res_rid_map`; extract size via `getattr(rid_obj, "byteSize", "-")`
+- `/textures` — for each child ID: look up `state.tex_map`; return width, height, format name (via `fmt.Name()` if available)
+- `/buffers` — for each child ID: look up `state.buf_map`; return length
+- `/shaders` — ensure `_build_shader_cache` called; for each child ID look up `state.shader_meta`; return stages (comma-joined), entry, inputs, outputs
+- default — return `["NAME", "TYPE"]` with only name and kind per child
+
+---
+
+## Commit 2: `feat(vfs): add -l flag to rdc ls and render_ls_long formatter`
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `src/rdc/commands/vfs.py` | Add `@click.option("-l", "--long", "use_long", is_flag=True, help="Long format (TSV)")` to `ls_cmd`; guard `-l` and `-F` mutual exclusion with a check + `raise SystemExit(1)`; when `use_long`, pass `"long": True` in RPC params; if `use_json`, pass enriched result to `write_json`; else call `render_ls_long(children, columns)` |
+| `src/rdc/vfs/formatter.py` | Add `render_ls_long(children: list[dict], columns: list[str]) -> str`; header = `"\t".join(columns)`; rows = one tab-joined line per child where each value is `str(child.get(col.lower(), "-") or "-")`; return `"\n".join([header, *rows])` |
+
+### Key details
+
+- Column key mapping: column header (uppercase) → child dict key (lowercase). E.g. `"DRAWS"` → `child["draws"]`.
+- `-F` and `-l` check: `if classify and use_long: click.echo("error: -F and -l are mutually exclusive", err=True); raise SystemExit(1)`
+- When `use_long` but response does not contain `"long": true` (e.g. path has no long schema), fall back to bare name rendering with a warning on stderr.
+
+---
+
+## Commit 3: `test: cover vfs_ls long mode`
+
+### New Test File
+
+| File | Content |
+|------|---------|
+| `tests/unit/test_vfs_formatter.py` | Unit tests for `render_ls_long` and regression tests for `render_ls` |
+
+### Updated Test Files
+
+| File | Tests Added |
+|------|-------------|
+| `tests/unit/test_vfs_handlers.py` | 14 new tests for `_handle_vfs_ls` with `long=True` across all path contexts (see test-plan.md) |
+| `tests/unit/test_vfs_commands.py` | 8 new tests for `-l` CLI flag behavior (see test-plan.md) |
+| `tests/integration/test_daemon_handlers_real.py` | 7 new GPU integration tests in `TestVfsLsLong` class (see test-plan.md) |
+
+---
+
+## File Conflict Analysis
+
+| File | Worktree |
+|------|----------|
+| `src/rdc/handlers/vfs.py` | Single agent |
+| `src/rdc/handlers/_helpers.py` | Single agent |
+| `src/rdc/commands/vfs.py` | Single agent |
+| `src/rdc/vfs/formatter.py` | Single agent |
+| `tests/unit/test_vfs_formatter.py` | Single agent (new file) |
+| `tests/unit/test_vfs_handlers.py` | Single agent |
+| `tests/unit/test_vfs_commands.py` | Single agent |
+| `tests/integration/test_daemon_handlers_real.py` | Single agent |
+
+No parallel split needed; all files belong to one feature boundary.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `rdc ls -l /passes` outputs a TSV with header `NAME\tDRAWS\tDISPATCHES\tTRIANGLES`
+- [ ] `rdc ls -l /draws` outputs a TSV with header `EID\tNAME\tTYPE\tTRIANGLES\tINSTANCES`
+- [ ] `rdc ls -l /resources` outputs a TSV with header `ID\tNAME\tTYPE\tSIZE`
+- [ ] `rdc ls -l /shaders` outputs a TSV with header `ID\tSTAGES\tENTRY\tINPUTS\tOUTPUTS`
+- [ ] `rdc ls -l /textures` outputs a TSV with header `ID\tNAME\tWIDTH\tHEIGHT\tFORMAT`
+- [ ] `rdc ls -l /buffers` outputs a TSV with header `ID\tNAME\tLENGTH`
+- [ ] `rdc ls -l --json /passes` emits valid JSON with `columns` and enriched children
+- [ ] `rdc ls -l -F` exits with code 1 and a clear mutual-exclusion error
+- [ ] `rdc ls /passes` without `-l` still outputs bare names (no regression)
+- [ ] `vfs_ls` without `long` param returns existing format (no regression)
+- [ ] `pixi run lint && pixi run test` passes with zero failures
+- [ ] Coverage remains >= 95%

--- a/openspec/changes/2026-02-22-design-deviation-vfs-ls-long/test-plan.md
+++ b/openspec/changes/2026-02-22-design-deviation-vfs-ls-long/test-plan.md
@@ -1,0 +1,134 @@
+# Test Plan: VFS ls Long Format (-l flag)
+
+## Overview
+
+Tests for adding `-l`/`--long` to `rdc ls` and extending `vfs_ls` RPC with `long: bool`.
+
+Estimated new test cases: ~28
+Target: maintain >= 95% coverage.
+
+---
+
+## Unit Tests
+
+### `tests/unit/test_vfs_handlers.py` — daemon handler
+
+New tests for `_handle_vfs_ls` with `long=True`:
+
+| Test name | Description |
+|-----------|-------------|
+| `test_vfs_ls_long_false_unchanged` | `long=False` (default) returns existing format — no `columns`, no extra fields in children |
+| `test_vfs_ls_long_passes` | `long=True` on `/passes` returns `columns=["NAME","DRAWS","DISPATCHES","TRIANGLES"]` and children with those fields |
+| `test_vfs_ls_long_draws` | `long=True` on `/draws` returns `columns=["EID","NAME","TYPE","TRIANGLES","INSTANCES"]` |
+| `test_vfs_ls_long_events` | `long=True` on `/events` returns `columns=["EID","NAME","TYPE"]` |
+| `test_vfs_ls_long_resources` | `long=True` on `/resources` returns `columns=["ID","NAME","TYPE","SIZE"]` |
+| `test_vfs_ls_long_textures` | `long=True` on `/textures` returns `columns=["ID","NAME","WIDTH","HEIGHT","FORMAT"]` |
+| `test_vfs_ls_long_buffers` | `long=True` on `/buffers` returns `columns=["ID","NAME","LENGTH"]` |
+| `test_vfs_ls_long_shaders` | `long=True` on `/shaders` returns `columns=["ID","STAGES","ENTRY","INPUTS","OUTPUTS"]` |
+| `test_vfs_ls_long_other_dir` | `long=True` on `/counters` (no specific schema) returns `columns=["NAME","TYPE"]` |
+| `test_vfs_ls_long_missing_fields_use_dash` | Child missing a metadata field → value is `"-"` not `None` or KeyError |
+| `test_vfs_ls_long_no_adapter_returns_error` | `long=True` when `state.adapter is None` → `-32002` error |
+| `test_vfs_ls_long_not_found_returns_error` | `long=True` on non-existent path → `-32001` error |
+| `test_vfs_ls_long_draws_triangles_computed` | Triangle count = `(num_indices // 3) * num_instances` |
+| `test_vfs_ls_long_draws_type_str` | Draw type string matches `_action_type_str()` result (Draw/DrawIndexed/Dispatch/Clear) |
+
+---
+
+### `tests/unit/test_vfs_commands.py` — CLI command
+
+Add to existing test file:
+
+| Test name | Description |
+|-----------|-------------|
+| `test_ls_long_calls_rpc_with_long_true` | `-l` flag causes `_daemon_call("vfs_ls", {"path": ..., "long": True})` |
+| `test_ls_long_renders_tsv_header` | Response with `columns` → first output line is tab-separated header |
+| `test_ls_long_renders_tsv_rows` | Each child row is tab-separated with correct field order |
+| `test_ls_long_missing_value_renders_dash` | Child entry missing a metadata key → `-` in that column |
+| `test_ls_long_json_emits_full_response` | `-l --json` → JSON output includes `columns` and enriched children |
+| `test_ls_long_classify_mutex` | `-l -F` together → exit code 1, error message mentioning mutual exclusion |
+| `test_ls_long_empty_directory` | `long=True` response with zero children → only header line, no rows |
+| `test_ls_no_long_default_unchanged` | Without `-l`, existing short format still works (regression) |
+
+---
+
+### `tests/unit/test_vfs_formatter.py` (new file)
+
+| Test name | Description |
+|-----------|-------------|
+| `test_render_ls_long_header_row` | First line matches `"\t".join(columns)` |
+| `test_render_ls_long_data_rows` | Each child produces a row with fields in column order |
+| `test_render_ls_long_none_field_becomes_dash` | A `None` value in a child dict → `-` in output |
+| `test_render_ls_long_empty_children` | No children → only the header line returned |
+| `test_render_ls_short_unchanged` | Existing `render_ls` still works (regression) |
+
+---
+
+## CLI Tests
+
+All CLI tests use `click.testing.CliRunner` with `monkeypatch` on `rdc.commands.vfs._daemon_call`.
+
+Mock response shape for `-l` tests:
+
+```python
+{
+    "path": "/passes",
+    "kind": "dir",
+    "long": True,
+    "columns": ["NAME", "DRAWS", "DISPATCHES", "TRIANGLES"],
+    "children": [
+        {"name": "Pass#1", "kind": "dir", "draws": 10, "dispatches": 0, "triangles": 5000},
+    ],
+}
+```
+
+---
+
+## GPU Integration Tests
+
+### `tests/integration/test_daemon_handlers_real.py`
+
+Add a new `TestVfsLsLong` class using the existing real-capture session fixture:
+
+| Test name | Description |
+|-----------|-------------|
+| `test_vfs_ls_long_passes_real` | `vfs_ls(path="/passes", long=True)` on real capture → `columns` matches expected header, each child has numeric `draws`/`dispatches`/`triangles` |
+| `test_vfs_ls_long_draws_real` | `vfs_ls(path="/draws", long=True)` → EID values match known draw EIDs, TYPE is a known string |
+| `test_vfs_ls_long_resources_real` | `vfs_ls(path="/resources", long=True)` → ID values are non-zero integers, SIZE is int or `-` |
+| `test_vfs_ls_long_textures_real` | `vfs_ls(path="/textures", long=True)` → WIDTH and HEIGHT are positive integers |
+| `test_vfs_ls_long_buffers_real` | `vfs_ls(path="/buffers", long=True)` → LENGTH is non-negative integer |
+| `test_vfs_ls_long_shaders_real` | `vfs_ls(path="/shaders", long=True)` → STAGES is a comma-joined string like `"ps"` or `"vs,ps"` |
+| `test_vfs_ls_long_backward_compat_real` | `vfs_ls(path="/passes")` without `long` → no `columns` key, children have only `name`+`kind` |
+
+---
+
+## Coverage Expectations
+
+| Area | New cases | Notes |
+|------|-----------|-------|
+| Daemon handler (unit) | 14 | All path contexts + edge cases |
+| CLI command (unit) | 8 | Flag behavior, rendering, mutex |
+| Formatter (unit) | 5 | New `render_ls_long` function |
+| GPU integration | 7 | Real capture validation |
+| **Total** | **~34** | |
+
+- All unit tests run without GPU (`pixi run test`)
+- GPU tests run with `pixi run test-gpu`
+- Overall coverage must remain >= 95%
+
+---
+
+## Test Matrix
+
+| Dimension | Value |
+|-----------|-------|
+| Python | 3.10, 3.12 (pixi matrix) |
+| Platform | Linux (primary) |
+| GPU | Unit tests: none; Integration: real capture required |
+| CI | `pixi run lint && pixi run test` |
+
+### Fixtures and helpers
+
+- Handler tests: `DaemonState` + `MockReplayController` from `tests/mocks/mock_renderdoc.py`; populate `vfs_tree`, `tex_map`, `buf_map`, `res_names`, `shader_meta` with synthetic data
+- CLI tests: `CliRunner` + `monkeypatch` on `rdc.commands.vfs._daemon_call`
+- Formatter tests: direct function calls, no fixtures needed
+- GPU tests: session-scoped real-capture fixture already defined in `tests/integration/test_daemon_handlers_real.py`

--- a/src/rdc/diff/__init__.py
+++ b/src/rdc/diff/__init__.py
@@ -7,6 +7,7 @@ from rdc.diff.draws import (
     diff_draws,
     render_json,
     render_shortstat,
+    render_tsv,
     render_unified,
 )
 
@@ -18,5 +19,6 @@ __all__ = [
     "diff_draws",
     "render_json",
     "render_shortstat",
+    "render_tsv",
     "render_unified",
 ]

--- a/src/rdc/diff/draws.py
+++ b/src/rdc/diff/draws.py
@@ -213,6 +213,32 @@ def render_shortstat(rows: list[DrawDiffRow]) -> str:
     return f"{added} added, {deleted} deleted, {modified} modified, {unchanged} unchanged"
 
 
+def render_tsv(rows: list[DrawDiffRow], *, header: bool = True) -> str:
+    """Render rows as tab-separated values.
+
+    Args:
+        rows: Diff rows to render.
+        header: Include header line.
+
+    Returns:
+        TSV string.
+    """
+    lines: list[str] = []
+    if header:
+        lines.append("STATUS\tEID_A\tEID_B\tMARKER\tTYPE\tTRI_A\tTRI_B\tINST_A\tINST_B\tCONFIDENCE")
+
+    def _v(x: int | None) -> str:
+        return str(x) if x is not None else "-"
+
+    for r in rows:
+        lines.append(
+            f"{r.status.value}\t{_v(r.eid_a)}\t{_v(r.eid_b)}\t{r.marker}\t{r.draw_type}"
+            f"\t{_v(r.triangles_a)}\t{_v(r.triangles_b)}"
+            f"\t{_v(r.instances_a)}\t{_v(r.instances_b)}\t{r.confidence}"
+        )
+    return "\n".join(lines)
+
+
 def render_json(rows: list[DrawDiffRow]) -> str:
     """Render rows as a JSON array.
 

--- a/src/rdc/handlers/_helpers.py
+++ b/src/rdc/handlers/_helpers.py
@@ -209,6 +209,8 @@ def _build_shader_cache(state: DaemonState) -> None:
             "uses": len(shader_eids[sid]),
             "first_eid": first_eid,
             "entry": getattr(refl, "entryPoint", "main") if refl else "main",
+            "inputs": len(getattr(refl, "readOnlyResources", [])) if refl else 0,
+            "outputs": len(getattr(refl, "readWriteResources", [])) if refl else 0,
         }
 
     state._shader_cache_built = True

--- a/src/rdc/handlers/vfs.py
+++ b/src/rdc/handlers/vfs.py
@@ -5,15 +5,254 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from rdc.handlers._helpers import (
+    _action_type_str,
     _build_shader_cache,
     _ensure_shader_populated,
     _error_response,
+    _get_flat_actions,
     _resolve_vfs_path,
     _result_response,
 )
 
 if TYPE_CHECKING:
     from rdc.daemon_server import DaemonState
+    from rdc.vfs.tree_cache import VfsNode
+
+# Column definitions per path context
+_COLUMNS: dict[str, list[str]] = {
+    "passes": ["NAME", "DRAWS", "DISPATCHES", "TRIANGLES"],
+    "draws": ["EID", "NAME", "TYPE", "TRIANGLES", "INSTANCES"],
+    "events": ["EID", "NAME", "TYPE"],
+    "resources": ["ID", "NAME", "TYPE", "SIZE"],
+    "textures": ["ID", "NAME", "WIDTH", "HEIGHT", "FORMAT"],
+    "buffers": ["ID", "NAME", "LENGTH"],
+    "shaders": ["ID", "STAGES", "ENTRY", "INPUTS", "OUTPUTS"],
+}
+_DEFAULT_COLUMNS = ["NAME", "TYPE"]
+
+
+def _ls_long_children(
+    path: str, node: VfsNode, state: DaemonState
+) -> tuple[list[str], list[dict[str, Any]]]:
+    """Enrich children with metadata based on path context.
+
+    Returns:
+        Tuple of (columns, enriched_children).
+    """
+    segments = [s for s in path.strip("/").split("/") if s]
+    context = segments[0] if segments else ""
+    depth = len(segments)
+
+    parent = path.rstrip("/")
+
+    # Context-specific enrichment only at top level (e.g., /draws, /passes)
+    if depth == 1 and context in _COLUMNS:
+        columns = _COLUMNS[context]
+        if context == "passes":
+            children = _long_passes(node, state)
+        elif context == "draws":
+            children = _long_draws(node, parent, state)
+        elif context == "events":
+            children = _long_events(node, parent, state)
+        elif context == "resources":
+            children = _long_resources(node, state)
+        elif context == "textures":
+            children = _long_textures(node, state)
+        elif context == "buffers":
+            children = _long_buffers(node, state)
+        else:  # shaders
+            children = _long_shaders(node, state)
+    else:
+        columns = _DEFAULT_COLUMNS
+        children = _long_default(node, parent, state)
+
+    return columns, children
+
+
+def _long_passes(node: VfsNode, state: DaemonState) -> list[dict[str, Any]]:
+    pass_map = {p["name"]: p for p in (state.vfs_tree.pass_list or [])}
+    safe_map = state.vfs_tree.pass_name_map
+    result: list[dict[str, Any]] = []
+    for name in node.children:
+        orig = safe_map.get(name, name)
+        p = pass_map.get(orig, {})
+        result.append(
+            {
+                "name": name,
+                "kind": "dir",
+                "draws": p.get("draws", "-"),
+                "dispatches": p.get("dispatches", "-"),
+                "triangles": p.get("triangles", "-"),
+            }
+        )
+    return result
+
+
+def _long_draws(node: VfsNode, parent: str, state: DaemonState) -> list[dict[str, Any]]:
+    flat = _get_flat_actions(state)
+    eid_map = {str(a.eid): a for a in flat}
+    result: list[dict[str, Any]] = []
+    for name in node.children:
+        child_path = f"{parent}/{name}" if parent != "/" else f"/{name}"
+        child_node = state.vfs_tree.static.get(child_path)
+        a = eid_map.get(name)
+        if a:
+            triangles = (a.num_indices // 3) * a.num_instances
+            result.append(
+                {
+                    "name": name,
+                    "kind": child_node.kind if child_node else "dir",
+                    "eid": a.eid,
+                    "type": _action_type_str(a.flags),
+                    "triangles": triangles,
+                    "instances": a.num_instances,
+                }
+            )
+        else:
+            result.append(
+                {
+                    "name": name,
+                    "kind": child_node.kind if child_node else "dir",
+                    "eid": "-",
+                    "type": "-",
+                    "triangles": "-",
+                    "instances": "-",
+                }
+            )
+    return result
+
+
+def _long_events(node: VfsNode, parent: str, state: DaemonState) -> list[dict[str, Any]]:
+    flat = _get_flat_actions(state)
+    eid_map = {str(a.eid): a for a in flat}
+    result: list[dict[str, Any]] = []
+    for name in node.children:
+        child_path = f"{parent}/{name}" if parent != "/" else f"/{name}"
+        child_node = state.vfs_tree.static.get(child_path)
+        a = eid_map.get(name)
+        if a:
+            result.append(
+                {
+                    "name": name,
+                    "kind": child_node.kind if child_node else "leaf",
+                    "eid": a.eid,
+                    "type": _action_type_str(a.flags),
+                }
+            )
+        else:
+            result.append(
+                {
+                    "name": name,
+                    "kind": child_node.kind if child_node else "leaf",
+                    "eid": "-",
+                    "type": "-",
+                }
+            )
+    return result
+
+
+def _long_resources(node: VfsNode, state: DaemonState) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for name in node.children:
+        rid_int = int(name) if name.isdigit() else 0
+        res_type = state.res_types.get(rid_int, "-")
+        rid_obj = state.res_rid_map.get(rid_int)
+        size = getattr(rid_obj, "byteSize", "-") if rid_obj else "-"
+        result.append(
+            {
+                "name": name,
+                "kind": "dir",
+                "id": rid_int,
+                "type": res_type,
+                "size": size,
+            }
+        )
+    return result
+
+
+def _long_textures(node: VfsNode, state: DaemonState) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for name in node.children:
+        rid_int = int(name) if name.isdigit() else 0
+        tex = state.tex_map.get(rid_int)
+        if tex:
+            fmt = getattr(tex, "format", None)
+            fmt_name = fmt.Name() if fmt and hasattr(fmt, "Name") else str(fmt) if fmt else "-"
+            result.append(
+                {
+                    "name": name,
+                    "kind": "dir",
+                    "id": rid_int,
+                    "width": getattr(tex, "width", "-"),
+                    "height": getattr(tex, "height", "-"),
+                    "format": fmt_name,
+                }
+            )
+        else:
+            result.append(
+                {
+                    "name": name,
+                    "kind": "dir",
+                    "id": rid_int,
+                    "width": "-",
+                    "height": "-",
+                    "format": "-",
+                }
+            )
+    return result
+
+
+def _long_buffers(node: VfsNode, state: DaemonState) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for name in node.children:
+        rid_int = int(name) if name.isdigit() else 0
+        buf = state.buf_map.get(rid_int)
+        length = getattr(buf, "length", "-") if buf else "-"
+        result.append(
+            {
+                "name": name,
+                "kind": "dir",
+                "id": rid_int,
+                "length": length,
+            }
+        )
+    return result
+
+
+def _long_shaders(node: VfsNode, state: DaemonState) -> list[dict[str, Any]]:
+    _build_shader_cache(state)
+    result: list[dict[str, Any]] = []
+    for name in node.children:
+        sid = int(name) if name.isdigit() else 0
+        meta = state.shader_meta.get(sid, {})
+        stages = ",".join(meta.get("stages", []))
+        result.append(
+            {
+                "name": name,
+                "kind": "dir",
+                "id": sid,
+                "stages": stages or "-",
+                "entry": meta.get("entry", "-"),
+                "inputs": meta.get("inputs", "-"),
+                "outputs": meta.get("outputs", "-"),
+            }
+        )
+    return result
+
+
+def _long_default(node: VfsNode, parent: str, state: DaemonState) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for name in node.children:
+        child_path = f"{parent}/{name}" if parent != "/" else f"/{name}"
+        child_node = state.vfs_tree.static.get(child_path)
+        result.append(
+            {
+                "name": name,
+                "kind": child_node.kind if child_node else "dir",
+                "type": child_node.kind if child_node else "dir",
+            }
+        )
+    return result
 
 
 def _handle_vfs_ls(
@@ -22,6 +261,7 @@ def _handle_vfs_ls(
     if state.adapter is None:
         return _error_response(request_id, -32002, "no replay loaded"), True
     path = str(params.get("path", "/"))
+    long = bool(params.get("long", False))
     path, err = _resolve_vfs_path(path, state)
     if err:
         return _error_response(request_id, -32002, err), True
@@ -40,14 +280,24 @@ def _handle_vfs_ls(
     if node is None:
         return _error_response(request_id, -32001, f"not found: {path}"), True
 
-    parent = path.rstrip("/")
-    children = []
-    for c in node.children:
-        child_path = f"{parent}/{c}" if parent != "/" else f"/{c}"
-        child_node = state.vfs_tree.static.get(child_path)
-        children.append({"name": c, "kind": child_node.kind if child_node else "dir"})
+    if long and node.kind == "dir":
+        columns, children = _ls_long_children(path, node, state)
+        result: dict[str, Any] = {
+            "path": path,
+            "kind": node.kind,
+            "long": True,
+            "columns": columns,
+            "children": children,
+        }
+    else:
+        parent = path.rstrip("/")
+        children_list: list[dict[str, Any]] = []
+        for c in node.children:
+            child_path = f"{parent}/{c}" if parent != "/" else f"/{c}"
+            child_node = state.vfs_tree.static.get(child_path)
+            children_list.append({"name": c, "kind": child_node.kind if child_node else "dir"})
+        result = {"path": path, "kind": node.kind, "children": children_list}
 
-    result = {"path": path, "kind": node.kind, "children": children}
     return _result_response(request_id, result), True
 
 

--- a/src/rdc/vfs/formatter.py
+++ b/src/rdc/vfs/formatter.py
@@ -10,6 +10,24 @@ from typing import Any
 _CLASSIFY: dict[str, str] = {"dir": "/", "leaf_bin": "*", "alias": "@", "leaf": ""}
 
 
+def render_ls_long(children: list[dict[str, Any]], columns: list[str]) -> str:
+    """Render long-format ls output as TSV with header row.
+
+    Args:
+        children: List of child dicts with metadata fields.
+        columns: Column headers (uppercase); child keys are lowercase.
+    """
+    header = "\t".join(columns)
+    rows: list[str] = [header]
+    for child in children:
+        vals: list[str] = []
+        for col in columns:
+            v = child.get(col.lower())
+            vals.append(str(v) if v is not None else "-")
+        rows.append("\t".join(vals))
+    return "\n".join(rows)
+
+
 def render_ls(children: list[dict[str, str]], *, classify: bool = False) -> str:
     """Render ls output: one name per line, optional -F classification suffix.
 

--- a/tests/unit/test_daemon_shader_extended.py
+++ b/tests/unit/test_daemon_shader_extended.py
@@ -105,6 +105,9 @@ def test_shader_constants() -> None:
     assert r["stage"] == "ps"
     assert len(r["constants"]) == 1
     assert r["constants"][0]["name"] == "Globals"
+    assert "variables" in r["constants"][0]
+    assert isinstance(r["constants"][0]["variables"], list)
+    assert "data" not in r["constants"][0]
 
 
 def test_shader_constants_invalid_stage() -> None:
@@ -128,6 +131,8 @@ def test_shader_source() -> None:
     assert r["stage"] == "ps"
     assert "source" in r
     assert "has_debug_info" in r
+    assert "files" in r
+    assert isinstance(r["files"], list)
 
 
 def test_shader_source_invalid_stage() -> None:

--- a/tests/unit/test_diff_command.py
+++ b/tests/unit/test_diff_command.py
@@ -1,6 +1,10 @@
+"""Tests for the rdc diff CLI command."""
+
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -26,8 +30,107 @@ def _make_ctx() -> DiffContext:
     )
 
 
+def _draws_resp(
+    draws: list[dict[str, object]] | None = None,
+) -> dict[str, Any]:
+    if draws is None:
+        draws = [
+            {
+                "eid": 10,
+                "type": "DrawIndexed",
+                "triangles": 100,
+                "instances": 1,
+                "pass": "GBuffer",
+                "marker": "Floor",
+            },
+        ]
+    return {"result": {"draws": draws, "summary": f"{len(draws)} draw calls"}}
+
+
+def _stats_resp(
+    per_pass: list[dict[str, object]] | None = None,
+    event_count: int = 100,
+) -> dict[str, Any]:
+    if per_pass is None:
+        per_pass = [{"name": "GBuffer", "draws": 10, "triangles": 5000, "dispatches": 0}]
+    return {"result": {"per_pass": per_pass, "event_count": event_count, "top_draws": []}}
+
+
+def _resources_resp(
+    rows: list[dict[str, object]] | None = None,
+) -> dict[str, Any]:
+    if rows is None:
+        rows = [{"id": 1, "type": "Texture2D", "name": "albedo"}]
+    return {"result": {"rows": rows}}
+
+
+def _patch_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    stats_a: dict[str, Any] | None = None,
+    stats_b: dict[str, Any] | None = None,
+    res_a: dict[str, Any] | None = None,
+    res_b: dict[str, Any] | None = None,
+) -> None:
+    """Patch diff module for summary mode (default)."""
+    ctx = _make_ctx()
+    sa = stats_a or _stats_resp()
+    sb = stats_b or _stats_resp()
+    ra = res_a or _resources_resp()
+    rb = res_b or _resources_resp()
+
+    monkeypatch.setattr(diff_mod, "start_diff_session", lambda *a, **kw: (ctx, ""))
+    monkeypatch.setattr(diff_mod, "stop_diff_session", lambda c: None)
+
+    def mock_query_both(c: object, method: str, params: object, **kw: object) -> tuple[Any, ...]:
+        if method == "stats":
+            return sa, sb, ""
+        if method == "resources":
+            return ra, rb, ""
+        return None, None, "unexpected"
+
+    monkeypatch.setattr(diff_mod, "query_both", mock_query_both)
+
+
+def _patch_draws(
+    monkeypatch: pytest.MonkeyPatch,
+    draws_a: dict[str, Any] | None = None,
+    draws_b: dict[str, Any] | None = None,
+) -> None:
+    """Patch diff module for --draws mode."""
+    ctx = _make_ctx()
+    da = draws_a or _draws_resp()
+    db = draws_b or _draws_resp()
+
+    monkeypatch.setattr(diff_mod, "start_diff_session", lambda *a, **kw: (ctx, ""))
+    monkeypatch.setattr(diff_mod, "stop_diff_session", lambda c: None)
+    monkeypatch.setattr(
+        diff_mod,
+        "query_both",
+        lambda c, m, p, **kw: (da, db, ""),
+    )
+
+
+def _patch_passes(
+    monkeypatch: pytest.MonkeyPatch,
+    stats_a: dict[str, Any] | None = None,
+    stats_b: dict[str, Any] | None = None,
+) -> None:
+    """Patch diff module for --passes mode."""
+    ctx = _make_ctx()
+    sa = stats_a or _stats_resp()
+    sb = stats_b or _stats_resp()
+
+    monkeypatch.setattr(diff_mod, "start_diff_session", lambda *a, **kw: (ctx, ""))
+    monkeypatch.setattr(diff_mod, "stop_diff_session", lambda c: None)
+    monkeypatch.setattr(
+        diff_mod,
+        "query_both",
+        lambda c, m, p, **kw: (sa, sb, ""),
+    )
+
+
 # ---------------------------------------------------------------------------
-# #26  Happy path → exit 0
+# #26  Happy path → exit 0 (summary, identical)
 # ---------------------------------------------------------------------------
 
 
@@ -37,9 +140,7 @@ def test_diff_happy_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Non
     a.touch()
     b.touch()
 
-    ctx = _make_ctx()
-    monkeypatch.setattr(diff_mod, "start_diff_session", lambda *a, **kw: (ctx, ""))
-    monkeypatch.setattr(diff_mod, "stop_diff_session", lambda c: None)
+    _patch_summary(monkeypatch)
 
     runner = CliRunner()
     result = runner.invoke(diff_cmd, [str(a), str(b)])
@@ -65,6 +166,15 @@ def test_diff_timeout_forwarded(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
 
     monkeypatch.setattr(diff_mod, "start_diff_session", mock_start)
     monkeypatch.setattr(diff_mod, "stop_diff_session", lambda c: None)
+    monkeypatch.setattr(
+        diff_mod,
+        "query_both",
+        lambda c, m, p, **kw: (
+            (_stats_resp(), _stats_resp(), "")
+            if m == "stats"
+            else (_resources_resp(), _resources_resp(), "")
+        ),
+    )
 
     runner = CliRunner()
     result = runner.invoke(diff_cmd, [str(a), str(b), "--timeout", "90"])
@@ -103,11 +213,11 @@ def test_diff_startup_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
 
 
 # ---------------------------------------------------------------------------
-# #30  Mode stub raises → cleanup still runs
+# #30  Cleanup always runs (even on query error)
 # ---------------------------------------------------------------------------
 
 
-def test_diff_cleanup_on_stub_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_diff_cleanup_on_query_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     a = tmp_path / "a.rdc"
     b = tmp_path / "b.rdc"
     a.touch()
@@ -117,32 +227,16 @@ def test_diff_cleanup_on_stub_error(monkeypatch: pytest.MonkeyPatch, tmp_path: P
     stop_called = MagicMock()
     monkeypatch.setattr(diff_mod, "start_diff_session", lambda *a, **kw: (ctx, ""))
     monkeypatch.setattr(diff_mod, "stop_diff_session", stop_called)
+    monkeypatch.setattr(
+        diff_mod,
+        "query_both",
+        lambda c, m, p, **kw: (None, None, "both daemons failed"),
+    )
 
     runner = CliRunner()
     result = runner.invoke(diff_cmd, [str(a), str(b), "--draws"])
     assert stop_called.called
     assert result.exit_code == 2
-
-
-# ---------------------------------------------------------------------------
-# #31  --draws → mode dispatched
-# ---------------------------------------------------------------------------
-
-
-def test_diff_draws_mode(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    a = tmp_path / "a.rdc"
-    b = tmp_path / "b.rdc"
-    a.touch()
-    b.touch()
-
-    ctx = _make_ctx()
-    monkeypatch.setattr(diff_mod, "start_diff_session", lambda *a, **kw: (ctx, ""))
-    monkeypatch.setattr(diff_mod, "stop_diff_session", lambda c: None)
-
-    runner = CliRunner()
-    result = runner.invoke(diff_cmd, [str(a), str(b), "--draws"])
-    assert result.exit_code == 2
-    assert "not yet implemented" in result.output.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -160,69 +254,281 @@ def test_diff_pipeline_mode(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
     monkeypatch.setattr(diff_mod, "start_diff_session", lambda *a, **kw: (ctx, ""))
     monkeypatch.setattr(diff_mod, "stop_diff_session", lambda c: None)
 
-    # Pipeline is now implemented — without mocking query_both it
-    # reports "both daemons failed" (exit 2), proving dispatch works.
     runner = CliRunner()
     result = runner.invoke(diff_cmd, [str(a), str(b), "--pipeline", "vs"])
     assert result.exit_code == 2
     assert "both daemons failed" in result.output
 
 
-# ---------------------------------------------------------------------------
-# #33  No flag → summary
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# --draws mode tests (C-01, C-03 through C-09)
+# ===========================================================================
 
 
-def test_diff_default_summary(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    a = tmp_path / "a.rdc"
-    b = tmp_path / "b.rdc"
-    a.touch()
-    b.touch()
+class TestDiffDrawsCLI:
+    def test_draws_identical_exit_0(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-01/C-03: --draws with identical draws exits 0, TSV header present."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        _patch_draws(monkeypatch)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--draws"])
+        assert result.exit_code == 0
+        assert "STATUS" in result.output
 
-    ctx = _make_ctx()
-    monkeypatch.setattr(diff_mod, "start_diff_session", lambda *a, **kw: (ctx, ""))
-    monkeypatch.setattr(diff_mod, "stop_diff_session", lambda c: None)
+    def test_draws_differences_exit_1(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """C-04: --draws with differences exits 1."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        da = _draws_resp(
+            [
+                {
+                    "eid": 10,
+                    "type": "DrawIndexed",
+                    "triangles": 100,
+                    "instances": 1,
+                    "pass": "GBuffer",
+                    "marker": "Floor",
+                },
+            ]
+        )
+        db = _draws_resp(
+            [
+                {
+                    "eid": 10,
+                    "type": "DrawIndexed",
+                    "triangles": 200,
+                    "instances": 1,
+                    "pass": "GBuffer",
+                    "marker": "Floor",
+                },
+            ]
+        )
+        _patch_draws(monkeypatch, da, db)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--draws"])
+        assert result.exit_code == 1
+        assert "~" in result.output
 
-    runner = CliRunner()
-    result = runner.invoke(diff_cmd, [str(a), str(b)])
-    assert result.exit_code == 0
+    def test_draws_shortstat(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-05: --draws --shortstat produces summary line."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        _patch_draws(monkeypatch)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--draws", "--shortstat"])
+        assert result.exit_code == 0
+        assert "unchanged" in result.output
+
+    def test_draws_json(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-06: --draws --format json produces valid JSON."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        _patch_draws(monkeypatch)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--draws", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+    def test_draws_unified(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-07: --draws --format unified starts with --- a/ header."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        _patch_draws(monkeypatch)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--draws", "--format", "unified"])
+        assert result.exit_code == 0
+        assert "--- a/" in result.output
+
+    def test_draws_query_error(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-08: --draws when query fails exits 2."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        ctx = _make_ctx()
+        monkeypatch.setattr(diff_mod, "start_diff_session", lambda *a, **kw: (ctx, ""))
+        monkeypatch.setattr(diff_mod, "stop_diff_session", lambda c: None)
+        monkeypatch.setattr(
+            diff_mod,
+            "query_both",
+            lambda c, m, p, **kw: (None, None, "timeout"),
+        )
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--draws"])
+        assert result.exit_code == 2
+
+    def test_draws_no_header(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-09: --draws --no-header omits header line."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        _patch_draws(monkeypatch)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--draws", "--no-header"])
+        assert result.exit_code == 0
+        assert "STATUS" not in result.output
 
 
-# ---------------------------------------------------------------------------
-# #34  --json forwarded
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# --passes mode tests (C-10 through C-16)
+# ===========================================================================
 
 
-def test_diff_json_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    a = tmp_path / "a.rdc"
-    b = tmp_path / "b.rdc"
-    a.touch()
-    b.touch()
+class TestDiffPassesCLI:
+    def test_passes_identical_exit_0(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-10: --passes with identical passes exits 0."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        _patch_passes(monkeypatch)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--passes"])
+        assert result.exit_code == 0
+        assert "=" in result.output
 
-    ctx = _make_ctx()
-    monkeypatch.setattr(diff_mod, "start_diff_session", lambda *a, **kw: (ctx, ""))
-    monkeypatch.setattr(diff_mod, "stop_diff_session", lambda c: None)
+    def test_passes_added_exit_1(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-11: --passes with pass added exits 1."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        sa = _stats_resp([{"name": "GBuffer", "draws": 10, "triangles": 5000, "dispatches": 0}])
+        sb = _stats_resp(
+            [
+                {"name": "GBuffer", "draws": 10, "triangles": 5000, "dispatches": 0},
+                {"name": "PostFX", "draws": 5, "triangles": 100, "dispatches": 0},
+            ]
+        )
+        _patch_passes(monkeypatch, sa, sb)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--passes"])
+        assert result.exit_code == 1
+        assert "+" in result.output
 
-    runner = CliRunner()
-    result = runner.invoke(diff_cmd, [str(a), str(b), "--json"])
-    assert result.exit_code == 0
+    def test_passes_removed_exit_1(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-12: --passes with pass removed exits 1."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        sa = _stats_resp(
+            [
+                {"name": "GBuffer", "draws": 10, "triangles": 5000, "dispatches": 0},
+                {"name": "Shadow", "draws": 3, "triangles": 200, "dispatches": 0},
+            ]
+        )
+        sb = _stats_resp([{"name": "GBuffer", "draws": 10, "triangles": 5000, "dispatches": 0}])
+        _patch_passes(monkeypatch, sa, sb)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--passes"])
+        assert result.exit_code == 1
+        assert "-" in result.output
+
+    def test_passes_shortstat(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-13: --passes --shortstat produces shortstat format."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        _patch_passes(monkeypatch)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--passes", "--shortstat"])
+        assert result.exit_code == 0
+        assert "passes changed" in result.output
+
+    def test_passes_json(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-14: --passes --format json produces valid JSON."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        _patch_passes(monkeypatch)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--passes", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+    def test_passes_unified(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-15: --passes --format unified starts with --- a/ header."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        _patch_passes(monkeypatch)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--passes", "--format", "unified"])
+        assert result.exit_code == 0
+        assert "--- a/" in result.output
+
+    def test_passes_query_error(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-16: --passes when query fails exits 2."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        ctx = _make_ctx()
+        monkeypatch.setattr(diff_mod, "start_diff_session", lambda *a, **kw: (ctx, ""))
+        monkeypatch.setattr(diff_mod, "stop_diff_session", lambda c: None)
+        monkeypatch.setattr(
+            diff_mod,
+            "query_both",
+            lambda c, m, p, **kw: (None, None, "timeout"),
+        )
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--passes"])
+        assert result.exit_code == 2
 
 
-# ---------------------------------------------------------------------------
-# #35  --no-header forwarded
-# ---------------------------------------------------------------------------
+# ===========================================================================
+# summary mode tests (C-02, C-17 through C-20)
+# ===========================================================================
 
 
-def test_diff_no_header_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    a = tmp_path / "a.rdc"
-    b = tmp_path / "b.rdc"
-    a.touch()
-    b.touch()
+class TestDiffSummaryCLI:
+    def test_summary_identical_exit_0(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """C-02/C-17: no flag, all identical exits 0, output is 'identical'."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        _patch_summary(monkeypatch)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b)])
+        assert result.exit_code == 0
+        assert "identical" in result.output
 
-    ctx = _make_ctx()
-    monkeypatch.setattr(diff_mod, "start_diff_session", lambda *a, **kw: (ctx, ""))
-    monkeypatch.setattr(diff_mod, "stop_diff_session", lambda c: None)
+    def test_summary_draws_differ_exit_1(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """C-18: no flag, draws differ exits 1, output contains draws: line."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        sa = _stats_resp(
+            [{"name": "GBuffer", "draws": 10, "triangles": 5000, "dispatches": 0}],
+            event_count=100,
+        )
+        sb = _stats_resp(
+            [{"name": "GBuffer", "draws": 15, "triangles": 5000, "dispatches": 0}],
+            event_count=100,
+        )
+        _patch_summary(monkeypatch, sa, sb)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b)])
+        assert result.exit_code == 1
+        assert "draws:" in result.output
 
-    runner = CliRunner()
-    result = runner.invoke(diff_cmd, [str(a), str(b), "--no-header"])
-    assert result.exit_code == 0
+    def test_summary_json(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-19: no flag --json produces valid JSON with four keys."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        _patch_summary(monkeypatch)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert set(data.keys()) == {"draws", "passes", "resources", "events"}
+
+    def test_summary_query_error(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """C-20: no flag, query fails exits 2."""
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        ctx = _make_ctx()
+        monkeypatch.setattr(diff_mod, "start_diff_session", lambda *a, **kw: (ctx, ""))
+        monkeypatch.setattr(diff_mod, "stop_diff_session", lambda c: None)
+        monkeypatch.setattr(
+            diff_mod,
+            "query_both",
+            lambda c, m, p, **kw: (None, None, "timeout"),
+        )
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b)])
+        assert result.exit_code == 2

--- a/tests/unit/test_diff_summary.py
+++ b/tests/unit/test_diff_summary.py
@@ -1,0 +1,176 @@
+"""Tests for capture-level summary diff module."""
+
+from __future__ import annotations
+
+import json
+
+from rdc.diff.summary import SummaryRow, diff_summary, render_json, render_text
+
+
+def _stats(per_pass: list[dict[str, object]], event_count: int = 0) -> dict[str, object]:
+    return {"per_pass": per_pass, "event_count": event_count}
+
+
+def _pass(
+    name: str = "GBuffer", draws: int = 10, triangles: int = 5000, dispatches: int = 0
+) -> dict[str, object]:
+    return {"name": name, "draws": draws, "triangles": triangles, "dispatches": dispatches}
+
+
+# ---------------------------------------------------------------------------
+# S-01 through S-06: diff_summary logic
+# ---------------------------------------------------------------------------
+
+
+class TestDiffSummary:
+    def test_identical_stats(self) -> None:
+        """S-01: identical stats produce all-zero deltas."""
+        s = _stats([_pass("G", draws=10)], event_count=100)
+        rows = diff_summary(s, s, 5, 5)
+        assert all(r.delta == 0 for r in rows)
+        assert rows[0].value_a == rows[0].value_b == 10
+
+    def test_draw_count_increased(self) -> None:
+        """S-02: draw count delta is positive when B has more."""
+        sa = _stats([_pass(draws=10)], event_count=100)
+        sb = _stats([_pass(draws=15)], event_count=100)
+        rows = diff_summary(sa, sb, 5, 5)
+        draw_row = next(r for r in rows if r.category == "draws")
+        assert draw_row.delta == 5
+
+    def test_pass_removed(self) -> None:
+        """S-03: pass removed produces negative delta."""
+        sa = _stats([_pass("A"), _pass("B")], event_count=100)
+        sb = _stats([_pass("A")], event_count=100)
+        rows = diff_summary(sa, sb, 5, 5)
+        pass_row = next(r for r in rows if r.category == "passes")
+        assert pass_row.delta == -1
+
+    def test_resource_count_changed(self) -> None:
+        """S-04: resource count change produces non-zero delta."""
+        s = _stats([_pass()], event_count=100)
+        rows = diff_summary(s, s, 5, 8)
+        res_row = next(r for r in rows if r.category == "resources")
+        assert res_row.delta == 3
+
+    def test_all_categories_changed(self) -> None:
+        """S-05: all four categories changed simultaneously."""
+        sa = _stats([_pass(draws=10), _pass(draws=5)], event_count=100)
+        sb = _stats([_pass(draws=20)], event_count=200)
+        rows = diff_summary(sa, sb, 5, 10)
+        assert len(rows) == 4
+        assert all(r.delta != 0 for r in rows)
+
+    def test_empty_both_sides(self) -> None:
+        """S-06: empty inputs produce all-zero deltas."""
+        s = _stats([], event_count=0)
+        rows = diff_summary(s, s, 0, 0)
+        assert all(r.delta == 0 for r in rows)
+        assert all(r.value_a == 0 and r.value_b == 0 for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# S-07 through S-11: render_text
+# ---------------------------------------------------------------------------
+
+
+class TestRenderText:
+    def test_all_zero_identical(self) -> None:
+        """S-07: all-zero deltas produce 'identical'."""
+        rows = [
+            SummaryRow("draws", 10, 10, 0),
+            SummaryRow("passes", 2, 2, 0),
+            SummaryRow("resources", 5, 5, 0),
+            SummaryRow("events", 100, 100, 0),
+        ]
+        assert render_text(rows) == "identical"
+
+    def test_positive_draw_delta(self) -> None:
+        """S-08: positive delta formats as (+N)."""
+        rows = [
+            SummaryRow("draws", 10, 15, 5),
+            SummaryRow("passes", 2, 2, 0),
+            SummaryRow("resources", 5, 5, 0),
+            SummaryRow("events", 100, 100, 0),
+        ]
+        out = render_text(rows)
+        assert "(+5)" in out
+        assert "draws:" in out
+
+    def test_negative_pass_delta(self) -> None:
+        """S-09: negative delta formats as (-N)."""
+        rows = [
+            SummaryRow("draws", 10, 10, 0),
+            SummaryRow("passes", 3, 2, -1),
+            SummaryRow("resources", 5, 5, 0),
+            SummaryRow("events", 100, 100, 0),
+        ]
+        out = render_text(rows)
+        assert "(-1)" in out
+        assert "passes:" in out
+
+    def test_equal_shows_eq(self) -> None:
+        """S-10: zero-delta categories show (=)."""
+        rows = [
+            SummaryRow("draws", 10, 15, 5),
+            SummaryRow("passes", 2, 2, 0),
+            SummaryRow("resources", 5, 5, 0),
+            SummaryRow("events", 100, 100, 0),
+        ]
+        out = render_text(rows)
+        assert "(=)" in out
+
+    def test_four_lines_when_non_identical(self) -> None:
+        """S-11: output has exactly 4 lines when non-identical."""
+        rows = [
+            SummaryRow("draws", 10, 15, 5),
+            SummaryRow("passes", 2, 3, 1),
+            SummaryRow("resources", 5, 6, 1),
+            SummaryRow("events", 100, 110, 10),
+        ]
+        out = render_text(rows)
+        lines = [ln for ln in out.split("\n") if ln.strip()]
+        assert len(lines) == 4
+
+
+# ---------------------------------------------------------------------------
+# S-12 through S-14: render_json
+# ---------------------------------------------------------------------------
+
+
+class TestRenderJsonSummary:
+    def test_json_schema(self) -> None:
+        """S-12: JSON has all four category keys."""
+        rows = [
+            SummaryRow("draws", 10, 15, 5),
+            SummaryRow("passes", 2, 2, 0),
+            SummaryRow("resources", 5, 5, 0),
+            SummaryRow("events", 100, 100, 0),
+        ]
+        data = json.loads(render_json(rows))
+        assert set(data.keys()) == {"draws", "passes", "resources", "events"}
+
+    def test_subfields(self) -> None:
+        """S-13: each key has a, b, delta sub-fields as ints."""
+        rows = [
+            SummaryRow("draws", 10, 15, 5),
+            SummaryRow("passes", 2, 2, 0),
+            SummaryRow("resources", 5, 5, 0),
+            SummaryRow("events", 100, 100, 0),
+        ]
+        data = json.loads(render_json(rows))
+        for cat in data.values():
+            assert isinstance(cat["a"], int)
+            assert isinstance(cat["b"], int)
+            assert isinstance(cat["delta"], int)
+
+    def test_empty_valid_json(self) -> None:
+        """S-14: empty input produces valid JSON with all-zero values."""
+        rows = [
+            SummaryRow("draws", 0, 0, 0),
+            SummaryRow("passes", 0, 0, 0),
+            SummaryRow("resources", 0, 0, 0),
+            SummaryRow("events", 0, 0, 0),
+        ]
+        data = json.loads(render_json(rows))
+        assert all(v["delta"] == 0 for v in data.values())

--- a/tests/unit/test_vfs_formatter.py
+++ b/tests/unit/test_vfs_formatter.py
@@ -1,0 +1,67 @@
+"""Tests for VFS formatter: render_ls and render_ls_long."""
+
+from __future__ import annotations
+
+from rdc.vfs.formatter import render_ls, render_ls_long
+
+
+class TestRenderLsLong:
+    def test_header_row(self) -> None:
+        columns = ["NAME", "DRAWS", "DISPATCHES", "TRIANGLES"]
+        result = render_ls_long([], columns)
+        assert result == "NAME\tDRAWS\tDISPATCHES\tTRIANGLES"
+
+    def test_data_rows(self) -> None:
+        columns = ["EID", "NAME", "TYPE"]
+        children = [
+            {"eid": 42, "name": "draw1", "type": "DrawIndexed"},
+            {"eid": 100, "name": "draw2", "type": "Draw"},
+        ]
+        result = render_ls_long(children, columns)
+        lines = result.split("\n")
+        assert len(lines) == 3
+        assert lines[0] == "EID\tNAME\tTYPE"
+        assert lines[1] == "42\tdraw1\tDrawIndexed"
+        assert lines[2] == "100\tdraw2\tDraw"
+
+    def test_none_field_becomes_dash(self) -> None:
+        columns = ["NAME", "SIZE"]
+        children = [{"name": "res1", "size": None}]
+        result = render_ls_long(children, columns)
+        lines = result.split("\n")
+        assert lines[1] == "res1\t-"
+
+    def test_missing_field_becomes_dash(self) -> None:
+        columns = ["NAME", "SIZE"]
+        children = [{"name": "res1"}]
+        result = render_ls_long(children, columns)
+        lines = result.split("\n")
+        assert lines[1] == "res1\t-"
+
+    def test_empty_children(self) -> None:
+        columns = ["NAME", "TYPE"]
+        result = render_ls_long([], columns)
+        lines = result.split("\n")
+        assert len(lines) == 1
+        assert lines[0] == "NAME\tTYPE"
+
+
+class TestRenderLsRegression:
+    def test_render_ls_unchanged(self) -> None:
+        children = [
+            {"name": "info", "kind": "leaf"},
+            {"name": "draws", "kind": "dir"},
+        ]
+        result = render_ls(children)
+        assert result == "info\ndraws"
+
+    def test_render_ls_classify(self) -> None:
+        children = [
+            {"name": "info", "kind": "leaf"},
+            {"name": "draws", "kind": "dir"},
+            {"name": "current", "kind": "alias"},
+        ]
+        result = render_ls(children, classify=True)
+        assert "info" in result
+        assert "draws/" in result
+        assert "current@" in result


### PR DESCRIPTION
## Summary

- **diff completeness**: implement `--draws` (draw call diff), `--passes` (pass structure diff), and no-flag summary mode — all three were stubs or silent exits
- **shader API fix**: `shader_source` now checks `refl.debugInfo.files` before fallback to disassembly; `shader_constants` uses `GetCBufferVariableContents` (structured variables) instead of `GetConstantBuffer` (raw hex)
- **VFS ls -l**: add `-l/--long` flag to `rdc ls` with per-context TSV metadata columns for passes/draws/events/resources/textures/buffers/shaders

All 6 items from `待解决.md` § 设计偏差 (P2) are resolved. P3 global options deferred.

## Test plan

- [x] 1469 tests pass (was 1406), 95.06% coverage
- [x] `pixi run lint` clean
- [x] Opus code review on all 3 workstreams
- [x] Review fixes applied: deduplicated `_handle_passes`/`_handle_stats`, fixed VFS depth bug for nested paths
- [ ] GPU integration tests (`pixi run test-gpu`)
- [ ] Bot review (CodeRabbit, Greptile)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three diff comparison modes: `--draws` for per-draw analysis, `--passes` for pass-level statistics, and summary mode for compact delta summaries across categories
  * Enhanced shader introspection with debug info detection and structured constant variable output
  * Added `-l/--long` flag to `vfs ls` for detailed directory listings with metadata columns (draws, passes, resources, etc.)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->