### PR TITLE
feat(pixel): add pick-pixel for single-pixel color readback

### DIFF
--- a/src/rdc/cli.py
+++ b/src/rdc/cli.py
@@ -22,6 +22,7 @@ from rdc.commands.events import draw_cmd, draws_cmd, event_cmd, events_cmd
 from rdc.commands.export import buffer_cmd, rt_cmd, texture_cmd
 from rdc.commands.info import info_cmd, log_cmd, stats_cmd
 from rdc.commands.mesh import mesh_cmd
+from rdc.commands.pick_pixel import pick_pixel_cmd
 from rdc.commands.pipeline import bindings_cmd, pipeline_cmd, shader_cmd, shaders_cmd
 from rdc.commands.pixel import pixel_cmd
 from rdc.commands.resources import pass_cmd, passes_cmd, resource_cmd, resources_cmd
@@ -107,6 +108,7 @@ main.add_command(completion_cmd, name="completion")
 main.add_command(counters_cmd, name="counters")
 main.add_command(script_cmd, name="script")
 main.add_command(pixel_cmd, name="pixel")
+main.add_command(pick_pixel_cmd, name="pick-pixel")
 main.add_command(diff_cmd, name="diff")
 main.add_command(assert_image_cmd, name="assert-image")
 main.add_command(assert_pixel_cmd, name="assert-pixel")

--- a/src/rdc/commands/pick_pixel.py
+++ b/src/rdc/commands/pick_pixel.py
@@ -1,0 +1,29 @@
+"""rdc pick-pixel command -- single-pixel color readback."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+from rdc.commands.info import _daemon_call
+from rdc.formatters.json_fmt import write_json
+
+
+@click.command("pick-pixel")
+@click.argument("x", type=int)
+@click.argument("y", type=int)
+@click.argument("eid", required=False, type=int)
+@click.option("--target", default=0, type=int, help="Color target index (default 0)")
+@click.option("--json", "use_json", is_flag=True, help="JSON output")
+def pick_pixel_cmd(x: int, y: int, eid: int | None, target: int, use_json: bool) -> None:
+    """Read pixel color at (X, Y) from the current render target."""
+    params: dict[str, Any] = {"x": x, "y": y, "target": target}
+    if eid is not None:
+        params["eid"] = eid
+    result = _daemon_call("pick_pixel", params)
+    if use_json:
+        write_json(result)
+        return
+    c = result["color"]
+    click.echo(f"r={c['r']:.4f}  g={c['g']:.4f}  b={c['b']:.4f}  a={c['a']:.4f}")

--- a/tests/mocks/mock_renderdoc.py
+++ b/tests/mocks/mock_renderdoc.py
@@ -1289,6 +1289,7 @@ class MockReplayController:
         self._counter_descriptions: dict[int, CounterDescription] = {}
         self._counter_results: list[CounterResult] = []
         self._pixel_history_map: dict[tuple[int, int], list[PixelModification]] = {}
+        self._pick_pixel_map: dict[tuple[int, int], PixelValue] = {}
         self._debug_pixel_map: dict[tuple[int, int], ShaderDebugTrace] = {}
         self._debug_vertex_map: dict[int, ShaderDebugTrace] = {}
         self._debug_thread_map: dict[tuple[int, int, int, int, int, int], ShaderDebugTrace] = {}
@@ -1401,6 +1402,10 @@ class MockReplayController:
     ) -> list[PixelModification]:
         """Mock PixelHistory -- returns modifications keyed by (x, y)."""
         return self._pixel_history_map.get((x, y), [])
+
+    def PickPixel(self, texture: Any, x: int, y: int, sub: Any, comp_type: Any) -> PixelValue:
+        """Mock PickPixel -- returns PixelValue keyed by (x, y)."""
+        return self._pick_pixel_map.get((int(x), int(y)), PixelValue())
 
     def DebugPixel(self, x: int, y: int, inputs: Any) -> ShaderDebugTrace:
         return self._debug_pixel_map.get((x, y), ShaderDebugTrace())

--- a/tests/unit/test_pick_pixel_commands.py
+++ b/tests/unit/test_pick_pixel_commands.py
@@ -1,0 +1,122 @@
+"""Tests for rdc pick-pixel CLI command."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+import rdc.commands.pick_pixel as mod
+from rdc.cli import main
+from rdc.commands.pick_pixel import pick_pixel_cmd
+
+_HAPPY = {
+    "x": 512,
+    "y": 384,
+    "eid": 120,
+    "target": {"index": 0, "id": 42},
+    "color": {"r": 0.5, "g": 0.3, "b": 0.1, "a": 1.0},
+}
+
+
+def _patch(monkeypatch, response=_HAPPY):
+    captured: dict = {}
+
+    def fake_call(method, params=None):
+        captured["method"] = method
+        captured["params"] = params
+        return response
+
+    monkeypatch.setattr(mod, "_daemon_call", fake_call)
+    return captured
+
+
+def test_pick_pixel_default_output(monkeypatch):
+    _patch(monkeypatch)
+    r = CliRunner().invoke(pick_pixel_cmd, ["512", "384"])
+    assert r.exit_code == 0
+    assert "r=0.5000  g=0.3000  b=0.1000  a=1.0000" in r.output
+
+
+def test_pick_pixel_json(monkeypatch):
+    _patch(monkeypatch)
+    r = CliRunner().invoke(pick_pixel_cmd, ["512", "384", "--json"])
+    assert r.exit_code == 0
+    data = json.loads(r.output)
+    assert "color" in data
+    assert data["color"]["r"] == 0.5
+    assert data["color"]["g"] == 0.3
+    assert data["color"]["b"] == 0.1
+    assert data["color"]["a"] == 1.0
+
+
+def test_pick_pixel_eid_arg(monkeypatch):
+    cap = _patch(monkeypatch)
+    CliRunner().invoke(pick_pixel_cmd, ["512", "384", "120"])
+    assert cap["params"]["eid"] == 120
+
+
+def test_pick_pixel_eid_omitted(monkeypatch):
+    cap = _patch(monkeypatch)
+    CliRunner().invoke(pick_pixel_cmd, ["512", "384"])
+    assert "eid" not in cap["params"]
+
+
+def test_pick_pixel_target_option(monkeypatch):
+    cap = _patch(monkeypatch)
+    CliRunner().invoke(pick_pixel_cmd, ["512", "384", "--target", "2"])
+    assert cap["params"]["target"] == 2
+
+
+def test_pick_pixel_default_target(monkeypatch):
+    cap = _patch(monkeypatch)
+    CliRunner().invoke(pick_pixel_cmd, ["512", "384"])
+    assert cap["params"]["target"] == 0
+
+
+def test_pick_pixel_method_name(monkeypatch):
+    cap = _patch(monkeypatch)
+    CliRunner().invoke(pick_pixel_cmd, ["512", "384"])
+    assert cap["method"] == "pick_pixel"
+
+
+def test_pick_pixel_non_integer_x():
+    r = CliRunner().invoke(pick_pixel_cmd, ["abc", "384"])
+    assert r.exit_code == 2
+
+
+def test_pick_pixel_non_integer_y():
+    r = CliRunner().invoke(pick_pixel_cmd, ["512", "xyz"])
+    assert r.exit_code == 2
+
+
+def test_pick_pixel_help():
+    r = CliRunner().invoke(pick_pixel_cmd, ["--help"])
+    assert r.exit_code == 0
+    assert "pick-pixel" in r.output.lower() or "Read pixel color" in r.output
+
+
+def test_pick_pixel_in_main_help():
+    r = CliRunner().invoke(main, ["--help"])
+    assert r.exit_code == 0
+    assert "pick-pixel" in r.output
+
+
+def test_pick_pixel_float_formatting(monkeypatch):
+    resp = {
+        "x": 0,
+        "y": 0,
+        "eid": 1,
+        "target": {"index": 0, "id": 1},
+        "color": {"r": 1.0, "g": 0.0, "b": 0.0, "a": 0.5},
+    }
+    _patch(monkeypatch, resp)
+    r = CliRunner().invoke(pick_pixel_cmd, ["0", "0"])
+    assert r.exit_code == 0
+    assert "r=1.0000  g=0.0000  b=0.0000  a=0.5000" in r.output
+
+
+def test_pick_pixel_daemon_error(monkeypatch):
+    monkeypatch.setattr(mod, "_daemon_call", lambda m, p=None: (_ for _ in ()).throw(SystemExit(1)))
+    r = CliRunner().invoke(pick_pixel_cmd, ["512", "384"])
+    assert r.exit_code == 1

--- a/tests/unit/test_pick_pixel_daemon.py
+++ b/tests/unit/test_pick_pixel_daemon.py
@@ -1,0 +1,173 @@
+"""Tests for daemon pick_pixel handler."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from rdc.adapter import RenderDocAdapter
+from rdc.daemon_server import DaemonState, _handle_request
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
+
+import mock_renderdoc as rd  # noqa: E402
+
+
+def _make_state(
+    pick_pixel: dict[tuple[int, int], rd.PixelValue] | None = None,
+    output_targets: list[rd.Descriptor] | None = None,
+    ms_samp: int = 1,
+) -> DaemonState:
+    ctrl = rd.MockReplayController()
+    rt_rid = rd.ResourceId(42)
+    rt_rid2 = rd.ResourceId(43)
+    targets = output_targets or [rd.Descriptor(resource=rt_rid)]
+    ctrl._pipe_state = rd.MockPipeState(output_targets=targets)
+    ctrl._pick_pixel_map = pick_pixel or {}
+    ctrl._textures = [
+        rd.TextureDescription(resourceId=rt_rid, width=1024, height=768, msSamp=ms_samp),
+        rd.TextureDescription(resourceId=rt_rid2, width=1024, height=768, msSamp=1),
+    ]
+    ctrl._actions = [
+        rd.ActionDescription(eventId=120, flags=rd.ActionFlags.Drawcall, _name="vkCmdDraw"),
+    ]
+
+    state = DaemonState(capture="test.rdc", current_eid=120, token="tok")
+    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
+    state.max_eid = 120
+    state.rd = rd
+    state.tex_map = {int(t.resourceId): t for t in ctrl._textures}
+    return state
+
+
+def _req(method: str, params: dict | None = None) -> dict:
+    p = {"_token": "tok"}
+    if params:
+        p.update(params)
+    return {"jsonrpc": "2.0", "id": 1, "method": method, "params": p}
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_pick_pixel_happy() -> None:
+    pv = rd.PixelValue(floatValue=[0.5, 0.3, 0.1, 1.0])
+    state = _make_state(pick_pixel={(512, 384): pv})
+    resp, running = _handle_request(_req("pick_pixel", {"x": 512, "y": 384}), state)
+    assert running
+    r = resp["result"]
+    assert r["color"] == {"r": 0.5, "g": 0.3, "b": 0.1, "a": 1.0}
+
+
+def test_pick_pixel_result_schema() -> None:
+    pv = rd.PixelValue(floatValue=[0.5, 0.3, 0.1, 1.0])
+    state = _make_state(pick_pixel={(512, 384): pv})
+    resp, _ = _handle_request(_req("pick_pixel", {"x": 512, "y": 384}), state)
+    r = resp["result"]
+    assert r["x"] == 512
+    assert r["y"] == 384
+    assert r["eid"] == 120
+    assert r["target"] == {"index": 0, "id": 42}
+
+
+def test_pick_pixel_target_index_1() -> None:
+    rt0 = rd.Descriptor(resource=rd.ResourceId(42))
+    rt1 = rd.Descriptor(resource=rd.ResourceId(43))
+    pv = rd.PixelValue(floatValue=[1.0, 0.0, 0.0, 1.0])
+    state = _make_state(pick_pixel={(100, 200): pv}, output_targets=[rt0, rt1])
+    resp, _ = _handle_request(_req("pick_pixel", {"x": 100, "y": 200, "target": 1}), state)
+    r = resp["result"]
+    assert r["target"]["index"] == 1
+    assert r["target"]["id"] == 43
+
+
+def test_pick_pixel_eid_defaults_to_current() -> None:
+    state = _make_state(pick_pixel={(10, 20): rd.PixelValue()})
+    state.current_eid = 120
+    resp, _ = _handle_request(_req("pick_pixel", {"x": 10, "y": 20}), state)
+    assert resp["result"]["eid"] == 120
+
+
+def test_pick_pixel_eid_override() -> None:
+    state = _make_state(pick_pixel={(10, 20): rd.PixelValue()})
+    state._eid_cache = -1
+    resp, _ = _handle_request(_req("pick_pixel", {"x": 10, "y": 20, "eid": 120}), state)
+    ctrl = state.adapter.controller  # type: ignore[union-attr]
+    assert (120, True) in ctrl._set_frame_event_calls
+
+
+def test_pick_pixel_unknown_pixel_returns_zero() -> None:
+    state = _make_state()
+    resp, _ = _handle_request(_req("pick_pixel", {"x": 999, "y": 999}), state)
+    r = resp["result"]
+    assert r["color"] == {"r": 0.0, "g": 0.0, "b": 0.0, "a": 0.0}
+
+
+def test_pick_pixel_keep_running_true() -> None:
+    state = _make_state()
+    _, running = _handle_request(_req("pick_pixel", {"x": 0, "y": 0}), state)
+    assert running is True
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_pick_pixel_no_adapter() -> None:
+    state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
+    resp, _ = _handle_request(_req("pick_pixel", {"x": 0, "y": 0}), state)
+    assert resp["error"]["code"] == -32002
+
+
+def test_pick_pixel_missing_x() -> None:
+    state = _make_state()
+    resp, _ = _handle_request(_req("pick_pixel", {"y": 0}), state)
+    assert resp["error"]["code"] == -32602
+    assert "x" in resp["error"]["message"]
+
+
+def test_pick_pixel_missing_y() -> None:
+    state = _make_state()
+    resp, _ = _handle_request(_req("pick_pixel", {"x": 0}), state)
+    assert resp["error"]["code"] == -32602
+    assert "y" in resp["error"]["message"]
+
+
+def test_pick_pixel_no_targets() -> None:
+    state = _make_state(output_targets=[rd.Descriptor(resource=rd.ResourceId(0))])
+    resp, _ = _handle_request(_req("pick_pixel", {"x": 0, "y": 0}), state)
+    assert resp["error"]["code"] == -32001
+    assert "no color targets" in resp["error"]["message"]
+
+
+def test_pick_pixel_target_out_of_range() -> None:
+    state = _make_state()
+    resp, _ = _handle_request(_req("pick_pixel", {"x": 0, "y": 0, "target": 5}), state)
+    assert resp["error"]["code"] == -32001
+
+
+def test_pick_pixel_eid_out_of_range() -> None:
+    state = _make_state()
+    resp, _ = _handle_request(_req("pick_pixel", {"x": 0, "y": 0, "eid": 9999}), state)
+    assert resp["error"]["code"] == -32002
+
+
+def test_pick_pixel_msaa_rejected() -> None:
+    state = _make_state(ms_samp=4)
+    resp, _ = _handle_request(_req("pick_pixel", {"x": 0, "y": 0}), state)
+    assert resp["error"]["code"] == -32001
+    assert "MSAA" in resp["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Handler registration
+# ---------------------------------------------------------------------------
+
+
+def test_pick_pixel_handler_registered() -> None:
+    from rdc.handlers.pixel import HANDLERS
+
+    assert "pick_pixel" in HANDLERS


### PR DESCRIPTION
## Summary

- Add `rdc pick-pixel <x> <y> [eid] [--target N] [--json]` for reading pixel color from the current render target
- Uses `PickPixel` API with render target lookup from pipeline state
- MSAA guard returns error for multisampled textures
- Default output: `r=0.5000  g=0.3000  b=0.1000  a=1.0000`
- 28 new tests (13 CLI + 15 handler) + 5 GPU integration tests

## Test plan

- [x] `pixi run lint` — all checks passed
- [x] `pixi run test` — 1497 passed, 95.10% coverage
- [x] e2e tests — 26 passed, 0 failed
- [ ] GPU: `rdc pick-pixel 100 100` with real capture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `pick-pixel` CLI command to sample and retrieve color data from a single pixel at specified coordinates with RGBA output formatting.
  * Supports optional element ID parameter, custom target selection, and JSON output mode.

* **Tests**
  * Comprehensive unit and integration tests added for the new pick-pixel command and daemon handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->