### PR TITLE
feat(texture): add tex-stats for min/max and histogram

### DIFF
--- a/src/rdc/cli.py
+++ b/src/rdc/cli.py
@@ -37,6 +37,7 @@ from rdc.commands.shader_edit import (
     shader_restore_cmd,
 )
 from rdc.commands.snapshot import snapshot_cmd
+from rdc.commands.tex_stats import tex_stats_cmd
 from rdc.commands.unix_helpers import count_cmd, shader_map_cmd
 from rdc.commands.usage import usage_cmd
 from rdc.commands.vfs import cat_cmd, complete_cmd, ls_cmd, tree_cmd
@@ -122,6 +123,7 @@ main.add_command(shader_build_cmd, name="shader-build")
 main.add_command(shader_replace_cmd, name="shader-replace")
 main.add_command(shader_restore_cmd, name="shader-restore")
 main.add_command(shader_restore_all_cmd, name="shader-restore-all")
+main.add_command(tex_stats_cmd, name="tex-stats")
 
 
 if __name__ == "__main__":

--- a/src/rdc/commands/tex_stats.py
+++ b/src/rdc/commands/tex_stats.py
@@ -1,0 +1,52 @@
+"""rdc tex-stats command -- texture min/max and histogram."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+
+from rdc.commands.info import _daemon_call
+from rdc.formatters.json_fmt import write_json
+from rdc.formatters.tsv import write_tsv
+
+
+@click.command("tex-stats")
+@click.argument("resource_id", type=int)
+@click.argument("eid", required=False, type=int)
+@click.option("--mip", default=0, type=int, help="Mip level (default 0)")
+@click.option("--slice", "array_slice", default=0, type=int, help="Array slice (default 0)")
+@click.option("--histogram", is_flag=True, help="Show 256-bucket histogram")
+@click.option("--json", "use_json", is_flag=True, help="JSON output")
+def tex_stats_cmd(
+    resource_id: int,
+    eid: int | None,
+    mip: int,
+    array_slice: int,
+    histogram: bool,
+    use_json: bool,
+) -> None:
+    """Show texture min/max statistics and optional histogram."""
+    params: dict[str, Any] = {"id": resource_id, "mip": mip, "slice": array_slice}
+    if histogram:
+        params["histogram"] = True
+    if eid is not None:
+        params["eid"] = eid
+    result = _daemon_call("tex_stats", params)
+    if use_json:
+        write_json(result)
+        return
+    mn, mx = result["min"], result["max"]
+    header = ["CHANNEL", "MIN", "MAX"]
+    rows = [
+        ["R", f"{mn['r']:.4f}", f"{mx['r']:.4f}"],
+        ["G", f"{mn['g']:.4f}", f"{mx['g']:.4f}"],
+        ["B", f"{mn['b']:.4f}", f"{mx['b']:.4f}"],
+        ["A", f"{mn['a']:.4f}", f"{mx['a']:.4f}"],
+    ]
+    write_tsv(rows, header=header)
+    if "histogram" in result:
+        click.echo()
+        hist_header = ["BUCKET", "R", "G", "B", "A"]
+        hist_rows = [[h["bucket"], h["r"], h["g"], h["b"], h["a"]] for h in result["histogram"]]
+        write_tsv(hist_rows, header=hist_header)

--- a/tests/mocks/mock_renderdoc.py
+++ b/tests/mocks/mock_renderdoc.py
@@ -1295,6 +1295,8 @@ class MockReplayController:
         self._debug_thread_map: dict[tuple[int, int, int, int, int, int], ShaderDebugTrace] = {}
         self._debug_states: dict[int, list[list[ShaderDebugState]]] = {}
         self._mesh_data: dict[int, MeshFormat] = {}
+        self._min_max_map: dict[int, tuple[PixelValue, PixelValue]] = {}
+        self._histogram_map: dict[tuple[int, int], list[int]] = {}
         self._target_encodings: list[int] = [3, 2]
         self._built_counter: int = 1000
         self._replacements: dict[int, int] = {}
@@ -1446,6 +1448,17 @@ class MockReplayController:
 
     def FreeTargetResource(self, rid: Any) -> None:
         self._freed.add(int(rid))
+
+    def GetMinMax(self, tex_id: Any, sub: Any, comp_type: Any) -> tuple[PixelValue, PixelValue]:
+        rid = int(tex_id)
+        return self._min_max_map.get(rid, (PixelValue(), PixelValue()))
+
+    def GetHistogram(
+        self, tex_id: Any, sub: Any, comp_type: Any, min_val: float, max_val: float, channels: Any
+    ) -> list[int]:
+        rid = int(tex_id)
+        ch = next((i for i, c in enumerate(channels) if c), 0)
+        return self._histogram_map.get((rid, ch), [0] * 256)
 
     def CreateOutput(self, windowing: Any, output_type: Any) -> MockReplayOutput:
         return MockReplayOutput()

--- a/tests/unit/test_tex_stats_commands.py
+++ b/tests/unit/test_tex_stats_commands.py
@@ -1,0 +1,153 @@
+"""Tests for rdc tex-stats CLI command."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from click.testing import CliRunner
+
+from rdc.cli import main
+from rdc.commands import tex_stats as tex_stats_mod
+
+_HAPPY_RESPONSE: dict[str, Any] = {
+    "id": 42,
+    "eid": 100,
+    "mip": 0,
+    "slice": 0,
+    "min": {"r": 0.0, "g": 0.0, "b": 0.01, "a": 1.0},
+    "max": {"r": 1.0, "g": 0.85, "b": 0.92, "a": 1.0},
+}
+
+_HISTOGRAM_RESPONSE: dict[str, Any] = {
+    **_HAPPY_RESPONSE,
+    "histogram": [{"bucket": i, "r": i, "g": i * 2, "b": i * 3, "a": 0} for i in range(256)],
+}
+
+_captured_params: dict[str, Any] = {}
+
+
+def _patch(monkeypatch: Any, response: dict[str, Any]) -> None:
+    def fake_daemon_call(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        _captured_params.clear()
+        _captured_params["method"] = method
+        _captured_params["params"] = params
+        return response
+
+    monkeypatch.setattr(tex_stats_mod, "_daemon_call", fake_daemon_call)
+
+
+# ---------------------------------------------------------------------------
+# Table output
+# ---------------------------------------------------------------------------
+
+
+def test_tex_stats_table_output(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _HAPPY_RESPONSE)
+    result = CliRunner().invoke(main, ["tex-stats", "42"])
+    assert result.exit_code == 0
+    lines = result.output.strip().split("\n")
+    assert lines[0] == "CHANNEL\tMIN\tMAX"
+    assert len(lines) == 5  # header + 4 rows
+    assert lines[1].startswith("R\t")
+    assert lines[4].startswith("A\t")
+
+
+def test_tex_stats_float_format(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _HAPPY_RESPONSE)
+    result = CliRunner().invoke(main, ["tex-stats", "42"])
+    assert result.exit_code == 0
+    lines = result.output.strip().split("\n")
+    assert "0.0000" in lines[1]
+    assert "1.0000" in lines[1]
+    assert "0.0100" in lines[3]
+
+
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+
+def test_tex_stats_json(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _HAPPY_RESPONSE)
+    result = CliRunner().invoke(main, ["tex-stats", "42", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "min" in data
+    assert "max" in data
+    assert data["min"]["r"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Histogram
+# ---------------------------------------------------------------------------
+
+
+def test_tex_stats_histogram_table(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _HISTOGRAM_RESPONSE)
+    result = CliRunner().invoke(main, ["tex-stats", "42", "--histogram"])
+    assert result.exit_code == 0
+    lines = result.output.strip().split("\n")
+    # 5 lines for min/max table, then 257 lines for histogram (header + 256 rows)
+    assert "CHANNEL\tMIN\tMAX" in lines[0]
+    assert "BUCKET\tR\tG\tB\tA" in result.output
+
+
+def test_tex_stats_histogram_json(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _HISTOGRAM_RESPONSE)
+    result = CliRunner().invoke(main, ["tex-stats", "42", "--histogram", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "histogram" in data
+    assert len(data["histogram"]) == 256
+
+
+# ---------------------------------------------------------------------------
+# Argument forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_tex_stats_eid_arg(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _HAPPY_RESPONSE)
+    CliRunner().invoke(main, ["tex-stats", "42", "200"])
+    assert _captured_params["params"]["eid"] == 200
+
+
+def test_tex_stats_eid_omitted(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _HAPPY_RESPONSE)
+    CliRunner().invoke(main, ["tex-stats", "42"])
+    assert "eid" not in _captured_params["params"]
+
+
+def test_tex_stats_mip_slice(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _HAPPY_RESPONSE)
+    CliRunner().invoke(main, ["tex-stats", "42", "--mip", "2", "--slice", "1"])
+    assert _captured_params["params"]["mip"] == 2
+    assert _captured_params["params"]["slice"] == 1
+
+
+def test_tex_stats_histogram_flag(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _HAPPY_RESPONSE)
+    CliRunner().invoke(main, ["tex-stats", "42", "--histogram"])
+    assert _captured_params["params"]["histogram"] is True
+
+
+def test_tex_stats_no_histogram_flag(monkeypatch: Any) -> None:
+    _patch(monkeypatch, _HAPPY_RESPONSE)
+    CliRunner().invoke(main, ["tex-stats", "42"])
+    assert "histogram" not in _captured_params["params"]
+
+
+# ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+
+
+def test_tex_stats_help() -> None:
+    result = CliRunner().invoke(main, ["tex-stats", "--help"])
+    assert result.exit_code == 0
+    assert "min/max" in result.output.lower() or "histogram" in result.output.lower()
+
+
+def test_tex_stats_registered() -> None:
+    assert "tex-stats" in CliRunner().invoke(main, ["--help"]).output

--- a/tests/unit/test_tex_stats_handler.py
+++ b/tests/unit/test_tex_stats_handler.py
@@ -1,0 +1,208 @@
+"""Tests for daemon tex_stats handler."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from rdc.adapter import RenderDocAdapter
+from rdc.daemon_server import DaemonState, _handle_request
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
+
+import mock_renderdoc as rd  # noqa: E402
+
+
+def _make_state(
+    tex_id: int = 42,
+    ms_samp: int = 1,
+    min_max: tuple[rd.PixelValue, rd.PixelValue] | None = None,
+    histogram: dict[tuple[int, int], list[int]] | None = None,
+) -> DaemonState:
+    ctrl = rd.MockReplayController()
+    rid = rd.ResourceId(tex_id)
+    ctrl._textures = [
+        rd.TextureDescription(resourceId=rid, width=256, height=256, msSamp=ms_samp),
+    ]
+    ctrl._actions = [
+        rd.ActionDescription(eventId=100, flags=rd.ActionFlags.Drawcall, _name="vkCmdDraw"),
+    ]
+    if min_max is not None:
+        ctrl._min_max_map[tex_id] = min_max
+    if histogram is not None:
+        ctrl._histogram_map.update(histogram)
+
+    state = DaemonState(capture="test.rdc", current_eid=100, token="tok")
+    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
+    state.max_eid = 100
+    state.rd = rd
+    state.tex_map = {int(t.resourceId): t for t in ctrl._textures}
+    return state
+
+
+def _req(params: dict[str, Any] | None = None) -> dict[str, Any]:
+    p: dict[str, Any] = {"_token": "tok"}
+    if params:
+        p.update(params)
+    return {"jsonrpc": "2.0", "id": 1, "method": "tex_stats", "params": p}
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_tex_stats_happy_minmax() -> None:
+    mn = rd.PixelValue(floatValue=[0.0, 0.1, 0.2, 1.0])
+    mx = rd.PixelValue(floatValue=[1.0, 0.9, 0.8, 1.0])
+    state = _make_state(min_max=(mn, mx))
+    resp, running = _handle_request(_req({"id": 42}), state)
+    assert running
+    r = resp["result"]
+    assert r["id"] == 42
+    assert r["min"] == {"r": 0.0, "g": 0.1, "b": 0.2, "a": 1.0}
+    assert r["max"] == {"r": 1.0, "g": 0.9, "b": 0.8, "a": 1.0}
+
+
+def test_tex_stats_minmax_values() -> None:
+    mn = rd.PixelValue(floatValue=[0.25, 0.5, 0.75, 0.0])
+    mx = rd.PixelValue(floatValue=[0.75, 1.0, 1.0, 1.0])
+    state = _make_state(min_max=(mn, mx))
+    resp, _ = _handle_request(_req({"id": 42}), state)
+    r = resp["result"]
+    assert r["min"]["r"] == 0.25
+    assert r["max"]["g"] == 1.0
+
+
+def test_tex_stats_no_histogram_by_default() -> None:
+    state = _make_state()
+    resp, _ = _handle_request(_req({"id": 42}), state)
+    assert "histogram" not in resp["result"]
+
+
+def test_tex_stats_histogram_present() -> None:
+    mn = rd.PixelValue(floatValue=[0.0, 0.0, 0.0, 0.0])
+    mx = rd.PixelValue(floatValue=[1.0, 1.0, 1.0, 1.0])
+    hist = {(42, i): list(range(256)) for i in range(4)}
+    state = _make_state(min_max=(mn, mx), histogram=hist)
+    resp, _ = _handle_request(_req({"id": 42, "histogram": True}), state)
+    r = resp["result"]
+    assert "histogram" in r
+    assert len(r["histogram"]) == 256
+
+
+def test_tex_stats_histogram_values() -> None:
+    mn = rd.PixelValue(floatValue=[0.0, 0.0, 0.0, 0.0])
+    mx = rd.PixelValue(floatValue=[1.0, 1.0, 1.0, 1.0])
+    hist = {(42, i): list(range(256)) for i in range(4)}
+    state = _make_state(min_max=(mn, mx), histogram=hist)
+    resp, _ = _handle_request(_req({"id": 42, "histogram": True}), state)
+    entry = resp["result"]["histogram"][0]
+    assert set(entry.keys()) == {"bucket", "r", "g", "b", "a"}
+    assert entry["bucket"] == 0
+
+
+def test_tex_stats_mip_slice_forwarded() -> None:
+    state = _make_state()
+    resp, _ = _handle_request(_req({"id": 42, "mip": 2, "slice": 3}), state)
+    r = resp["result"]
+    assert r["mip"] == 2
+    assert r["slice"] == 3
+
+
+def test_tex_stats_eid_navigation() -> None:
+    state = _make_state()
+    state._eid_cache = -1
+    resp, _ = _handle_request(_req({"id": 42, "eid": 100}), state)
+    ctrl = state.adapter.controller  # type: ignore[union-attr]
+    assert (100, True) in ctrl._set_frame_event_calls
+    assert resp["result"]["eid"] == 100
+
+
+def test_tex_stats_default_eid() -> None:
+    state = _make_state()
+    state.current_eid = 100
+    resp, _ = _handle_request(_req({"id": 42}), state)
+    assert resp["result"]["eid"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_tex_stats_no_adapter() -> None:
+    state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
+    resp, _ = _handle_request(_req({"id": 42}), state)
+    assert resp["error"]["code"] == -32002
+
+
+def test_tex_stats_no_rd() -> None:
+    state = _make_state()
+    state.rd = None
+    resp, _ = _handle_request(_req({"id": 42}), state)
+    assert resp["error"]["code"] == -32002
+
+
+def test_tex_stats_unknown_id() -> None:
+    state = _make_state()
+    resp, _ = _handle_request(_req({"id": 999}), state)
+    assert resp["error"]["code"] == -32001
+    assert "999" in resp["error"]["message"]
+
+
+def test_tex_stats_msaa_rejected() -> None:
+    state = _make_state(ms_samp=4)
+    resp, _ = _handle_request(_req({"id": 42}), state)
+    assert resp["error"]["code"] == -32001
+    assert "MSAA" in resp["error"]["message"]
+
+
+def test_tex_stats_eid_out_of_range() -> None:
+    state = _make_state()
+    resp, _ = _handle_request(_req({"id": 42, "eid": 9999}), state)
+    assert resp["error"]["code"] == -32002
+
+
+# ---------------------------------------------------------------------------
+# Mock GetMinMax / GetHistogram
+# ---------------------------------------------------------------------------
+
+
+def test_mock_get_minmax_default() -> None:
+    ctrl = rd.MockReplayController()
+    mn, mx = ctrl.GetMinMax(rd.ResourceId(999), rd.Subresource(), rd.CompType.Typeless)
+    assert mn.floatValue == [0.0, 0.0, 0.0, 0.0]
+    assert mx.floatValue == [0.0, 0.0, 0.0, 0.0]
+
+
+def test_mock_get_minmax_configured() -> None:
+    ctrl = rd.MockReplayController()
+    expected_min = rd.PixelValue(floatValue=[0.1, 0.2, 0.3, 0.4])
+    expected_max = rd.PixelValue(floatValue=[0.5, 0.6, 0.7, 0.8])
+    ctrl._min_max_map[42] = (expected_min, expected_max)
+    mn, mx = ctrl.GetMinMax(rd.ResourceId(42), rd.Subresource(), rd.CompType.Typeless)
+    assert mn.floatValue == [0.1, 0.2, 0.3, 0.4]
+    assert mx.floatValue == [0.5, 0.6, 0.7, 0.8]
+
+
+def test_mock_get_histogram_default() -> None:
+    ctrl = rd.MockReplayController()
+    ch_mask = [True, False, False, False]
+    result = ctrl.GetHistogram(
+        rd.ResourceId(999), rd.Subresource(), rd.CompType.Typeless, 0.0, 1.0, ch_mask
+    )
+    assert len(result) == 256
+    assert all(v == 0 for v in result)
+
+
+def test_mock_get_histogram_configured() -> None:
+    ctrl = rd.MockReplayController()
+    expected = list(range(256))
+    ctrl._histogram_map[(42, 0)] = expected
+    ch_mask = [True, False, False, False]
+    result = ctrl.GetHistogram(
+        rd.ResourceId(42), rd.Subresource(), rd.CompType.Typeless, 0.0, 1.0, ch_mask
+    )
+    assert result == expected


### PR DESCRIPTION
## Summary

- Add `rdc tex-stats <resource_id> [eid] [--mip N] [--slice N] [--histogram] [--json]` for inspecting texture value ranges
- Uses `GetMinMax` for per-channel min/max, `GetHistogram` for 256-bucket distribution
- Manual `Subresource` construction (supports both mip and slice, unlike `_make_subresource`)
- MSAA guard returns error for multisampled textures
- 28 new unit tests + 6 GPU integration tests

## Test plan

- [x] `pixi run lint` — all checks passed
- [x] `pixi run test` — 1498 passed, 95.10% coverage
- [x] e2e tests — 26 passed, 0 failed
- [ ] GPU: `rdc tex-stats <texture_id>` and `rdc tex-stats <texture_id> --histogram` with real capture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a new `tex-stats` command that analyzes texture statistics, displaying minimum and maximum color values per channel (R, G, B, A).
* Supports optional histogram generation to visualize color distribution across textures.
* Output available in both table and JSON formats for flexible data consumption.
* Includes options for MIP level and array slice selection with frame event navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->