### PR TITLE
feat(skill): add Claude Code SKILL.md with auto-generated command reference

### DIFF
--- a/.claude/skills/rdc-cli/SKILL.md
+++ b/.claude/skills/rdc-cli/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: rdc-cli
+description: >
+  Use this skill when working with RenderDoc capture files (.rdc), analyzing GPU frames,
+  tracing shaders, inspecting draw calls, or running CI assertions against GPU captures.
+  Trigger phrases: "open capture", "rdc file", ".rdc", "renderdoc", "shader debug",
+  "pixel trace", "draw calls", "GPU frame", "assert pixel", "export render target".
+---
+
+# rdc-cli Skill
+
+## Overview
+
+rdc-cli is a Unix-friendly command-line interface for RenderDoc GPU captures. It provides a daemon-backed architecture using JSON-RPC over TCP, a virtual filesystem (VFS) path namespace for navigating capture internals, and composable commands designed for shell pipelines, scripting, and CI assertions.
+
+Install: `pip install rdc-cli` (requires a local RenderDoc build with Python bindings).
+Check setup: `rdc doctor`.
+
+## Core Workflow
+
+Follow this session lifecycle for any capture analysis task:
+
+1. **Open** a capture: `rdc open path/to/capture.rdc`
+2. **Inspect** metadata: `rdc info`, `rdc stats`, `rdc events`
+3. **Navigate** the VFS: `rdc ls /`, `rdc ls /textures`, `rdc cat /pipelines/0`
+4. **Analyze** specifics: `rdc shaders`, `rdc pipeline`, `rdc resources`, `rdc bindings`
+5. **Debug** shaders: `rdc debug pixel X Y`, `rdc debug vertex EID VTXID`, `rdc debug thread EID GX GY GZ`
+6. **Export** data: `rdc texture EID -o out.png`, `rdc rt EID`, `rdc buffer EID -o buf.bin`, `rdc log`
+7. **Close** the session: `rdc close`
+
+### Session Management
+
+- Default session name: `default` (or value of `$RDC_SESSION`).
+- Override per-command: `rdc --session myname open capture.rdc`.
+- Check active session: `rdc status`.
+- Navigate to a specific event: `rdc goto EID`.
+
+## Output Formats
+
+All list/table commands default to TSV (tab-separated values) with a header row, suitable for `cut`, `awk`, and `sort`.
+
+| Flag | Format | Use Case |
+|------|--------|----------|
+| *(default)* | TSV with header | Human reading, shell pipelines |
+| `--no-header` | TSV without header | Piping to `awk`/`cut` without stripping |
+| `--json` | JSON array | Structured processing with `jq` |
+| `--jsonl` | Newline-delimited JSON | Streaming processing, large datasets |
+| `-q` / `--quiet` | Minimal (single column) | Extracting IDs for loops |
+
+Example -- get all draw call EIDs as a plain list:
+
+```bash
+rdc draws -q
+```
+
+Example -- JSON pipeline with jq:
+
+```bash
+rdc events --json | jq '.[] | select(.type == "DrawIndexed")'
+```
+
+## Common Tasks
+
+### Find all draw calls
+
+```bash
+rdc draws
+rdc draws --pass "GBuffer" --json
+```
+
+### Trace a pixel
+
+```bash
+rdc debug pixel 512 384
+rdc debug pixel 512 384 --json    # structured output
+rdc debug pixel 512 384 --trace   # full step-by-step trace
+```
+
+### Search shaders by name or source
+
+```bash
+rdc search "main" --type shader
+rdc shaders --name "GBuffer*"
+```
+
+### Export render targets
+
+```bash
+rdc rt EID -o output.png
+rdc texture EID --format png -o tex.png
+```
+
+### Browse VFS paths
+
+```bash
+rdc ls /
+rdc ls /textures -l
+rdc tree /pipelines --depth 2
+rdc cat /events/42
+```
+
+### Inspect pipeline state at a draw call
+
+```bash
+rdc goto EID
+rdc pipeline --json
+rdc bindings --json
+```
+
+### Compare state before/after a pass
+
+```bash
+rdc goto 100 && rdc pipeline --json > before.json
+rdc goto 200 && rdc pipeline --json > after.json
+diff before.json after.json
+```
+
+## CI Assertions
+
+rdc-cli provides assertion commands that exit non-zero on failure, designed for automated testing pipelines:
+
+| Command | Purpose |
+|---------|---------|
+| `rdc assert-pixel X Y --expect R,G,B,A` | Assert pixel color at coordinates |
+| `rdc assert-clean` | Assert no validation errors in capture |
+| `rdc assert-count --type DrawIndexed --min N` | Assert minimum draw call count |
+| `rdc assert-state FIELD VALUE` | Assert pipeline state field matches value |
+| `rdc assert-image EID --ref reference.png` | Assert render target matches reference image |
+
+Example CI script:
+
+```bash
+#!/bin/bash
+set -e
+rdc open test_capture.rdc
+rdc assert-clean
+rdc assert-count --type DrawIndexed --min 10
+rdc assert-pixel 256 256 --expect 1.0,0.0,0.0,1.0
+rdc close
+```
+
+## Shader Edit-Replay
+
+Modify and replay shaders without recompiling the application:
+
+```bash
+rdc shader-encodings EID          # list available encodings
+rdc shader EID --source > s.frag  # extract shader source
+# ... edit s.frag ...
+rdc shader-build s.frag --encoding glsl  # compile edited shader
+rdc shader-replace EID s.frag     # hot-swap into capture
+rdc shader-restore EID            # revert single shader
+rdc shader-restore-all            # revert all modifications
+```
+
+## Command Reference
+
+For the complete list of all commands with their arguments, options, types, and defaults, see [references/commands-quick-ref.md](references/commands-quick-ref.md).

--- a/.claude/skills/rdc-cli/references/commands-quick-ref.md
+++ b/.claude/skills/rdc-cli/references/commands-quick-ref.md
@@ -1,0 +1,878 @@
+# rdc-cli Command Quick Reference
+
+## `rdc assert-clean`
+
+Assert capture log has no messages at or above given severity.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--min-severity` | Minimum severity threshold. | choice | HIGH |
+| `--json` | JSON output. | flag |  |
+
+## `rdc assert-count`
+
+Assert a capture metric satisfies a numeric comparison.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `what` | choice | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--expect` | Expected count value. | integer |  |
+| `--op` | Comparison operator. | choice | eq |
+| `--pass` | Filter by render pass name. | text |  |
+| `--json` | JSON output. | flag |  |
+
+## `rdc assert-image`
+
+Compare two images pixel-by-pixel.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `expected` | file | yes |
+| `actual` | file | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--threshold` | Diff ratio threshold (%). | float | 0.0 |
+| `--diff-output` | Write diff visualization PNG. | file |  |
+| `--json` | JSON output. | flag |  |
+
+## `rdc assert-pixel`
+
+Assert pixel RGBA at (x, y) matches expected value within tolerance.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | yes |
+| `x` | integer | yes |
+| `y` | integer | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--expect` | Expected RGBA as 4 space-separated floats. | text |  |
+| `--tolerance` | Per-channel tolerance. | float | 0.01 |
+| `--target` | Render target index. | integer | 0 |
+| `--json` | JSON output. | flag |  |
+
+## `rdc assert-state`
+
+Assert pipeline state value at EID matches expected.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | yes |
+| `key_path` | text | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--expect` | Expected value. | text |  |
+| `--json` | JSON output. | flag |  |
+
+## `rdc bindings`
+
+Show bound resources per shader stage.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | no |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--binding` | Filter by binding index. | integer |  |
+| `--set` | Filter by descriptor set index. | integer |  |
+| `--json` | Output JSON. | flag |  |
+| `--no-header` | Omit TSV header | flag |  |
+| `--jsonl` | JSONL output | flag |  |
+| `-q, --quiet` | Print primary key column only | flag |  |
+
+## `rdc buffer`
+
+Export buffer raw data.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `id` | integer | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `-o, --output` | Write to file | path |  |
+| `--raw` | Force raw output even on TTY | flag |  |
+
+## `rdc capture`
+
+Thin wrapper around renderdoccmd capture.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--api` | Capture API (maps to --opt-api). | text |  |
+| `-o, --output` | Output capture file path. | path |  |
+| `--list-apis` | List capture APIs via renderdoccmd and exit. | flag |  |
+
+## `rdc cat`
+
+Output VFS leaf node content.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `path` | text | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--json` | JSON output | flag |  |
+| `--raw` | Force raw output even on TTY | flag |  |
+| `-o, --output` | Write binary output to file | path |  |
+
+## `rdc close`
+
+Close daemon-backed session.
+
+## `rdc completion`
+
+Generate shell completion script.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `shell` | choice | no |
+
+## `rdc count`
+
+Output a single integer count to stdout.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `what` | choice | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--pass` | Filter by render pass name. | text |  |
+
+## `rdc counters`
+
+Query GPU performance counters.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--list` | List available counters. | flag |  |
+| `--eid` | Filter to specific event ID. | integer |  |
+| `--name` | Filter counters by name substring. | text |  |
+| `--json` | JSON output. | flag |  |
+| `--no-header` | Omit TSV header | flag |  |
+| `--jsonl` | JSONL output | flag |  |
+| `-q, --quiet` | Print primary key column only | flag |  |
+
+## `rdc debug pixel`
+
+Debug pixel shader at (X, Y) for event EID.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | yes |
+| `x` | integer | yes |
+| `y` | integer | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--trace` | Full execution trace (TSV) | flag |  |
+| `--dump-at` | Var snapshot at LINE | integer |  |
+| `--sample` | MSAA sample index | integer |  |
+| `--primitive` | Primitive ID override | integer |  |
+| `--json` | JSON output | flag |  |
+| `--no-header` | Suppress TSV header row | flag |  |
+
+## `rdc debug thread`
+
+Debug compute shader thread at workgroup (GX,GY,GZ) thread (TX,TY,TZ).
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | yes |
+| `gx` | integer | yes |
+| `gy` | integer | yes |
+| `gz` | integer | yes |
+| `tx` | integer | yes |
+| `ty` | integer | yes |
+| `tz` | integer | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--trace` | Full execution trace (TSV) | flag |  |
+| `--dump-at` | Var snapshot at LINE | integer |  |
+| `--json` | JSON output | flag |  |
+| `--no-header` | Suppress TSV header row | flag |  |
+
+## `rdc debug vertex`
+
+Debug vertex shader for vertex VTX_ID at event EID.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | yes |
+| `vtx_id` | integer | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--trace` | Full execution trace (TSV) | flag |  |
+| `--dump-at` | Var snapshot at LINE | integer |  |
+| `--instance` | Instance index (default 0) | integer | 0 |
+| `--json` | JSON output | flag |  |
+| `--no-header` | Suppress TSV header row | flag |  |
+
+## `rdc diff`
+
+Compare two RenderDoc captures side-by-side.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `capture_a` | file | yes |
+| `capture_b` | file | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--draws` |  | flag |  |
+| `--resources` |  | flag |  |
+| `--passes` |  | flag |  |
+| `--stats` |  | flag |  |
+| `--framebuffer` |  | flag |  |
+| `--pipeline` |  | text |  |
+| `--json` |  | flag |  |
+| `--format` |  | choice | tsv |
+| `--shortstat` |  | flag |  |
+| `--no-header` |  | flag |  |
+| `--verbose` |  | flag |  |
+| `--timeout` |  | float | 60.0 |
+| `--target` | Color target index (default 0) | integer | 0 |
+| `--threshold` | Max diff ratio %% to count as identical | float | 0.0 |
+| `--eid` | Compare at specific EID (default: last draw) | integer |  |
+| `--diff-output` | Write diff PNG here | path |  |
+
+## `rdc doctor`
+
+Run environment checks for rdc-cli.
+
+## `rdc draw`
+
+Show draw call detail.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | no |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--json` | JSON output | flag |  |
+
+## `rdc draws`
+
+List draw calls.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--pass` | Filter by pass name | text |  |
+| `--sort` | Sort field | text |  |
+| `--limit` | Max rows | integer |  |
+| `--no-header` | Omit TSV header | flag |  |
+| `--json` | JSON output | flag |  |
+| `--jsonl` | JSONL output | flag |  |
+| `-q, --quiet` | Only EID column | flag |  |
+
+## `rdc event`
+
+Show single API call detail.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--json` | JSON output | flag |  |
+
+## `rdc events`
+
+List all events.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--type` | Filter by type | text |  |
+| `--filter` | Filter by name glob | text |  |
+| `--limit` | Max rows | integer |  |
+| `--range` | EID range N:M | text |  |
+| `--no-header` | Omit TSV header | flag |  |
+| `--json` | JSON output | flag |  |
+| `--jsonl` | JSONL output | flag |  |
+| `-q, --quiet` | Only EID column | flag |  |
+
+## `rdc goto`
+
+Update current event id via daemon.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | yes |
+
+## `rdc info`
+
+Show capture metadata.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--json` | JSON output | flag |  |
+
+## `rdc log`
+
+Show debug/validation messages from the capture.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--level` | Filter by severity. | choice |  |
+| `--eid` | Filter by event ID. | integer |  |
+| `--json` | JSON output | flag |  |
+| `--no-header` | Omit TSV header | flag |  |
+| `--jsonl` | JSONL output | flag |  |
+| `-q, --quiet` | Print primary key column only | flag |  |
+
+## `rdc ls`
+
+List VFS directory contents.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `path` | text | no |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `-F, --classify` | Append type indicator (/ * @) | flag |  |
+| `-l, --long` | Long format (TSV with metadata) | flag |  |
+| `--json` | JSON output | flag |  |
+| `--no-header` | Omit TSV header (with -l) | flag |  |
+| `--jsonl` | JSONL output (with -l) | flag |  |
+| `-q, --quiet` | Print name only (with -l) | flag |  |
+
+## `rdc mesh`
+
+Export post-transform mesh as OBJ.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | no |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--stage` | Mesh data stage (default: vs-out) | choice | vs-out |
+| `-o, --output` | Write to file | path |  |
+| `--json` | JSON output | flag |  |
+| `--no-header` | Suppress OBJ header comment | flag |  |
+
+## `rdc open`
+
+Create local default session and start daemon skeleton.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `capture` | path | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--preload` | Preload shader cache after open. | flag |  |
+
+## `rdc pass`
+
+Show detail for a single render pass by index or name.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `identifier` | text | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--json` | Output JSON. | flag |  |
+
+## `rdc passes`
+
+List render passes.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--json` | Output JSON. | flag |  |
+| `--no-header` | Omit TSV header | flag |  |
+| `--jsonl` | JSONL output | flag |  |
+| `-q, --quiet` | Print primary key column only | flag |  |
+
+## `rdc pick-pixel`
+
+Read pixel color at (X, Y) from the current render target.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `x` | integer | yes |
+| `y` | integer | yes |
+| `eid` | integer | no |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--target` | Color target index (default 0) | integer | 0 |
+| `--json` | JSON output | flag |  |
+
+## `rdc pipeline`
+
+Show pipeline summary for current or specified EID.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | no |
+| `section` | text | no |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--json` | Output JSON. | flag |  |
+
+## `rdc pixel`
+
+Query pixel history at (X, Y) for the current or specified event.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `x` | integer | yes |
+| `y` | integer | yes |
+| `eid` | integer | no |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--target` | Color target index (default 0) | integer | 0 |
+| `--sample` | MSAA sample index (default 0) | integer | 0 |
+| `--json` | JSON output | flag |  |
+| `--no-header` | Omit TSV header | flag |  |
+| `--jsonl` | JSONL output | flag |  |
+| `-q, --quiet` | Print primary key column only | flag |  |
+
+## `rdc resource`
+
+Show details of a specific resource.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `resid` | integer | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--json` | Output JSON. | flag |  |
+
+## `rdc resources`
+
+List all resources.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--json` | Output JSON. | flag |  |
+| `--type` | Filter by resource type (exact, case-insensitive). | text |  |
+| `--name` | Filter by name substring (case-insensitive). | text |  |
+| `--sort` | Sort order. | choice | id |
+| `--no-header` | Omit TSV header | flag |  |
+| `--jsonl` | JSONL output | flag |  |
+| `-q, --quiet` | Print primary key column only | flag |  |
+
+## `rdc rt`
+
+Export render target as PNG.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | no |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `-o, --output` | Write to file | path |  |
+| `--target` | Color target index (default 0) | integer | 0 |
+| `--raw` | Force raw output even on TTY | flag |  |
+| `--overlay` | Render with debug overlay | choice |  |
+| `--width` | Overlay render width | integer | 256 |
+| `--height` | Overlay render height | integer | 256 |
+
+## `rdc script`
+
+Execute a Python script inside the daemon process.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `script_file` | file | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--arg` | Script argument. | text |  |
+| `--json` | Raw JSON output. | flag |  |
+
+## `rdc search`
+
+Search shader disassembly text for PATTERN (regex).
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `pattern` | text | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--stage` | Filter by stage (vs/ps/cs/...). | text |  |
+| `--limit` | Max results. | integer | 200 |
+| `-C, --context` | Context lines. | integer | 0 |
+| `-i, --case-sensitive` | Case-sensitive search. | flag |  |
+| `--json` | JSON output. | flag |  |
+
+## `rdc shader`
+
+Show shader metadata for a stage at EID.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | no |
+| `stage` | choice | no |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--reflect` | Include reflection data (inputs/outputs/cbuffers). | flag |  |
+| `--constants` | Include constant buffer values. | flag |  |
+| `--source` | Include debug source code. | flag |  |
+| `--target` | Disassembly target format (e.g., 'dxil', 'spirv', 'glsl'). | text |  |
+| `--targets` | List available disassembly targets. | flag |  |
+| `-o, --output` | Output file path. | path |  |
+| `--all` | Get all shader data for all stages. | flag |  |
+| `--json` | Output JSON. | flag |  |
+
+## `rdc shader-build`
+
+Build a shader from source file.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `source_file` | file | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--stage` | Shader stage | choice |  |
+| `--entry` | Entry point name | text | main |
+| `--encoding` | Encoding name (default: GLSL) | text | GLSL |
+| `--json` | JSON output | flag |  |
+| `-q, --quiet` | Print only shader_id | flag |  |
+
+## `rdc shader-encodings`
+
+List available shader encodings for this capture.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--json` | JSON output | flag |  |
+
+## `rdc shader-map`
+
+Output EID-to-shader mapping as TSV.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--no-header` | Omit TSV header row. | flag |  |
+| `--json` | JSON output. | flag |  |
+| `--jsonl` | JSONL output. | flag |  |
+| `-q, --quiet` | Print EID column only. | flag |  |
+
+## `rdc shader-replace`
+
+Replace shader at EID/STAGE with a built shader.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | yes |
+| `stage` | choice | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--with` | Built shader ID from shader-build | integer |  |
+| `--json` | JSON output | flag |  |
+
+## `rdc shader-restore`
+
+Restore original shader at EID/STAGE.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | yes |
+| `stage` | choice | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--json` | JSON output | flag |  |
+
+## `rdc shader-restore-all`
+
+Restore all replaced shaders and free built resources.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--json` | JSON output | flag |  |
+
+## `rdc shaders`
+
+List unique shaders in capture.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--stage` | Filter by shader stage. | choice |  |
+| `--sort` | Sort order. | choice | name |
+| `--json` | Output JSON. | flag |  |
+| `--no-header` | Omit TSV header | flag |  |
+| `--jsonl` | JSONL output | flag |  |
+| `-q, --quiet` | Print primary key column only | flag |  |
+
+## `rdc snapshot`
+
+Export a complete rendering state snapshot for a draw event.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `eid` | integer | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `-o, --output` | Output directory | path |  |
+| `--json` | JSON output | flag |  |
+
+## `rdc stats`
+
+Show per-pass breakdown, top draws, largest resources.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--json` | JSON output | flag |  |
+| `--no-header` | Omit TSV header | flag |  |
+
+## `rdc status`
+
+Show current daemon-backed session status.
+
+## `rdc tex-stats`
+
+Show texture min/max statistics and optional histogram.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `resource_id` | integer | yes |
+| `eid` | integer | no |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--mip` | Mip level (default 0) | integer | 0 |
+| `--slice` | Array slice (default 0) | integer | 0 |
+| `--histogram` | Show 256-bucket histogram | flag |  |
+| `--json` | JSON output | flag |  |
+
+## `rdc texture`
+
+Export texture as PNG.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `id` | integer | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `-o, --output` | Write to file | path |  |
+| `--mip` | Mip level (default 0) | integer | 0 |
+| `--raw` | Force raw output even on TTY | flag |  |
+
+## `rdc tree`
+
+Display VFS subtree structure.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `path` | text | no |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--depth` |  | integer range | 2 |
+| `--json` | JSON output | flag |  |
+
+## `rdc usage`
+
+Show resource usage (which events read/write a resource).
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `resource_id` | integer | no |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--all` | Show all resources usage matrix. | flag |  |
+| `--type` | Filter by resource type. | text |  |
+| `--usage` | Filter by usage type. | text |  |
+| `--json` | JSON output. | flag |  |
+| `--no-header` | Omit TSV header | flag |  |
+| `--jsonl` | JSONL output | flag |  |
+| `-q, --quiet` | Print primary key column only | flag |  |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
       - name: Ruff format check
         run: uv run ruff format --check src tests
 
+      - name: Verify skill reference is fresh
+        run: diff <(uv run python scripts/gen-skill-ref.py) .claude/skills/rdc-cli/references/commands-quick-ref.md
+        shell: bash
+
   security:
     name: Dependency audit
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist/
 CLAUDE.md
 tests/fixtures/vulkan_samples
 .local/
-.claude/
+.claude/*
+!.claude/skills/
 _site/
 docs-astro/dist/

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,5 +20,7 @@ test = "uv run pytest tests/unit -v --cov=rdc --cov-report=term-missing --cov-fa
 test-gpu = "uv run pytest tests -v -m gpu --no-header"
 test-all = "uv run pytest tests -v --cov=rdc --cov-report=term-missing"
 check = "pixi run lint && pixi run typecheck && pixi run test"
+gen-skill-ref = "bash -c 'uv run python scripts/gen-skill-ref.py > .claude/skills/rdc-cli/references/commands-quick-ref.md'"
+check-skill-ref = "bash -c 'diff <(uv run python scripts/gen-skill-ref.py) .claude/skills/rdc-cli/references/commands-quick-ref.md'"
 verify = "bash scripts/verify-package.sh"
 e2e = "bash scripts/e2e-test.sh"

--- a/scripts/gen-skill-ref.py
+++ b/scripts/gen-skill-ref.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Generate commands-quick-ref.md from Click introspection."""
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import click
+
+
+def iter_leaf_commands(
+    group: click.Group, ctx: click.Context, prefix: str = ""
+) -> Iterator[tuple[str, click.Command]]:
+    """Yield ``(full_name, command)`` for every non-hidden leaf command.
+
+    Groups are recursed into; their subcommands are prefixed with the group
+    name (e.g. ``"debug pixel"``).
+
+    Args:
+        group: Click group to walk.
+        ctx: Click context for the group.
+        prefix: Name prefix for nested groups.
+    """
+    for name in sorted(group.list_commands(ctx)):
+        cmd = group.get_command(ctx, name)
+        if cmd is None or getattr(cmd, "hidden", False):
+            continue
+        full = f"{prefix}{name}"
+        if isinstance(cmd, click.Group):
+            sub_ctx = click.Context(cmd, parent=ctx)
+            yield from iter_leaf_commands(cmd, sub_ctx, prefix=f"{full} ")
+        else:
+            yield full, cmd
+
+
+def _render_command(name: str, cmd: click.Command) -> list[str]:
+    """Render a single command as markdown lines."""
+    lines: list[str] = [f"## `rdc {name}`", ""]
+    if cmd.help:
+        lines += [cmd.help.split("\n\n")[0].strip(), ""]
+
+    args = [p for p in cmd.params if isinstance(p, click.Argument)]
+    opts = [
+        p
+        for p in cmd.params
+        if isinstance(p, click.Option) and p.name != "help"
+    ]
+
+    if args:
+        lines += ["**Arguments:**", ""]
+        lines += ["| Name | Type | Required |", "|------|------|----------|"]
+        for a in args:
+            type_name = a.type.name if a.type else "TEXT"
+            req = "yes" if a.required else "no"
+            lines.append(f"| `{a.name}` | {type_name} | {req} |")
+        lines.append("")
+
+    if opts:
+        lines += ["**Options:**", ""]
+        lines += [
+            "| Flag | Help | Type | Default |",
+            "|------|------|------|---------|",
+        ]
+        for o in opts:
+            flags = ", ".join(o.opts)
+            help_text = (o.help or "").replace("|", "\\|")
+            if o.is_flag:
+                type_name = "flag"
+                default = ""
+            else:
+                type_name = o.type.name if o.type else "TEXT"
+                raw = o.default
+                default = str(raw) if raw is not None and type(raw).__name__ != "Sentinel" else ""
+            lines.append(f"| `{flags}` | {help_text} | {type_name} | {default} |")
+        lines.append("")
+
+    return lines
+
+
+def generate_skill_ref() -> str:
+    """Generate the full commands quick-reference as a markdown string.
+
+    Walks the rdc CLI group, introspects every leaf command, and renders
+    a markdown document with one section per command including help text,
+    arguments, and options tables.
+
+    Returns:
+        Complete markdown string ready to write to a file.
+    """
+    from rdc.cli import main as cli_group  # noqa: PLC0415
+
+    ctx = click.Context(cli_group)
+    lines: list[str] = ["# rdc-cli Command Quick Reference", ""]
+
+    for name, cmd in iter_leaf_commands(cli_group, ctx):
+        lines += _render_command(name, cmd)
+
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.stdout.write(generate_skill_ref())

--- a/tests/unit/test_gen_skill_ref.py
+++ b/tests/unit/test_gen_skill_ref.py
@@ -1,0 +1,66 @@
+"""Tests for scripts/gen-skill-ref.py — skill reference generator."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import click
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "gen-skill-ref.py"
+
+
+def _load_gen_skill_ref() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("gen_skill_ref", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_gen_skill_ref()
+generate_skill_ref = _mod.generate_skill_ref
+iter_leaf_commands = _mod.iter_leaf_commands
+
+
+def test_gen_skill_ref_produces_output() -> None:
+    result = generate_skill_ref()
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+def test_gen_skill_ref_contains_all_commands() -> None:
+    from rdc.cli import main as cli_group
+
+    result = generate_skill_ref()
+    ctx = click.Context(cli_group)
+    for name, _cmd in iter_leaf_commands(cli_group, ctx):
+        assert name in result, f"Command {name!r} missing from skill ref"
+
+
+def test_gen_skill_ref_deterministic() -> None:
+    assert generate_skill_ref() == generate_skill_ref()
+
+
+def test_gen_skill_ref_contains_help_text() -> None:
+    result = generate_skill_ref()
+    for cmd in ("open", "info", "events"):
+        assert cmd in result, f"Known command {cmd!r} absent from skill ref"
+
+
+def test_gen_skill_ref_contains_options() -> None:
+    result = generate_skill_ref()
+    assert "--type" in result
+    assert "--name" in result
+
+
+def test_gen_skill_ref_handles_subgroups() -> None:
+    result = generate_skill_ref()
+    for sub in ("pixel", "vertex", "thread"):
+        assert sub in result, f"debug subcommand {sub!r} missing from skill ref"
+
+
+def test_gen_skill_ref_no_sentinel_leak() -> None:
+    result = generate_skill_ref()
+    assert "Sentinel" not in result, "Click internal Sentinel leaked into output"

--- a/tests/unit/test_skill_structure.py
+++ b/tests/unit/test_skill_structure.py
@@ -1,0 +1,63 @@
+"""Tests for .claude/skills/rdc-cli/ structure and freshness."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "gen-skill-ref.py"
+
+
+def _load_gen_skill_ref() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("gen_skill_ref", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def test_skill_md_exists(project_root: Path) -> None:
+    skill = project_root / ".claude/skills/rdc-cli/SKILL.md"
+    assert skill.exists(), "SKILL.md not found"
+
+
+def test_skill_md_has_valid_frontmatter(project_root: Path) -> None:
+    text = (project_root / ".claude/skills/rdc-cli/SKILL.md").read_text()
+    assert text.startswith("---"), "Missing YAML frontmatter"
+    assert "name:" in text
+    assert "description:" in text
+
+
+def test_skill_md_name_is_rdc_cli(project_root: Path) -> None:
+    text = (project_root / ".claude/skills/rdc-cli/SKILL.md").read_text()
+    front = text.split("---")[1]
+    assert "name: rdc-cli" in front or 'name: "rdc-cli"' in front
+
+
+def test_skill_md_description_has_triggers(project_root: Path) -> None:
+    text = (project_root / ".claude/skills/rdc-cli/SKILL.md").read_text()
+    for phrase in ("RenderDoc", ".rdc", "shader"):
+        assert phrase in text, f"Trigger phrase {phrase!r} missing from SKILL.md"
+
+
+def test_commands_ref_exists(project_root: Path) -> None:
+    ref = project_root / ".claude/skills/rdc-cli/references/commands-quick-ref.md"
+    assert ref.exists(), "commands-quick-ref.md not found"
+
+
+def test_commands_ref_is_fresh(project_root: Path) -> None:
+    mod = _load_gen_skill_ref()
+    committed = (
+        project_root / ".claude/skills/rdc-cli/references/commands-quick-ref.md"
+    ).read_text()
+    assert committed == mod.generate_skill_ref(), (
+        "commands-quick-ref.md is stale — run `pixi run gen-skill-ref` to regenerate"
+    )


### PR DESCRIPTION
## Summary

- Add Claude Code skill at `.claude/skills/rdc-cli/` so AI agents can discover and use rdc-cli commands for RenderDoc capture analysis
- `SKILL.md`: hand-written workflow guide with trigger phrases, core workflow, output formats, common tasks, CI assertions, and shader edit-replay recipes
- `scripts/gen-skill-ref.py`: Click introspection script that auto-generates `references/commands-quick-ref.md` with per-command help text, argument tables, and option tables
- CI: add skill reference freshness check to lint job (`diff` against regenerated output)
- `.gitignore`: change `.claude/` to `.claude/*` + `!.claude/skills/` so the skill directory is tracked while `CLAUDE.md` stays ignored

## Test plan

- [x] 13 new unit tests: generator output, determinism, subgroup handling, Sentinel leak guard, skill file structure validation
- [x] `pixi run check-skill-ref` passes (generated file matches committed)
- [x] `pixi run lint && pixi run test` — 1712 passed, 95.68% coverage
- [x] E2E tests pass (26/26)
- [x] `git ls-files .claude/skills/` tracks both files; `CLAUDE.md` still ignored