### PR TITLE
refactor(daemon): extract adapter-guard middleware and clean up handler boilerplate

### DIFF
--- a/src/rdc/discover.py
+++ b/src/rdc/discover.py
@@ -74,11 +74,11 @@ def _try_import_from(directory: str) -> ModuleType | None:
     if directory in sys.path:
         return _try_import()
 
-    sys.path.insert(0, directory)
+    sys.path.append(directory)
     try:
         mod = importlib.import_module("renderdoc")
     except Exception:  # noqa: BLE001
-        sys.path.pop(0)
+        sys.path.remove(directory)
         return None
     log.debug("renderdoc found at %s", directory)
     return mod

--- a/src/rdc/handlers/_helpers.py
+++ b/src/rdc/handlers/_helpers.py
@@ -292,7 +292,11 @@ def _ensure_shader_populated(
 ) -> dict[str, Any] | None:
     """Trigger dynamic shader subtree population if needed."""
     m = _SHADER_PATH_RE.match(path)
-    if m and state.vfs_tree.get_draw_subtree(int(m.group(1))) is None:
+    if (
+        m
+        and state.vfs_tree is not None
+        and state.vfs_tree.get_draw_subtree(int(m.group(1))) is None
+    ):
         from rdc.vfs.tree_cache import populate_draw_subtree
 
         eid = int(m.group(1))
@@ -300,5 +304,6 @@ def _ensure_shader_populated(
         if err:
             return _error_response(request_id, -32002, err)
         pipe = state.adapter.get_pipeline_state()  # type: ignore[union-attr]
+        assert state.vfs_tree is not None
         populate_draw_subtree(state.vfs_tree, eid, pipe)
     return None

--- a/src/rdc/handlers/_types.py
+++ b/src/rdc/handlers/_types.py
@@ -1,0 +1,16 @@
+"""Shared type aliases for handler modules."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+# DaemonState lives in daemon_server which imports handler modules,
+# so we use a string literal to break the cycle.  With
+# ``from __future__ import annotations`` every annotation is a string
+# at runtime anyway, so mypy resolves it via TYPE_CHECKING.
+from typing import TYPE_CHECKING, Any, TypeAlias
+
+if TYPE_CHECKING:
+    from rdc.daemon_server import DaemonState
+
+Handler: TypeAlias = Callable[[int, dict[str, Any], "DaemonState"], tuple[dict[str, Any], bool]]

--- a/src/rdc/handlers/core.py
+++ b/src/rdc/handlers/core.py
@@ -9,6 +9,7 @@ from rdc.handlers._helpers import (
     _result_response,
     _set_frame_event,
 )
+from rdc.handlers._types import Handler
 
 if TYPE_CHECKING:
     from rdc.daemon_server import DaemonState
@@ -97,7 +98,13 @@ def _handle_shutdown(
     return _result_response(request_id, {"ok": True}), False
 
 
-HANDLERS: dict[str, Any] = {
+_handle_ping._no_replay = True  # type: ignore[attr-defined]
+_handle_status._no_replay = True  # type: ignore[attr-defined]
+_handle_goto._no_replay = True  # type: ignore[attr-defined]
+_handle_shutdown._no_replay = True  # type: ignore[attr-defined]
+_handle_count._no_replay = True  # type: ignore[attr-defined]
+
+HANDLERS: dict[str, Handler] = {
     "ping": _handle_ping,
     "status": _handle_status,
     "goto": _handle_goto,

--- a/src/rdc/handlers/debug.py
+++ b/src/rdc/handlers/debug.py
@@ -11,6 +11,7 @@ from rdc.handlers._helpers import (
     _result_response,
     _set_frame_event,
 )
+from rdc.handlers._types import Handler
 
 if TYPE_CHECKING:
     from rdc.daemon_server import DaemonState
@@ -110,8 +111,7 @@ def _handle_debug_pixel(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
     """Handle debug_pixel JSON-RPC request."""
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     for key in ("eid", "x", "y"):
         if key not in params:
             return _error_response(request_id, -32602, f"missing required param: {key}"), True
@@ -156,8 +156,7 @@ def _handle_debug_vertex(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
     """Handle debug_vertex JSON-RPC request."""
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     for key in ("eid", "vtx_id"):
         if key not in params:
             return _error_response(request_id, -32602, f"missing required param: {key}"), True
@@ -199,8 +198,7 @@ def _handle_debug_thread(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
     """Handle debug_thread JSON-RPC request."""
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     for key in ("eid", "gx", "gy", "gz", "tx", "ty", "tz"):
         if key not in params:
             return _error_response(request_id, -32602, f"missing required param: {key}"), True
@@ -243,7 +241,7 @@ def _handle_debug_thread(
     ), True
 
 
-HANDLERS: dict[str, Any] = {
+HANDLERS: dict[str, Handler] = {
     "debug_pixel": _handle_debug_pixel,
     "debug_vertex": _handle_debug_vertex,
     "debug_thread": _handle_debug_thread,

--- a/src/rdc/handlers/descriptor.py
+++ b/src/rdc/handlers/descriptor.py
@@ -10,6 +10,7 @@ from rdc.handlers._helpers import (
     _result_response,
     _set_frame_event,
 )
+from rdc.handlers._types import Handler
 
 if TYPE_CHECKING:
     from rdc.daemon_server import DaemonState
@@ -18,8 +19,7 @@ if TYPE_CHECKING:
 def _handle_descriptors(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -70,8 +70,7 @@ def _handle_descriptors(
 def _handle_usage(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     resid = int(params.get("id", 0))
     if resid not in state.res_names:
         return _error_response(request_id, -32001, f"resource {resid} not found"), True
@@ -87,8 +86,7 @@ def _handle_usage(
 def _handle_usage_all(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     type_filter = params.get("type")
     usage_filter = params.get("usage")
     usage_rows: list[dict[str, Any]] = []
@@ -111,8 +109,7 @@ def _handle_usage_all(
 def _handle_counter_list(  # noqa: PLR0912
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     controller = state.adapter.controller
     raw_counters = controller.EnumerateCounters()
     counters_out = []
@@ -146,8 +143,7 @@ def _handle_counter_list(  # noqa: PLR0912
 def _handle_counter_fetch(  # noqa: PLR0912
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     controller = state.adapter.controller
     raw_counters = controller.EnumerateCounters()
     counter_info: dict[int, dict[str, Any]] = {}
@@ -207,7 +203,7 @@ def _handle_counter_fetch(  # noqa: PLR0912
     return _result_response(request_id, {"rows": fetch_rows, "total": len(fetch_rows)}), True
 
 
-HANDLERS: dict[str, Any] = {
+HANDLERS: dict[str, Handler] = {
     "descriptors": _handle_descriptors,
     "usage": _handle_usage,
     "usage_all": _handle_usage_all,

--- a/src/rdc/handlers/pipe_state.py
+++ b/src/rdc/handlers/pipe_state.py
@@ -13,6 +13,7 @@ from rdc.handlers._helpers import (
     _sanitize_size,
     _set_frame_event,
 )
+from rdc.handlers._types import Handler
 
 if TYPE_CHECKING:
     from rdc.daemon_server import DaemonState
@@ -21,8 +22,7 @@ if TYPE_CHECKING:
 def _handle_pipe_topology(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -36,8 +36,7 @@ def _handle_pipe_topology(
 def _handle_pipe_viewport(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -61,8 +60,7 @@ def _handle_pipe_viewport(
 def _handle_pipe_scissor(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -85,8 +83,7 @@ def _handle_pipe_scissor(
 def _handle_pipe_blend(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -116,8 +113,7 @@ def _handle_pipe_blend(
 def _handle_pipe_stencil(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -144,8 +140,7 @@ def _handle_pipe_stencil(
 def _handle_pipe_vinputs(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -171,8 +166,7 @@ def _handle_pipe_vinputs(
 def _handle_pipe_samplers(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -206,8 +200,7 @@ def _handle_pipe_samplers(
 def _handle_pipe_vbuffers(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -231,8 +224,7 @@ def _handle_pipe_vbuffers(
 def _handle_pipe_ibuffer(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -254,8 +246,7 @@ def _handle_pipe_ibuffer(
 def _handle_pipe_push_constants(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -278,8 +269,7 @@ def _handle_pipe_push_constants(
 def _handle_pipe_rasterizer(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -307,8 +297,7 @@ def _handle_pipe_rasterizer(
 def _handle_pipe_depth_stencil(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -335,8 +324,7 @@ def _handle_pipe_depth_stencil(
 def _handle_pipe_msaa(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -352,7 +340,7 @@ def _handle_pipe_msaa(
     return _result_response(request_id, ms_data), True
 
 
-HANDLERS: dict[str, Any] = {
+HANDLERS: dict[str, Handler] = {
     "pipe_topology": _handle_pipe_topology,
     "pipe_viewport": _handle_pipe_viewport,
     "pipe_scissor": _handle_pipe_scissor,

--- a/src/rdc/handlers/pixel.py
+++ b/src/rdc/handlers/pixel.py
@@ -10,6 +10,7 @@ from rdc.handlers._helpers import (
     _result_response,
     _set_frame_event,
 )
+from rdc.handlers._types import Handler
 
 if TYPE_CHECKING:
     from rdc.daemon_server import DaemonState
@@ -72,8 +73,7 @@ def _handle_pixel_history(
     Returns:
         Tuple of (response dict, keep_running bool).
     """
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     for key in ("x", "y"):
         if key not in params:
             return _error_response(request_id, -32602, f"missing required param: {key}"), True
@@ -137,8 +137,7 @@ def _handle_pick_pixel(
     Returns:
         Tuple of (response dict, keep_running bool).
     """
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     for key in ("x", "y"):
         if key not in params:
             return _error_response(request_id, -32602, f"missing required param: {key}"), True
@@ -189,7 +188,7 @@ def _handle_pick_pixel(
     ), True
 
 
-HANDLERS: dict[str, Any] = {
+HANDLERS: dict[str, Handler] = {
     "pixel_history": _handle_pixel_history,
     "pick_pixel": _handle_pick_pixel,
 }

--- a/src/rdc/handlers/query.py
+++ b/src/rdc/handlers/query.py
@@ -20,6 +20,7 @@ from rdc.handlers._helpers import (
     _result_response,
     _set_frame_event,
 )
+from rdc.handlers._types import Handler
 
 if TYPE_CHECKING:
     from rdc.daemon_server import DaemonState
@@ -35,8 +36,7 @@ def _get_flat_actions(state: DaemonState) -> list[Any]:
 def _handle_shader_map(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     from rdc.services.query_service import collect_shader_map
 
     actions = state.adapter.get_root_actions()
@@ -48,8 +48,7 @@ def _handle_shader_map(
 def _handle_pipeline(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     from rdc.services.query_service import pipeline_row
 
     eid = int(params.get("eid", state.current_eid))
@@ -79,8 +78,7 @@ def _handle_pipeline(
 def _handle_bindings(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     from rdc.services.query_service import bindings_rows
 
     eid = int(params.get("eid", state.current_eid))
@@ -103,8 +101,7 @@ def _handle_bindings(
 def _handle_shader(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     from rdc.services.query_service import shader_row
 
     eid = int(params.get("eid", state.current_eid))
@@ -122,8 +119,7 @@ def _handle_shader(
 def _handle_shaders(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     from rdc.services.query_service import shader_inventory
 
     actions = state.adapter.get_root_actions()
@@ -139,8 +135,7 @@ def _handle_shaders(
 def _handle_resources(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     from rdc.services.query_service import get_resources
 
     rows = get_resources(state.adapter)
@@ -160,8 +155,7 @@ def _handle_resources(
 def _handle_resource(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     from rdc.services.query_service import get_resource_detail
 
     resid = int(params.get("id", 0))
@@ -174,8 +168,7 @@ def _handle_resource(
 def _handle_passes(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     from rdc.services.query_service import get_pass_hierarchy
 
     actions = state.adapter.get_root_actions()
@@ -186,8 +179,7 @@ def _handle_passes(
 def _handle_pass(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     from rdc.services.query_service import get_pass_detail
 
     identifier: int | str
@@ -224,8 +216,7 @@ def _handle_pass(
 def _handle_log(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     controller = state.adapter.controller
     level_filter = params.get("level")
     if level_filter is not None:
@@ -254,8 +245,7 @@ def _handle_log(
 def _handle_info(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     from rdc.services.query_service import aggregate_stats
 
     flat = _get_flat_actions(state)
@@ -281,8 +271,7 @@ def _handle_info(
 def _handle_stats(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     from rdc.services.query_service import aggregate_stats, get_top_draws
 
     flat = _get_flat_actions(state)
@@ -314,8 +303,7 @@ def _handle_stats(
 def _handle_events(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     from rdc.services.query_service import filter_by_pattern, filter_by_type
 
     flat = _get_flat_actions(state)
@@ -341,8 +329,7 @@ def _handle_events(
 def _handle_draws(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     from rdc.services.query_service import (
         aggregate_stats,
         filter_by_pass,
@@ -388,8 +375,7 @@ def _handle_draws(
 def _handle_event(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = params.get("eid")
     if eid is None:
         return _error_response(request_id, -32602, "missing eid parameter"), True
@@ -433,8 +419,7 @@ def _handle_event(
 def _handle_draw(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     from rdc.services.query_service import find_action_by_eid, walk_actions
 
     eid = params.get("eid")
@@ -469,8 +454,7 @@ def _handle_draw(
 def _handle_search(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     pattern = str(params.get("pattern", ""))
     if not pattern:
         return _error_response(request_id, -32602, "missing pattern"), True
@@ -519,7 +503,7 @@ def _handle_search(
     return _result_response(request_id, {"matches": matches, "truncated": truncated}), True
 
 
-HANDLERS: dict[str, Any] = {
+HANDLERS: dict[str, Handler] = {
     "shader_map": _handle_shader_map,
     "pipeline": _handle_pipeline,
     "bindings": _handle_bindings,

--- a/src/rdc/handlers/script.py
+++ b/src/rdc/handlers/script.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from rdc.handlers._helpers import _error_response, _result_response
+from rdc.handlers._types import Handler
 
 if TYPE_CHECKING:
     from rdc.daemon_server import DaemonState
@@ -28,8 +29,6 @@ def _handle_script(
     Returns:
         Tuple of (response_dict, keep_running).
     """
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
     if "path" not in params:
         return _error_response(request_id, -32602, "missing required param: path"), True
 
@@ -39,6 +38,7 @@ def _handle_script(
     if not path.is_file():
         return _error_response(request_id, -32002, "script path is a directory"), True
 
+    assert state.adapter is not None
     source = path.read_text("utf-8")
 
     try:
@@ -87,6 +87,6 @@ def _handle_script(
     ), True
 
 
-HANDLERS: dict[str, Any] = {
+HANDLERS: dict[str, Handler] = {
     "script": _handle_script,
 }

--- a/src/rdc/handlers/shader.py
+++ b/src/rdc/handlers/shader.py
@@ -13,6 +13,7 @@ from rdc.handlers._helpers import (
     get_default_disasm_target,
     get_pipeline_for_stage,
 )
+from rdc.handlers._types import Handler
 
 if TYPE_CHECKING:
     from rdc.daemon_server import DaemonState
@@ -21,8 +22,7 @@ if TYPE_CHECKING:
 def _handle_shader_targets(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     controller = state.adapter.controller
     if hasattr(controller, "GetDisassemblyTargets"):
         targets = controller.GetDisassemblyTargets(True)
@@ -35,8 +35,7 @@ def _handle_shader_targets(
 def _handle_shader_reflect(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     stage = str(params.get("stage", "ps")).lower()
     if stage not in STAGE_MAP:
@@ -141,8 +140,7 @@ def _flatten_shader_var(var: Any) -> dict[str, Any]:
 def _handle_shader_constants(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     stage = str(params.get("stage", "ps")).lower()
     if stage not in STAGE_MAP:
@@ -195,8 +193,7 @@ def _handle_shader_constants(
 def _handle_shader_source(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     stage = str(params.get("stage", "ps")).lower()
     if stage not in STAGE_MAP:
@@ -239,8 +236,7 @@ def _handle_shader_source(
 def _handle_shader_disasm(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     stage = str(params.get("stage", "ps")).lower()
     target = str(params.get("target", ""))
@@ -272,8 +268,7 @@ def _handle_shader_disasm(
 def _handle_shader_all(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     eid = int(params.get("eid", state.current_eid))
     err = _set_frame_event(state, eid)
     if err:
@@ -307,8 +302,6 @@ def _handle_shader_all(
 def _handle_shader_list_info(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
     _build_shader_cache(state)
     sid = int(params.get("id", 0))
     info_meta = state.shader_meta.get(sid)
@@ -320,8 +313,6 @@ def _handle_shader_list_info(
 def _handle_shader_list_disasm(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
     _build_shader_cache(state)
     sid = int(params.get("id", 0))
     if sid not in state.disasm_cache:
@@ -329,7 +320,7 @@ def _handle_shader_list_disasm(
     return _result_response(request_id, {"id": sid, "disasm": state.disasm_cache[sid]}), True
 
 
-HANDLERS: dict[str, Any] = {
+HANDLERS: dict[str, Handler] = {
     "shader_targets": _handle_shader_targets,
     "shader_reflect": _handle_shader_reflect,
     "shader_constants": _handle_shader_constants,

--- a/src/rdc/handlers/shader_edit.py
+++ b/src/rdc/handlers/shader_edit.py
@@ -10,6 +10,7 @@ from rdc.handlers._helpers import (
     _result_response,
     _set_frame_event,
 )
+from rdc.handlers._types import Handler
 
 if TYPE_CHECKING:
     from rdc.daemon_server import DaemonState
@@ -32,8 +33,7 @@ _ENCODING_VALUES: dict[str, int] = {v.upper(): k for k, v in _ENCODING_NAMES.ite
 def _handle_shader_encodings(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     controller = state.adapter.controller
     raw = controller.GetTargetShaderEncodings()
     encodings = sorted(
@@ -46,8 +46,7 @@ def _handle_shader_encodings(
 def _handle_shader_build(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     if "source" not in params:
         return _error_response(request_id, -32602, "missing required param: source"), True
     stage = str(params.get("stage", "")).lower()
@@ -76,8 +75,7 @@ def _handle_shader_build(
 def _handle_shader_replace(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     for key in ("shader_id", "eid"):
         if key not in params:
             return _error_response(request_id, -32602, f"missing required param: {key}"), True
@@ -110,8 +108,7 @@ def _handle_shader_replace(
 def _handle_shader_restore(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     if "eid" not in params:
         return _error_response(request_id, -32602, "missing required param: eid"), True
     stage = str(params.get("stage", "")).lower()
@@ -138,9 +135,7 @@ def _handle_shader_restore(
 def _handle_shader_restore_all(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
-
+    assert state.adapter is not None
     controller = state.adapter.controller
     restored_count = len(state.shader_replacements)
     freed_count = len(state.built_shaders)
@@ -158,7 +153,7 @@ def _handle_shader_restore_all(
     ), True
 
 
-HANDLERS: dict[str, Any] = {
+HANDLERS: dict[str, Handler] = {
     "shader_encodings": _handle_shader_encodings,
     "shader_build": _handle_shader_build,
     "shader_replace": _handle_shader_replace,

--- a/src/rdc/handlers/texture.py
+++ b/src/rdc/handlers/texture.py
@@ -12,6 +12,7 @@ from rdc.handlers._helpers import (
     _result_response,
     _set_frame_event,
 )
+from rdc.handlers._types import Handler
 
 if TYPE_CHECKING:
     from rdc.daemon_server import DaemonState
@@ -32,8 +33,6 @@ _OVERLAY_MAP: dict[str, int] = {
 def _handle_tex_info(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
     res_id = int(params.get("id", 0))
     tex = state.tex_map.get(res_id)
     if tex is None:
@@ -64,8 +63,7 @@ def _handle_tex_info(
 def _handle_tex_export(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     if state.rd is None:
         return _error_response(request_id, -32002, "renderdoc module not available"), True
     if state.temp_dir is None:
@@ -94,8 +92,7 @@ def _handle_tex_export(
 def _handle_tex_raw(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     if state.rd is None:
         return _error_response(request_id, -32002, "renderdoc module not available"), True
     if state.temp_dir is None:
@@ -118,8 +115,7 @@ def _handle_tex_raw(
 def _handle_rt_export(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     if state.rd is None:
         return _error_response(request_id, -32002, "renderdoc module not available"), True
     if state.temp_dir is None:
@@ -151,8 +147,7 @@ def _handle_rt_export(
 def _handle_rt_depth(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     if state.rd is None:
         return _error_response(request_id, -32002, "renderdoc module not available"), True
     if state.temp_dir is None:
@@ -180,8 +175,7 @@ def _handle_rt_overlay(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
     """Render a debug overlay on the color target and save as PNG."""
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     if state.rd is None:
         return _error_response(request_id, -32002, "renderdoc module not available"), True
     if state.temp_dir is None:
@@ -241,8 +235,7 @@ def _handle_rt_overlay(
 def _handle_tex_stats(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     if state.rd is None:
         return _error_response(request_id, -32002, "renderdoc module not available"), True
 
@@ -315,7 +308,7 @@ def _handle_tex_stats(
     return _result_response(request_id, result_data), True
 
 
-HANDLERS: dict[str, Any] = {
+HANDLERS: dict[str, Handler] = {
     "tex_info": _handle_tex_info,
     "tex_export": _handle_tex_export,
     "tex_raw": _handle_tex_raw,

--- a/src/rdc/handlers/vfs.py
+++ b/src/rdc/handlers/vfs.py
@@ -13,6 +13,7 @@ from rdc.handlers._helpers import (
     _resolve_vfs_path,
     _result_response,
 )
+from rdc.handlers._types import Handler
 
 if TYPE_CHECKING:
     from rdc.daemon_server import DaemonState
@@ -70,6 +71,7 @@ def _ls_long_children(
 
 
 def _long_passes(node: VfsNode, state: DaemonState) -> list[dict[str, Any]]:
+    assert state.vfs_tree is not None
     pass_map = {p["name"]: p for p in (state.vfs_tree.pass_list or [])}
     safe_map = state.vfs_tree.pass_name_map
     result: list[dict[str, Any]] = []
@@ -89,6 +91,7 @@ def _long_passes(node: VfsNode, state: DaemonState) -> list[dict[str, Any]]:
 
 
 def _long_draws(node: VfsNode, parent: str, state: DaemonState) -> list[dict[str, Any]]:
+    assert state.vfs_tree is not None
     flat = _get_flat_actions(state)
     eid_map = {str(a.eid): a for a in flat}
     result: list[dict[str, Any]] = []
@@ -123,6 +126,7 @@ def _long_draws(node: VfsNode, parent: str, state: DaemonState) -> list[dict[str
 
 
 def _long_events(node: VfsNode, parent: str, state: DaemonState) -> list[dict[str, Any]]:
+    assert state.vfs_tree is not None
     flat = _get_flat_actions(state)
     eid_map = {str(a.eid): a for a in flat}
     result: list[dict[str, Any]] = []
@@ -241,6 +245,7 @@ def _long_shaders(node: VfsNode, state: DaemonState) -> list[dict[str, Any]]:
 
 
 def _long_default(node: VfsNode, parent: str, state: DaemonState) -> list[dict[str, Any]]:
+    assert state.vfs_tree is not None
     result: list[dict[str, Any]] = []
     for name in node.children:
         child_path = f"{parent}/{name}" if parent != "/" else f"/{name}"
@@ -258,8 +263,7 @@ def _long_default(node: VfsNode, parent: str, state: DaemonState) -> list[dict[s
 def _handle_vfs_ls(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     path = str(params.get("path", "/"))
     long = bool(params.get("long", False))
     path, err = _resolve_vfs_path(path, state)
@@ -304,8 +308,7 @@ def _handle_vfs_ls(
 def _handle_vfs_tree(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
-    if state.adapter is None:
-        return _error_response(request_id, -32002, "no replay loaded"), True
+    assert state.adapter is not None
     path = str(params.get("path", "/"))
     depth = int(params.get("depth", 2))
     path, err = _resolve_vfs_path(path, state)
@@ -343,7 +346,7 @@ def _handle_vfs_tree(
     return _result_response(request_id, {"path": path, "tree": _subtree(path, depth)}), True
 
 
-HANDLERS: dict[str, Any] = {
+HANDLERS: dict[str, Handler] = {
     "vfs_ls": _handle_vfs_ls,
     "vfs_tree": _handle_vfs_tree,
 }

--- a/tests/unit/test_discover.py
+++ b/tests/unit/test_discover.py
@@ -1,0 +1,50 @@
+"""Tests for discover.py — sys.path insertion order (P2-ARCH-1)."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+from rdc.discover import _try_import_from
+
+
+class TestTryImportFrom:
+    """_try_import_from appends to sys.path (not insert at 0) and cleans up on failure."""
+
+    def test_success_appends_to_end(self, tmp_path: str, monkeypatch: object) -> None:
+        """On success, directory appears at the END of sys.path."""
+        import types
+
+        fake_dir = str(tmp_path)
+        fake_mod = types.ModuleType("renderdoc")
+        fake_mod.GetVersionString = lambda: "1.41"  # type: ignore[attr-defined]
+
+        # Ensure directory is not already in sys.path
+        if fake_dir in sys.path:
+            sys.path.remove(fake_dir)
+
+        with patch("importlib.import_module", return_value=fake_mod):
+            result = _try_import_from(fake_dir)
+
+        assert result is fake_mod
+        assert fake_dir in sys.path
+        # It should be at the end, not at index 0
+        assert sys.path[-1] == fake_dir
+
+        # Cleanup
+        sys.path.remove(fake_dir)
+
+    def test_failure_removes_from_path(self, tmp_path: str) -> None:
+        """On import failure, directory is removed from sys.path."""
+
+        fake_dir = str(tmp_path)
+
+        # Ensure directory is not already in sys.path
+        if fake_dir in sys.path:
+            sys.path.remove(fake_dir)
+
+        with patch("importlib.import_module", side_effect=ImportError("no module")):
+            result = _try_import_from(fake_dir)
+
+        assert result is None
+        assert fake_dir not in sys.path


### PR DESCRIPTION
## Summary

- **P1-MAINT-1**: Add centralized adapter-guard middleware in `_handle_request()` — checks `state.adapter is None` once instead of 70+ times. Mark 5 no-replay handlers (`ping`, `status`, `goto`, `shutdown`, `count`) with `_no_replay = True`. Remove ~70 redundant top-of-function guards from 12 handler files.
- **P2-MAINT-1**: Extract `_decode_float_components()` and `_decode_index_buffer()` helpers in `handlers/buffer.py`; replace duplicated `struct.unpack_from` loops in `_handle_vbuffer_decode`, `_handle_mesh_data`, and `_handle_ibuffer_decode`. Intentional bug fix: `_handle_mesh_data` comp_width==1 now normalizes byte values as `data[off] / 255.0` (was silently returning 0.0).
- **P2-ARCH-1**: `discover.py` `_try_import_from()`: `sys.path.insert(0, …)` → `sys.path.append(…)` so renderdoc directory never shadows stdlib/project modules; cleanup uses `sys.path.remove()`.
- **P2-MAINT-2**: Define `Handler` TypeAlias in `handlers/_types.py`; retype `_DISPATCH` and all `HANDLERS` dicts; tighten `DaemonState.vfs_tree` from `Any` to `VfsTree | None`.

## Test plan
- [x] `tests/unit/test_daemon_server_unit.py` — 5 new middleware tests (no-replay handlers work with `adapter=None`; replay-required blocked with -32002)
- [x] `tests/unit/test_buffer_decode.py` — 13 new tests for `_decode_float_components` (all widths), `_decode_index_buffer` (all strides), golden-value comparisons for 3 refactored handlers
- [x] `tests/unit/test_discover.py` — 2 new tests for `sys.path.append` semantics and failure cleanup
- [x] `pixi run lint && pixi run test` — 1641 tests, 95.79% coverage, 0 mypy errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added replay requirement validation to ensure operations execute only when appropriate replay data is loaded.

* **Refactor**
  * Strengthened type annotations across handler modules for improved code reliability.
  * Optimized buffer decoding with new helper utilities.

* **Tests**
  * Expanded unit test coverage for buffer decoding and replay requirement enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->