### PR TITLE
feat(debug): add debug thread for compute shader tracing

### DIFF
--- a/tests/mocks/mock_renderdoc.py
+++ b/tests/mocks/mock_renderdoc.py
@@ -1291,6 +1291,7 @@ class MockReplayController:
         self._pixel_history_map: dict[tuple[int, int], list[PixelModification]] = {}
         self._debug_pixel_map: dict[tuple[int, int], ShaderDebugTrace] = {}
         self._debug_vertex_map: dict[int, ShaderDebugTrace] = {}
+        self._debug_thread_map: dict[tuple[int, int, int, int, int, int], ShaderDebugTrace] = {}
         self._debug_states: dict[int, list[list[ShaderDebugState]]] = {}
         self._mesh_data: dict[int, MeshFormat] = {}
         self._target_encodings: list[int] = [3, 2]
@@ -1406,6 +1407,11 @@ class MockReplayController:
 
     def DebugVertex(self, vtx: int, inst: int, idx: int, view: int) -> ShaderDebugTrace:
         return self._debug_vertex_map.get(vtx, ShaderDebugTrace())
+
+    def DebugThread(
+        self, group: tuple[int, int, int], thread: tuple[int, int, int]
+    ) -> ShaderDebugTrace:
+        return self._debug_thread_map.get((*group, *thread), ShaderDebugTrace())
 
     def ContinueDebug(self, debugger: Any) -> list[ShaderDebugState]:
         key = id(debugger)


### PR DESCRIPTION
## Summary

- Add `rdc debug thread <eid> <gx> <gy> <gz> <tx> <ty> <tz>` for compute shader execution tracing
- Validates event is a Dispatch via `_get_flat_actions` + `ActionFlags.Dispatch`
- Reuses existing `_run_debug_loop`, `_extract_inputs_outputs`, and output formatting
- 28 new tests (13 CLI + 15 handler)

## Test plan

- [x] `pixi run lint` — all checks passed
- [x] `pixi run test` — 1497 passed, 95.12% coverage
- [x] e2e tests — 26 passed, 0 failed
- [ ] GPU: `rdc debug thread <dispatch_eid> 0 0 0 0 0 0` with real capture