### PR TITLE
fix(security): restrict session file perms, add temp dir cleanup, log handler exceptions

### DIFF
--- a/src/rdc/session_state.py
+++ b/src/rdc/session_state.py
@@ -57,9 +57,14 @@ def load_session() -> SessionState | None:
 
 
 def save_session(state: SessionState) -> None:
+    """Write session state to disk with restricted permissions."""
     path = session_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(asdict(state), indent=2))
+    os.chmod(path.parent, 0o700)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(json.dumps(asdict(state), indent=2))
+    os.chmod(path, 0o600)
 
 
 def create_session(


### PR DESCRIPTION
## Summary

- **P0-SEC-1**: `save_session()` now creates `~/.rdc/sessions/` with `mode=0o700` (via explicit `os.chmod` to bypass umask) and writes the token file via `os.open(mode=0o600)` + follow-up `os.chmod`, preventing any local user from reading the auth token
- **P1-SEC-3**: daemon `_load_replay()` registers `atexit(_cleanup_temp)` immediately after `mkdtemp`; `main()` installs a `SIGTERM` handler that calls `sys.exit(0)` to trigger atexit on signal
- **P1-OBS-1**: extracted inline `try/except` in `run_server` into `_process_request()` — adds `logger.exception()` logging on unhandled handler errors without changing the JSON-RPC error response shape

## Test plan

- [ ] `test_save_session_file_mode_0600` / `test_save_session_dir_mode_0700` — assert exact permission bits
- [ ] `test_save_session_umask_override` — verify `os.chmod` overrides umask `0o022`
- [ ] `test_save_session_corrects_existing_file_perms` — overwrites `0o644` file, corrects to `0o600`
- [ ] `test_load_replay_registers_atexit` / `test_cleanup_temp_*` — atexit registration and idempotent cleanup
- [ ] `test_main_installs_sigterm_handler` — SIGTERM triggers `sys.exit(0)`
- [ ] `test_exception_is_logged` / `test_exception_returns_internal_error` / `test_exception_keeps_running_for_non_shutdown` — `_process_request` behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon robustness with centralized error handling and logging for unhandled exceptions.
  * Added graceful shutdown support via signal handling.
  * Implemented automatic cleanup of temporary resources on daemon exit.

* **Security**
  * Enhanced session file permissions with restricted read/write access.

* **Tests**
  * Added comprehensive unit test coverage for daemon reliability and session state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->