### PR TITLE
feat(cli): add --no-header, --jsonl, -q to 10 list commands

### DIFF
--- a/src/rdc/formatters/options.py
+++ b/src/rdc/formatters/options.py
@@ -1,0 +1,22 @@
+"""Shared output options decorator for list commands."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from typing import Any
+
+import click
+
+
+def list_output_options(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Attach --no-header, --jsonl, -q to a Click command."""
+
+    @click.option("--no-header", is_flag=True, help="Omit TSV header")
+    @click.option("--jsonl", "use_jsonl", is_flag=True, help="JSONL output")
+    @click.option("-q", "--quiet", is_flag=True, help="Print primary key column only")
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return fn(*args, **kwargs)
+
+    return wrapper

--- a/src/rdc/vfs/formatter.py
+++ b/src/rdc/vfs/formatter.py
@@ -10,15 +10,17 @@ from typing import Any
 _CLASSIFY: dict[str, str] = {"dir": "/", "leaf_bin": "*", "alias": "@", "leaf": ""}
 
 
-def render_ls_long(children: list[dict[str, Any]], columns: list[str]) -> str:
+def render_ls_long(
+    children: list[dict[str, Any]], columns: list[str], *, no_header: bool = False
+) -> str:
     """Render long-format ls output as TSV with header row.
 
     Args:
         children: List of child dicts with metadata fields.
         columns: Column headers (uppercase); child keys are lowercase.
+        no_header: If True, omit the header row.
     """
-    header = "\t".join(columns)
-    rows: list[str] = [header]
+    rows: list[str] = [] if no_header else ["\t".join(columns)]
     for child in children:
         vals: list[str] = []
         for col in columns:

--- a/tests/unit/test_counters_commands.py
+++ b/tests/unit/test_counters_commands.py
@@ -117,3 +117,75 @@ def test_counters_fetch_json(monkeypatch: Any) -> None:
     data = json.loads(result.output)
     assert data["total"] == 3
     assert len(data["rows"]) == 3
+
+
+# ── counters --list output options ─────────────────────────────────
+
+
+def test_counters_list_default_has_header(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _LIST_RESPONSE)
+    result = CliRunner().invoke(main, ["counters", "--list"])
+    assert result.exit_code == 0
+    assert "ID\tNAME\tUNIT\tTYPE\tCATEGORY" in result.output
+
+
+def test_counters_list_no_header(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _LIST_RESPONSE)
+    result = CliRunner().invoke(main, ["counters", "--list", "--no-header"])
+    assert result.exit_code == 0
+    assert "ID\tNAME\tUNIT\tTYPE\tCATEGORY" not in result.output
+    assert "EventGPUDuration" in result.output
+
+
+def test_counters_list_jsonl(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _LIST_RESPONSE)
+    result = CliRunner().invoke(main, ["counters", "--list", "--jsonl"])
+    assert result.exit_code == 0
+    lines = [json.loads(ln) for ln in result.output.strip().splitlines()]
+    assert len(lines) == 2
+    assert lines[0]["id"] == 1
+    assert lines[0]["name"] == "EventGPUDuration"
+
+
+def test_counters_list_quiet(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _LIST_RESPONSE)
+    result = CliRunner().invoke(main, ["counters", "--list", "-q"])
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+    assert lines == ["1", "8"]
+
+
+# ── counters fetch output options ──────────────────────────────────
+
+
+def test_counters_fetch_default_has_header(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _FETCH_RESPONSE)
+    result = CliRunner().invoke(main, ["counters"])
+    assert result.exit_code == 0
+    assert "EID\tCOUNTER\tVALUE\tUNIT" in result.output
+
+
+def test_counters_fetch_no_header(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _FETCH_RESPONSE)
+    result = CliRunner().invoke(main, ["counters", "--no-header"])
+    assert result.exit_code == 0
+    assert "EID\tCOUNTER\tVALUE\tUNIT" not in result.output
+    assert "EventGPUDuration" in result.output
+
+
+def test_counters_fetch_jsonl(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _FETCH_RESPONSE)
+    result = CliRunner().invoke(main, ["counters", "--jsonl"])
+    assert result.exit_code == 0
+    lines = [json.loads(ln) for ln in result.output.strip().splitlines()]
+    assert len(lines) == 3
+    assert lines[0]["eid"] == 10
+    assert lines[0]["counter"] == "EventGPUDuration"
+
+
+def test_counters_fetch_quiet(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _FETCH_RESPONSE)
+    result = CliRunner().invoke(main, ["counters", "-q"])
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+    assert lines == ["10", "10", "20"]

--- a/tests/unit/test_output_options.py
+++ b/tests/unit/test_output_options.py
@@ -1,0 +1,64 @@
+"""Tests for the @list_output_options decorator."""
+
+from __future__ import annotations
+
+import click
+from click.testing import CliRunner
+
+from rdc.formatters.options import list_output_options
+
+
+def test_decorator_adds_no_header() -> None:
+    @click.command("test-cmd")
+    @list_output_options
+    def cmd(no_header: bool, use_jsonl: bool, quiet: bool) -> None:
+        click.echo(f"no_header={no_header}")
+
+    result = CliRunner().invoke(cmd, ["--no-header"])
+    assert result.exit_code == 0
+    assert "no_header=True" in result.output
+
+
+def test_decorator_adds_jsonl() -> None:
+    @click.command("test-cmd")
+    @list_output_options
+    def cmd(no_header: bool, use_jsonl: bool, quiet: bool) -> None:
+        click.echo(f"use_jsonl={use_jsonl}")
+
+    result = CliRunner().invoke(cmd, ["--jsonl"])
+    assert result.exit_code == 0
+    assert "use_jsonl=True" in result.output
+
+
+def test_decorator_adds_quiet() -> None:
+    @click.command("test-cmd")
+    @list_output_options
+    def cmd(no_header: bool, use_jsonl: bool, quiet: bool) -> None:
+        click.echo(f"quiet={quiet}")
+
+    result = CliRunner().invoke(cmd, ["-q"])
+    assert result.exit_code == 0
+    assert "quiet=True" in result.output
+
+
+def test_decorator_defaults_false() -> None:
+    @click.command("test-cmd")
+    @list_output_options
+    def cmd(no_header: bool, use_jsonl: bool, quiet: bool) -> None:
+        click.echo(f"{no_header},{use_jsonl},{quiet}")
+
+    result = CliRunner().invoke(cmd, [])
+    assert result.exit_code == 0
+    assert "False,False,False" in result.output
+
+
+def test_decorator_preserves_other_options() -> None:
+    @click.command("test-cmd")
+    @click.option("--json", "as_json", is_flag=True)
+    @list_output_options
+    def cmd(as_json: bool, no_header: bool, use_jsonl: bool, quiet: bool) -> None:
+        click.echo(f"json={as_json},quiet={quiet}")
+
+    result = CliRunner().invoke(cmd, ["--json", "-q"])
+    assert result.exit_code == 0
+    assert "json=True,quiet=True" in result.output

--- a/tests/unit/test_pixel_history_commands.py
+++ b/tests/unit/test_pixel_history_commands.py
@@ -203,3 +203,38 @@ def test_non_integer_x() -> None:
 
 def test_help_shows_pixel() -> None:
     assert "pixel" in CliRunner().invoke(main, ["--help"]).output
+
+
+# ── pixel output options ───────────────────────────────────────────
+
+
+def test_pixel_default_has_header(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _HAPPY_RESPONSE)
+    result = CliRunner().invoke(main, ["pixel", "512", "384"])
+    assert result.exit_code == 0
+    assert "EID\tFRAG\tDEPTH\tPASSED\tFLAGS" in result.output
+
+
+def test_pixel_no_header_regression(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _HAPPY_RESPONSE)
+    result = CliRunner().invoke(main, ["pixel", "512", "384", "--no-header"])
+    assert result.exit_code == 0
+    assert "EID\tFRAG\tDEPTH\tPASSED\tFLAGS" not in result.output
+    assert "88" in result.output
+
+
+def test_pixel_jsonl(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _HAPPY_RESPONSE)
+    result = CliRunner().invoke(main, ["pixel", "512", "384", "--jsonl"])
+    assert result.exit_code == 0
+    lines = [json.loads(ln) for ln in result.output.strip().splitlines()]
+    assert len(lines) == 2
+    assert lines[0]["eid"] == 88
+
+
+def test_pixel_quiet(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _HAPPY_RESPONSE)
+    result = CliRunner().invoke(main, ["pixel", "512", "384", "-q"])
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+    assert lines == ["88", "102"]

--- a/tests/unit/test_usage_commands.py
+++ b/tests/unit/test_usage_commands.py
@@ -112,3 +112,77 @@ def test_usage_daemon_error_exits_1(monkeypatch: Any) -> None:
     monkeypatch.setattr(usage_mod, "_daemon_call", _raise_error)
     result = CliRunner().invoke(main, ["usage", "999"])
     assert result.exit_code == 1
+
+
+# ── usage single-resource output options ───────────────────────────
+
+
+def test_usage_single_default_has_header(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _SINGLE_RESPONSE)
+    result = CliRunner().invoke(main, ["usage", "97"])
+    assert result.exit_code == 0
+    assert "EID\tUSAGE" in result.output
+
+
+def test_usage_single_no_header(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _SINGLE_RESPONSE)
+    result = CliRunner().invoke(main, ["usage", "97", "--no-header"])
+    assert result.exit_code == 0
+    assert "EID\tUSAGE" not in result.output
+    assert "Clear" in result.output
+
+
+def test_usage_single_jsonl(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _SINGLE_RESPONSE)
+    result = CliRunner().invoke(main, ["usage", "97", "--jsonl"])
+    assert result.exit_code == 0
+    lines = [json.loads(ln) for ln in result.output.strip().splitlines()]
+    assert len(lines) == 3
+    assert lines[0]["eid"] == 6
+    assert lines[0]["usage"] == "Clear"
+
+
+def test_usage_single_quiet(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _SINGLE_RESPONSE)
+    result = CliRunner().invoke(main, ["usage", "97", "-q"])
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+    assert lines == ["6", "11", "12"]
+
+
+# ── usage --all output options ─────────────────────────────────────
+
+
+def test_usage_all_default_has_header(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _ALL_RESPONSE)
+    result = CliRunner().invoke(main, ["usage", "--all"])
+    assert result.exit_code == 0
+    assert "ID\tNAME\tEID\tUSAGE" in result.output
+
+
+def test_usage_all_no_header(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _ALL_RESPONSE)
+    result = CliRunner().invoke(main, ["usage", "--all", "--no-header"])
+    assert result.exit_code == 0
+    assert "ID\tNAME\tEID\tUSAGE" not in result.output
+    assert "2D Image 97" in result.output
+
+
+def test_usage_all_jsonl(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _ALL_RESPONSE)
+    result = CliRunner().invoke(main, ["usage", "--all", "--jsonl"])
+    assert result.exit_code == 0
+    lines = [json.loads(ln) for ln in result.output.strip().splitlines()]
+    assert len(lines) == 4
+    assert lines[0]["id"] == 97
+    assert lines[0]["name"] == "2D Image 97"
+    assert lines[0]["eid"] == 6
+    assert lines[0]["usage"] == "Clear"
+
+
+def test_usage_all_quiet(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _ALL_RESPONSE)
+    result = CliRunner().invoke(main, ["usage", "--all", "-q"])
+    assert result.exit_code == 0
+    lines = result.output.strip().splitlines()
+    assert lines == ["97", "97", "97", "105"]

--- a/tests/unit/test_vfs_formatter.py
+++ b/tests/unit/test_vfs_formatter.py
@@ -45,6 +45,26 @@ class TestRenderLsLong:
         assert len(lines) == 1
         assert lines[0] == "NAME\tTYPE"
 
+    def test_no_header_true(self) -> None:
+        columns = ["EID", "NAME", "TYPE"]
+        children = [
+            {"eid": 42, "name": "draw1", "type": "DrawIndexed"},
+        ]
+        result = render_ls_long(children, columns, no_header=True)
+        lines = result.split("\n")
+        assert len(lines) == 1
+        assert lines[0] == "42\tdraw1\tDrawIndexed"
+
+    def test_no_header_false(self) -> None:
+        columns = ["EID", "NAME", "TYPE"]
+        children = [
+            {"eid": 42, "name": "draw1", "type": "DrawIndexed"},
+        ]
+        result = render_ls_long(children, columns, no_header=False)
+        lines = result.split("\n")
+        assert len(lines) == 2
+        assert lines[0] == "EID\tNAME\tTYPE"
+
 
 class TestRenderLsRegression:
     def test_render_ls_unchanged(self) -> None:


### PR DESCRIPTION
## Summary

- Create shared `@list_output_options` decorator in `src/rdc/formatters/options.py`
- Apply output waterfall pattern (json → jsonl → quiet → tsv) to `resources`, `passes`, `bindings`, `shaders`, `counters`, `usage`, `log`, `pixel`, `ls -l`, and `shader-map`
- Add `no_header` parameter to `render_ls_long()` in VFS formatter
- 55 new unit tests across 9 test files

## Test plan

- [x] `pixi run lint` — all checks passed
- [x] `pixi run test` — 1524 passed, 95.14% coverage
- [x] e2e tests — 26 passed, 0 failed
- [ ] Manual spot checks: `rdc resources -q`, `rdc shaders --jsonl`, `rdc ls -l --no-header /passes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added JSONL (`--jsonl`) output format for JSON Lines structured output across multiple commands
  * Added quiet mode (`--quiet`/`-q`) to display only IDs or essential information
  * Added header suppression (`--no-header`) for tab-separated output
  * New options available on: counters, log, bindings, shaders, pixel, resources, passes, maps, usage, and file listing commands

* **Tests**
  * Added comprehensive test coverage for all new output format options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->