### PR TITLE
fix(output): JSON-aware error output for --json flag

### DIFF
--- a/tests/unit/test_json_errors.py
+++ b/tests/unit/test_json_errors.py
@@ -1,0 +1,208 @@
+"""Tests for B2: JSON-aware error output in _helpers and assert_ci."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import click
+from click.testing import CliRunner
+
+import rdc.commands._helpers as helpers_mod
+import rdc.commands.assert_ci as assert_ci_mod
+from rdc.cli import main
+from rdc.commands._helpers import _json_mode, call, require_session
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_session() -> MagicMock:
+    return MagicMock(host="localhost", port=9876, token="tok" * 4)
+
+
+# ---------------------------------------------------------------------------
+# require_session — plain text
+# ---------------------------------------------------------------------------
+
+
+def test_require_session_no_json_plain_error(monkeypatch: Any) -> None:
+    """No --json flag: stderr contains plain-text error."""
+    monkeypatch.setattr(helpers_mod, "load_session", lambda: None)
+
+    @click.command("dummy")
+    def cmd() -> None:
+        require_session()
+
+    runner = CliRunner()
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == 1
+    assert "error:" in result.stderr
+    assert not result.stderr.strip().startswith("{")
+
+
+# ---------------------------------------------------------------------------
+# require_session — JSON
+# ---------------------------------------------------------------------------
+
+
+def test_require_session_json_error(monkeypatch: Any) -> None:
+    """With --json flag: stderr is valid JSON error envelope."""
+    monkeypatch.setattr(helpers_mod, "load_session", lambda: None)
+
+    @click.command("dummy")
+    @click.option("--json", "output_json", is_flag=True)
+    def cmd(output_json: bool) -> None:
+        require_session()
+
+    runner = CliRunner()
+    result = runner.invoke(cmd, ["--json"])
+    assert result.exit_code == 1
+    data = json.loads(result.stderr.strip())
+    assert "error" in data
+    assert isinstance(data["error"]["message"], str)
+    assert len(data["error"]["message"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# call — OSError plain
+# ---------------------------------------------------------------------------
+
+
+def test_call_oserror_plain_error(monkeypatch: Any) -> None:
+    """OSError without --json: plain text on stderr."""
+    monkeypatch.setattr(helpers_mod, "load_session", lambda: _fake_session())
+    monkeypatch.setattr(helpers_mod, "send_request", _raise_oserror)
+
+    @click.command("dummy")
+    def cmd() -> None:
+        call("ping", {})
+
+    runner = CliRunner()
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == 1
+    assert "daemon unreachable" in result.stderr
+    assert not result.stderr.strip().startswith("{")
+
+
+def _raise_oserror(*_a: Any, **_kw: Any) -> None:
+    raise OSError("connection refused")
+
+
+# ---------------------------------------------------------------------------
+# call — OSError JSON
+# ---------------------------------------------------------------------------
+
+
+def test_call_oserror_json_error(monkeypatch: Any) -> None:
+    """OSError with --json: JSON envelope on stderr."""
+    monkeypatch.setattr(helpers_mod, "load_session", lambda: _fake_session())
+    monkeypatch.setattr(helpers_mod, "send_request", _raise_oserror)
+
+    @click.command("dummy")
+    @click.option("--json", "output_json", is_flag=True)
+    def cmd(output_json: bool) -> None:
+        call("ping", {})
+
+    runner = CliRunner()
+    result = runner.invoke(cmd, ["--json"])
+    assert result.exit_code == 1
+    data = json.loads(result.stderr.strip())
+    assert "error" in data
+    assert "unreachable" in data["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# call — daemon error plain
+# ---------------------------------------------------------------------------
+
+
+def test_call_daemon_error_plain(monkeypatch: Any) -> None:
+    """Daemon error without --json: plain text."""
+    monkeypatch.setattr(helpers_mod, "load_session", lambda: _fake_session())
+    monkeypatch.setattr(
+        helpers_mod,
+        "send_request",
+        lambda *a, **kw: {"error": {"message": "no capture loaded"}},
+    )
+
+    @click.command("dummy")
+    def cmd() -> None:
+        call("ping", {})
+
+    runner = CliRunner()
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == 1
+    assert "no capture loaded" in result.stderr
+    assert not result.stderr.strip().startswith("{")
+
+
+# ---------------------------------------------------------------------------
+# call — daemon error JSON
+# ---------------------------------------------------------------------------
+
+
+def test_call_daemon_error_json(monkeypatch: Any) -> None:
+    """Daemon error with --json: JSON on stderr."""
+    monkeypatch.setattr(helpers_mod, "load_session", lambda: _fake_session())
+    monkeypatch.setattr(
+        helpers_mod,
+        "send_request",
+        lambda *a, **kw: {"error": {"message": "no capture loaded"}},
+    )
+
+    @click.command("dummy")
+    @click.option("--json", "output_json", is_flag=True)
+    def cmd(output_json: bool) -> None:
+        call("ping", {})
+
+    runner = CliRunner()
+    result = runner.invoke(cmd, ["--json"])
+    assert result.exit_code == 1
+    data = json.loads(result.stderr.strip())
+    assert data == {"error": {"message": "no capture loaded"}}
+
+
+# ---------------------------------------------------------------------------
+# assert_ci — JSON error (no session)
+# ---------------------------------------------------------------------------
+
+
+def test_assert_ci_json_error_no_session(monkeypatch: Any) -> None:
+    """assert-count --json with no session: JSON error on stderr, exit 2."""
+    monkeypatch.setattr(assert_ci_mod, "load_session", lambda: None)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["assert-count", "draws", "--expect", "1", "--json"])
+    assert result.exit_code == 2
+    data = json.loads(result.stderr.strip())
+    assert "error" in data
+    assert isinstance(data["error"]["message"], str)
+
+
+# ---------------------------------------------------------------------------
+# assert_ci — plain error (no session)
+# ---------------------------------------------------------------------------
+
+
+def test_assert_ci_plain_error_no_session(monkeypatch: Any) -> None:
+    """assert-count without --json and no session: plain error, exit 2."""
+    monkeypatch.setattr(assert_ci_mod, "load_session", lambda: None)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["assert-count", "draws", "--expect", "1"])
+    assert result.exit_code == 2
+    assert "error:" in result.stderr
+    assert not result.stderr.strip().startswith("{")
+
+
+# ---------------------------------------------------------------------------
+# _json_mode — no Click context
+# ---------------------------------------------------------------------------
+
+
+def test_json_mode_false_without_context() -> None:
+    """_json_mode() returns False when called outside a Click invocation."""
+    assert _json_mode() is False


### PR DESCRIPTION
## Summary

- Add `_json_mode()` helper to `commands/_helpers.py` that detects the `--json` flag via the active Click context (checks `use_json`, `output_json`, `as_json` param names covering all command modules)
- Update `require_session()` and `call()` error paths to emit `{"error": {"message": "..."}}` JSON to stderr instead of plain text when `--json` is active
- Update `_assert_call()` in `assert_ci.py` to use the same helper, preserving `sys.exit(2)` exit code

Fixes B2 from 待解决.md: `--json` flag now consistently affects both success output (stdout) and error output (stderr).

## Test plan

- [ ] `test_require_session_plain_error` — no `--json` → plain text
- [ ] `test_require_session_json_error` — `--json` → `{"error": {"message": ...}}`
- [ ] `test_call_oserror_plain_error` / `test_call_oserror_json_error`
- [ ] `test_call_daemon_error_plain` / `test_call_daemon_error_json`
- [ ] `test_assert_ci_json_error_no_session` — exit code 2, JSON stderr
- [ ] `test_assert_ci_plain_error_no_session` — exit code 2, plain text preserved
- [ ] `test_json_mode_false_without_context` — returns False outside Click context
- [ ] Full suite: 1684 passed, 95.65% coverage



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error messages now support JSON formatting when JSON output is requested, providing structured error responses alongside plain-text alternatives across all error scenarios.

* **Tests**
  * Added comprehensive test coverage for JSON error output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->