### PR TITLE
fix(daemon): resolve remaining blackbox bugs B1/B6-B9 + JSON error coverage

### DIFF
--- a/openspec/changes/2026-02-22-bugfix-remaining-blackbox/proposal.md
+++ b/openspec/changes/2026-02-22-bugfix-remaining-blackbox/proposal.md
@@ -1,0 +1,164 @@
+# Proposal: Remaining Blackbox Bug Fixes + JSON Error Coverage (2026-02-22)
+
+## Summary
+
+Five blackbox bugs (B1, B6-B9) discovered during end-to-end testing remain open after PR #84 and
+PR #85. Additionally, PR #84's JSON error output fix left several error paths in `assert_ci.py`
+still outputting plain text regardless of `--json`. This proposal targets all six issues with
+minimal, focused changes across five source files. No new features or API surface are introduced.
+
+---
+
+## Motivation
+
+- **B6 (P1)**: `log --json/--jsonl/--no-header/-q` always returns an empty array. The
+  `GetDebugMessages()` API is consume-once; calling it a second time in the same session returns
+  nothing. Any structured output format that re-routes through a second call silently loses all
+  messages, making `rdc log` unreliable for CI pipelines that parse structured output.
+- **B1 (P2)**: `debug vertex` (and `debug pixel`, `debug thread`) return a generic `internal error`
+  in default and `--json` modes on real GPU traces. The root cause is `trace.stage` being accessed
+  after `_run_debug_loop()` frees the trace object in its `finally` block, causing an exception
+  that is caught by the daemon's generic handler.
+- **B7 (P2)**: `stats` always shows `-`/`0` for `RT_W`, `RT_H`, and `ATTACHMENTS` columns.
+  `aggregate_stats()` initializes these fields to zero and never updates them; the pipeline state
+  query needed to populate render-target info is never performed.
+- **B8 (P2)**: `stats --no-header` suppresses column headers as intended but still prints section
+  titles ("Per-Pass Breakdown:", "Top Draws:") to stderr unconditionally.
+- **B9 (P3)**: `stats` has no `--jsonl` or `-q` output mode. The command uses a custom decorator
+  instead of `@list_output_options`, leaving structured output unsupported.
+- **PR #84 incomplete**: `assert_ci.py` error paths in `_traverse_path()`, `assert_pixel_cmd`
+  validation, and `assert_state_cmd` section validation still emit plain text even when `--json`
+  is passed, inconsistent with the fix applied elsewhere in PR #84.
+
+---
+
+## Changes
+
+### B6: Cache debug messages in `DaemonState`
+
+**Root cause**: `controller.GetDebugMessages()` consumes the internal message queue on first call.
+Any subsequent call within the same session returns an empty list. When `--json`, `--jsonl`,
+`--no-header`, or `-q` is used, the handler or CLI re-reads messages via a second code path that
+calls the API again, receiving nothing.
+
+**Files**:
+- `src/rdc/daemon_server.py`: Add `_debug_messages_cache: list[Any] | None = None` to
+  `DaemonState`.
+- `src/rdc/handlers/query.py` (`_handle_log`): On first call, invoke `GetDebugMessages()` and
+  store the result in `state._debug_messages_cache`. On subsequent calls within the same session,
+  return the cached list. Cache is scoped to the session lifetime (invalidated on
+  `session_open`/`session_close`).
+
+**Scope**: Handler change only. No CLI changes needed; the empty-array symptom disappears once the
+handler returns the correct data on all calls.
+
+---
+
+### B1: Extract `trace.stage` before `_run_debug_loop()`
+
+**Root cause**: In `_handle_debug_vertex` (and the pixel/thread equivalents),
+`stage_name = _STAGE_NAMES.get(int(trace.stage), ...)` is evaluated after `_run_debug_loop()`.
+`_run_debug_loop()` calls `controller.FreeTrace(trace)` in its `finally` block, invalidating the
+trace object. On real GPU traces, accessing any attribute of a freed trace raises a native
+exception, which propagates to the daemon's catch-all and surfaces as `"internal error"`.
+
+**Files**:
+- `src/rdc/handlers/debug.py`:
+  - Move `stage_name` extraction to immediately after the `DebugVertex`/`DebugPixel`/`DebugThread`
+    call and before `_run_debug_loop()` in all three handlers.
+  - Wrap the `controller.DebugVertex`/`DebugPixel`/`DebugThread` call itself in a try/except and
+    return a structured error response (not a generic exception) if the API call fails.
+
+**Scope**: Three handler functions in one file. No CLI changes; the fix corrects the data flow.
+
+---
+
+### B7: Populate RT_W/RT_H/ATTACHMENTS in `_handle_stats`
+
+**Root cause**: `aggregate_stats()` produces per-pass rows with `rt_w`, `rt_h`, and `attachments`
+initialized to `0` and never updated. The pipeline-state query needed to retrieve framebuffer
+dimensions and attachment counts for each pass is never performed inside `_handle_stats`.
+
+**Files**:
+- `src/rdc/handlers/query.py` (`_handle_stats`): After `aggregate_stats()`, iterate over each
+  pass row and query `controller.GetPipelineState()` at a representative event within that pass
+  (e.g., the first draw EID). Extract framebuffer dimensions and color/depth attachment counts
+  from the pipeline state and enrich the pass row in-place. Follow the existing `_build_pass_list`
+  pattern for event selection.
+
+**Scope**: Handler enrichment loop only. Output schema is unchanged; previously-zero fields now
+carry real values.
+
+---
+
+### B8: Gate section titles on `not no_header`
+
+**Root cause**: "Per-Pass Breakdown:" and "Top Draws:" section titles are written to stderr
+unconditionally in `stats_cmd`, bypassing the `--no-header` flag that already suppresses column
+headers.
+
+**Files**:
+- `src/rdc/commands/info.py` (`stats_cmd`): Wrap each `sys.stderr.write(...)` section-title call
+  in `if not no_header:`.
+
+**Scope**: Two-line guard addition. No handler changes.
+
+---
+
+### B9: Add `--jsonl`/`-q` support to `stats`
+
+**Root cause**: `stats_cmd` uses a custom `@click.option` set instead of `@list_output_options`,
+so it has `--json` but no `--jsonl` or `-q`. The handler already returns a list-shaped response,
+so adding the decorator and routing its output modes is straightforward.
+
+**Files**:
+- `src/rdc/commands/info.py` (`stats_cmd`):
+  - Replace the custom `--json`/`--no-header` options with `@list_output_options` (which provides
+    `--json`, `--jsonl`, `-q`, `--no-header`).
+  - Update the function signature and output routing to handle all four modes.
+
+**Scope**: One command function. Handler unchanged.
+
+---
+
+### PR #84: Apply JSON error formatting to remaining `assert_ci.py` paths
+
+**Root cause**: PR #84 added `_json_mode()` / `_json_error()` helpers and applied them to the
+main response paths, but three sets of error paths were missed:
+1. `_traverse_path()` key-not-found and index-out-of-range errors (lines 102, 107, 111).
+2. `assert_pixel_cmd` argument validation errors (lines 141-147, 153).
+3. `assert_state_cmd` invalid-section error (line 299).
+
+All three still call `click.echo(f"error: ...")` unconditionally, so `--json` output is malformed
+when these paths are hit.
+
+**Files**:
+- `src/rdc/commands/assert_ci.py`:
+  - In `_traverse_path()`: call `_json_error(ctx, msg)` when `--json` is active, else fall back
+    to `click.echo`.
+  - In `assert_pixel_cmd` validation block: same pattern.
+  - In `assert_state_cmd` invalid-section block: same pattern.
+
+**Scope**: Error-path formatting only; no behavioral changes to success paths.
+
+---
+
+## Risk Assessment
+
+| Bug | Risk of Fix | Notes |
+|-----|------------|-------|
+| B6 cache | Low | Cache scoped to session; cleared on open/close; no thread-safety concern (single-threaded daemon) |
+| B1 stage extraction | Low | Reordering two lines; no new logic |
+| B7 RT enrichment | Medium | New pipeline-state queries per pass; tested only on mock; GPU test needed |
+| B8 no-header gate | Minimal | Two-line guard; no logic change |
+| B9 list_output_options | Low | Decorator is already used by other commands; adding it here is mechanical |
+| PR#84 assert_ci | Low | Error paths only; success paths untouched |
+
+---
+
+## Backward Compatibility
+
+All changes are internal behavior fixes on commands that were returning incorrect or incomplete
+data. No CLI flags are removed. B9 adds new flags (`--jsonl`, `-q`) to `stats`, which is purely
+additive. The B8 fix changes stderr output only when `--no-header` is explicitly passed, which
+previously produced inconsistent output anyway. No JSON-RPC method signatures change.

--- a/openspec/changes/2026-02-22-bugfix-remaining-blackbox/tasks.md
+++ b/openspec/changes/2026-02-22-bugfix-remaining-blackbox/tasks.md
@@ -1,0 +1,478 @@
+# Tasks: Remaining Blackbox Bug Fixes + JSON Error Coverage
+
+**Feature branch:** `fix/remaining-blackbox-bugs`
+**Spec date:** 2026-02-22
+
+> **GPU golden test philosophy:** Handler-level bugs (B1, B6, B7) MUST have GPU integration tests
+> in `tests/test_daemon_handlers_real.py`. The GPU test is the true regression guard — unit tests
+> with mocks only validate error handling logic, not correctness against real RenderDoc data.
+
+---
+
+## Agent Assignment
+
+| Agent | Files Owned | Bugs Covered | Parallel? |
+|-------|-------------|--------------|-----------|
+| Agent A | `src/rdc/daemon_server.py`, `src/rdc/handlers/query.py`, `src/rdc/handlers/debug.py` | B6, B1, B7 | Fully parallel with Agent B |
+| Agent B | `src/rdc/commands/info.py`, `src/rdc/commands/assert_ci.py` | B8, B9, PR#84 | Fully parallel with Agent A |
+| Agent C | various test files | all | Parallel with A+B; final integration after A+B |
+
+---
+
+## Agent A — Daemon Fixes (B6, B1, B7)
+
+### A1 — B6: Add `_debug_messages_cache` to `DaemonState`
+
+**File:** `src/rdc/daemon_server.py`
+
+Add one field to the `DaemonState` dataclass:
+
+```python
+_debug_messages_cache: list[Any] | None = None
+```
+
+Place it alongside the other `_`-prefixed cache fields (e.g. near `_shader_cache_built`).
+
+**Acceptance criteria:**
+- Field exists in `DaemonState` with type `list[Any] | None` and default `None`.
+- No other changes to `daemon_server.py`.
+
+**Dependencies:** none
+
+---
+
+### A2 — B6: Cache `GetDebugMessages()` in `_handle_log`
+
+**File:** `src/rdc/handlers/query.py`
+
+In `_handle_log`, replace the unconditional `controller.GetDebugMessages()` call with a
+cache-check-then-populate pattern:
+
+```python
+if state._debug_messages_cache is None:
+    state._debug_messages_cache = list(controller.GetDebugMessages())
+messages = state._debug_messages_cache
+```
+
+Then apply any existing level/source filtering to `messages` as before.
+
+The cache is never explicitly invalidated within a session (it is reset by the `DaemonState`
+re-instantiation on `session_open`). This is correct: the daemon is single-threaded and the
+debug message queue is exhausted after the first call.
+
+**Acceptance criteria:**
+- `GetDebugMessages()` is called at most once per session regardless of how many times
+  `rdc log` is invoked with any output flag.
+- The returned data is identical on all invocations within the same session.
+
+**Dependencies:** A1
+
+---
+
+### A3 — B1: Extract `stage_name` before `_run_debug_loop()` in all three debug handlers
+
+**File:** `src/rdc/handlers/debug.py`
+
+In `_handle_debug_vertex`, `_handle_debug_pixel`, and `_handle_debug_thread`, move the line:
+
+```python
+stage_name = _STAGE_NAMES.get(int(trace.stage), str(trace.stage))
+```
+
+to immediately after the `controller.DebugVertex()` / `controller.DebugPixel()` /
+`controller.DebugThread()` call and **before** the `_run_debug_loop(controller, trace)` call.
+
+`_run_debug_loop` calls `controller.FreeTrace(trace)` in its `finally` block, which invalidates
+the trace object. Any attribute access on `trace` after `_run_debug_loop` raises a native
+exception on real GPU traces.
+
+**Do NOT** restructure `_run_debug_loop` itself.
+
+**Acceptance criteria:**
+- `stage_name` is extracted before `_run_debug_loop` in all three handlers.
+- No functional change to the debug loop logic.
+
+**Dependencies:** none
+
+---
+
+### A4 — B1: Wrap debug API calls in try/except
+
+**File:** `src/rdc/handlers/debug.py`
+
+In each of the three debug handlers, wrap the `controller.DebugVertex()`,
+`controller.DebugPixel()`, and `controller.DebugThread()` calls in a `try/except Exception`
+block that returns a structured error response instead of propagating the exception:
+
+```python
+try:
+    trace = controller.DebugVertex(eid, vertex_idx, rd.DebugVertexInput())
+except Exception as exc:
+    return _error_response(request_id, f"DebugVertex failed: {exc}"), True
+```
+
+Use the same pattern for `DebugPixel` and `DebugThread`. Do not catch exceptions inside
+`_run_debug_loop` — let any loop errors surface as-is since they already have their own
+error path.
+
+**Acceptance criteria:**
+- A failed `DebugVertex`/`DebugPixel`/`DebugThread` API call returns a structured
+  `{"error": {...}}` response, not an unhandled exception.
+- `_run_debug_loop` is unchanged.
+
+**Dependencies:** A3 (ordering matters for correctness)
+
+---
+
+### A5 — B7: Enrich per-pass rows with RT_W/RT_H/ATTACHMENTS in `_handle_stats`
+
+**File:** `src/rdc/handlers/query.py`
+
+In `_handle_stats`, after calling `aggregate_stats()` which returns `per_pass` rows
+with `rt_w=0`, `rt_h=0`, `attachments=0`, add an enrichment pass:
+
+For each pass row in `per_pass`, pick a representative event ID (the first draw EID in that
+pass), call `controller.SetFrameEvent(eid, False)` and `pipe = controller.GetPipelineState()`,
+then extract:
+- `rt_w`, `rt_h` from `pipe.GetOutputTargets()` viewport or framebuffer dimensions (follow
+  the pattern used in `_build_pass_list` / `_set_frame_event` elsewhere in the file).
+- `attachments` = number of non-null color attachments + depth attachment (if present).
+
+Update the pass row dict in-place.
+
+If any pipeline query raises an exception for a pass, leave that pass's RT fields as `0`/`-`
+and continue (do not abort the entire stats response).
+
+**Acceptance criteria:**
+- `rt_w`, `rt_h` are non-zero for passes that include draw calls on real GPU traces.
+- `attachments` reflects the actual attachment count.
+- Passes with no events gracefully retain `0`/`-` without crashing.
+
+**Dependencies:** none (independent of A1–A4)
+
+---
+
+## Agent B — CLI Fixes (B8, B9, PR#84)
+
+### B1 — B8: Gate section titles on `not no_header` in `stats_cmd`
+
+**File:** `src/rdc/commands/info.py`
+
+Locate the two unconditional `sys.stderr.write(...)` calls that print section titles in
+`stats_cmd`:
+
+```python
+sys.stderr.write("Per-Pass Breakdown:\n")
+...
+sys.stderr.write("Top Draws by Triangle Count:\n")
+```
+
+Wrap each in `if not no_header:`:
+
+```python
+if not no_header:
+    sys.stderr.write("Per-Pass Breakdown:\n")
+...
+if not no_header:
+    sys.stderr.write("Top Draws by Triangle Count:\n")
+```
+
+**Acceptance criteria:**
+- `rdc stats --no-header` produces zero lines of section-title stderr output.
+- `rdc stats` (no flag) still prints section titles.
+
+**Dependencies:** none
+
+---
+
+### B2 — B9: Add `@list_output_options` to `stats_cmd`
+
+**File:** `src/rdc/commands/info.py`
+
+`stats_cmd` currently has custom `--json` / `--no-header` options inline. Replace them with
+the `@list_output_options` decorator (which provides `--json` as `use_json`, `--jsonl` as
+`use_jsonl`, `--no-header` as `no_header`, and `-q`/`--quiet` as `quiet`).
+
+Steps:
+
+1. Add `from rdc.formatters.options import list_output_options` import.
+2. Replace the individual `@click.option("--json", ...)` and `@click.option("--no-header", ...)`
+   decorators with a single `@list_output_options`.
+3. Update the function signature to accept `use_jsonl: bool` and `quiet: bool` (in addition to
+   the already-present `use_json` and `no_header`).
+4. Add output routing for the new modes. The handler response already contains
+   `{"per_pass": [...], "top_draws": [...]}`. Use:
+   - `use_jsonl`: write each pass row as a separate JSON line via `write_jsonl(result["per_pass"])`,
+     then `write_jsonl(result["top_draws"])`.
+   - `quiet`: print `pass["pass"]` per row, one per line, to stdout.
+5. Retain the existing `use_json` (full JSON dump) and plain-TSV paths unchanged.
+
+Import additions for `info.py`:
+
+```python
+from rdc.formatters.options import list_output_options
+from rdc.formatters.json_fmt import write_jsonl
+```
+
+**Acceptance criteria:**
+- `rdc stats --jsonl` produces valid JSONL (one object per line) with no section titles.
+- `rdc stats -q` prints one pass identifier per line.
+- `rdc stats --json` behavior is unchanged.
+- `rdc stats` (plain) behavior is unchanged.
+
+**Dependencies:** B1 (no_header gating must be present before decorator swap)
+
+---
+
+### B3 — PR#84: Fix JSON error formatting in `_traverse_path()`
+
+**File:** `src/rdc/commands/assert_ci.py`
+
+Three error `click.echo` calls inside `_traverse_path()` (around lines 102, 107, 111) currently
+always emit plain text. Replace each with the `_json_mode()` / `_json_error()` pattern already
+established in PR #84:
+
+```python
+# before
+click.echo(f"error: key '{key}' not found in ...", err=True)
+
+# after
+msg = f"key '{key}' not found in ..."
+if _json_mode():
+    click.echo(json.dumps({"error": {"message": msg}}), err=True)
+else:
+    click.echo(f"error: {msg}", err=True)
+```
+
+Apply the same pattern to the index-out-of-range error path.
+
+**Acceptance criteria:**
+- `assert-state --json SECTION.bad_key VALUE` emits valid JSON to stderr.
+- `assert-state SECTION.bad_key VALUE` (no `--json`) emits unchanged plain text.
+
+**Dependencies:** none
+
+---
+
+### B4 — PR#84: Fix JSON error formatting in `assert_pixel_cmd` validation
+
+**File:** `src/rdc/commands/assert_ci.py`
+
+The validation block in `assert_pixel_cmd` (lines 141–153) has two error paths:
+1. Invalid `--expect` format.
+2. No passing modification found.
+
+Both call `click.echo(f"error: ...")` unconditionally. Apply `_json_mode()` gating:
+
+```python
+msg = "invalid --expect format: ..."
+if _json_mode():
+    click.echo(json.dumps({"error": {"message": msg}}), err=True)
+else:
+    click.echo(f"error: {msg}", err=True)
+```
+
+**Acceptance criteria:**
+- `assert-pixel --json --expect bad_format` emits valid JSON error to stderr.
+- `assert-pixel --json` with no passing modification emits valid JSON error to stderr.
+- Both paths without `--json` are unchanged.
+
+**Dependencies:** none
+
+---
+
+### B5 — PR#84: Fix JSON error formatting in `assert_state_cmd` invalid-section path
+
+**File:** `src/rdc/commands/assert_ci.py`
+
+The invalid-section error in `assert_state_cmd` (around line 299) calls
+`click.echo(f"error: ...")` unconditionally. Apply `_json_mode()` gating identically to B3/B4.
+
+**Acceptance criteria:**
+- `assert-state --json bad_section.field value` emits valid JSON error to stderr.
+- Without `--json` the behavior is unchanged.
+
+**Dependencies:** none
+
+---
+
+## Agent C — Tests
+
+### C1 — Tests for B6: debug message caching
+
+**File:** `tests/unit/test_info_handlers.py` (or nearest log-handler test file)
+
+1. `test_log_caches_debug_messages` — mock `GetDebugMessages` returning 3 messages; call
+   `_handle_log` twice; assert `GetDebugMessages` was called exactly once.
+2. `test_log_cache_populated_on_first_call` — assert `state._debug_messages_cache` is `None`
+   before the first call and a list after.
+3. `test_log_second_call_returns_same_data` — assert both calls return the same message list.
+
+**File:** `tests/test_daemon_handlers_real.py` (GPU test)
+
+4. `test_log_jsonl_not_empty` — on a real capture that has debug messages, invoke `log` twice
+   via the daemon; assert neither response returns an empty list (i.e., cache is working).
+
+**Dependencies:** A1, A2
+
+---
+
+### C2 — Tests for B1: stage extraction order
+
+**File:** `tests/unit/test_debug_handlers.py`
+
+1. `test_debug_vertex_stage_extracted_before_free` — mock `DebugVertex` returning a trace
+   object whose `.stage` attribute raises `AttributeError` after `FreeTrace` is called;
+   assert the handler returns success with a valid `stage` field (i.e., stage was read
+   before free).
+2. `test_debug_vertex_api_exception_returns_error` — mock `DebugVertex` raising an exception;
+   assert response has `"error"` key with a meaningful message, exit rc = 1.
+3. `test_debug_pixel_api_exception_returns_error` — same pattern for `DebugPixel`.
+4. `test_debug_thread_api_exception_returns_error` — same pattern for `DebugThread`.
+
+**File:** `tests/test_daemon_handlers_real.py` (GPU test)
+
+5. `test_debug_vertex_default_mode_no_internal_error` — call `debug_vertex` on a real capture
+   EID with a valid vertex index; assert response has `"inputs"`, `"outputs"`, `"total_steps"`
+   and does NOT contain `"internal error"`.
+
+**Dependencies:** A3, A4
+
+---
+
+### C3 — Tests for B7: RT info enrichment
+
+**File:** `tests/unit/test_stats_handlers.py` (or nearest stats-handler test file)
+
+1. `test_stats_rt_fields_populated` — mock `GetPipelineState` returning a pipe state with
+   a non-zero viewport; call `_handle_stats`; assert `per_pass[0]["rt_w"]` is non-zero.
+2. `test_stats_rt_enrichment_failure_is_silent` — mock `GetPipelineState` raising an exception
+   for one pass; assert the other passes are still enriched and the response succeeds.
+
+**File:** `tests/test_daemon_handlers_real.py` (GPU test)
+
+3. `test_stats_rt_w_nonzero_on_real_capture` — call `stats` via daemon on a real capture;
+   assert at least one pass row has `rt_w > 0`.
+
+**Dependencies:** A5
+
+---
+
+### C4 — Tests for B8: no-header section titles
+
+**File:** `tests/unit/test_info_commands.py` (or nearest stats-command test file)
+
+1. `test_stats_no_header_suppresses_section_titles` — invoke `stats_cmd` with `--no-header`
+   via `CliRunner(mix_stderr=False)`; assert neither `"Per-Pass Breakdown:"` nor `"Top Draws"`
+   appears in `result.output` or captured stderr.
+2. `test_stats_default_shows_section_titles` — invoke `stats_cmd` without `--no-header`; assert
+   section titles are present in stderr.
+
+**Dependencies:** B1
+
+---
+
+### C5 — Tests for B9: JSONL and quiet output for stats
+
+**File:** `tests/unit/test_info_commands.py`
+
+1. `test_stats_jsonl_produces_valid_jsonl` — monkeypatch `send_request` to return a mock stats
+   response; invoke `stats_cmd --jsonl`; assert each non-empty stdout line is valid JSON.
+2. `test_stats_jsonl_no_section_titles` — same; assert stderr is empty (no section titles in
+   JSONL mode because `--jsonl` implies `no_header` behavior OR section titles are still
+   conditional on `--no-header`; confirm from proposal).
+3. `test_stats_quiet_one_pass_per_line` — invoke `stats_cmd -q`; assert stdout line count
+   equals the number of passes in the mock response.
+4. `test_stats_json_unchanged` — invoke `stats_cmd --json`; assert stdout is valid JSON object
+   with `per_pass` key.
+
+**Dependencies:** B2
+
+---
+
+### C6 — Tests for PR#84: JSON error formatting in assert commands
+
+**File:** `tests/unit/test_assert_ci_commands.py`
+
+1. `test_traverse_path_key_not_found_plain` — monkeypatch handler to return a valid response;
+   invoke `assert_state_cmd SECTION.nonexistent_key VALUE` without `--json`; assert stderr
+   contains `"error:"` as plain text.
+2. `test_traverse_path_key_not_found_json` — same with `--json`; assert stderr is valid JSON
+   with `"error"` key.
+3. `test_assert_pixel_bad_expect_plain` — invoke `assert_pixel_cmd --expect bad` without
+   `--json`; assert plain-text stderr error.
+4. `test_assert_pixel_bad_expect_json` — same with `--json`; assert JSON stderr error.
+5. `test_assert_state_invalid_section_plain` — invoke `assert_state_cmd bad_section.field val`
+   without `--json`; assert plain-text stderr.
+6. `test_assert_state_invalid_section_json` — same with `--json`; assert JSON stderr.
+
+Use `CliRunner(mix_stderr=False)` throughout. Monkeypatch on `rdc.commands._helpers` (not on
+individual command modules).
+
+**Dependencies:** B3, B4, B5
+
+---
+
+### C7 — CI gate: lint, typecheck, test
+
+**Files:** none (verification only)
+
+1. Run `pixi run check` (ruff lint + mypy + pytest).
+2. Fix any lint or type errors introduced by A1–A5, B1–B5.
+3. Confirm zero test failures and coverage stays at or above the pre-fix baseline.
+4. Run `pixi run test-gpu` to validate GPU golden tests pass on real RenderDoc data.
+
+**Acceptance criteria:**
+- `pixi run check` exits 0.
+- `pixi run test-gpu` exits 0 with all new GPU golden tests passing.
+- Test count is >= pre-fix baseline.
+
+**Dependencies:** all of A1–A5, B1–B5, C1–C6 merged to the feature branch.
+
+---
+
+## File Ownership and Conflict Analysis
+
+| Agent | Files Exclusively Owned |
+|-------|------------------------|
+| Agent A | `src/rdc/daemon_server.py`, `src/rdc/handlers/query.py`, `src/rdc/handlers/debug.py` |
+| Agent B | `src/rdc/commands/info.py`, `src/rdc/commands/assert_ci.py` |
+| Agent C | `tests/unit/test_info_handlers.py`, `tests/unit/test_debug_handlers.py`, `tests/unit/test_stats_handlers.py`, `tests/unit/test_info_commands.py`, `tests/unit/test_assert_ci_commands.py`, `tests/test_daemon_handlers_real.py` |
+
+No source file is touched by more than one agent. `tests/test_daemon_handlers_real.py` is owned
+exclusively by Agent C; Agent A and Agent B do not modify it.
+
+---
+
+## Parallelization Notes
+
+- **Agent A and Agent B are fully parallel.** No shared source files.
+- **Agent C can begin** on tasks C4–C6 (CLI-level tests) in parallel with A+B; tasks C1–C3
+  (handler-level and GPU tests) require A1–A5 to be merged first.
+- **C7 must run last**, after all other tasks are merged to the feature branch.
+
+Recommended worktree split:
+- Worktree 1: Agent A (A1 → A2 → A3+A4 → A5, in order within the worktree)
+- Worktree 2: Agent B (B1 → B2, then B3/B4/B5 in any order)
+- Worktree 3: Agent C (C4–C6 first, then C1–C3 after Worktree 1 merges, then C7 last)
+
+---
+
+## Completion Checklist
+
+- [ ] `pixi run check` passes with zero errors (C7)
+- [ ] `pixi run test-gpu` passes with all new GPU golden tests (C7)
+- [ ] B6: `rdc log --jsonl` on a capture with debug messages returns a non-empty array
+- [ ] B1: `rdc debug vertex` in default mode never returns `"internal error"` on real GPU traces
+- [ ] B7: `rdc stats` per-pass rows show non-zero `RT_W`/`RT_H`/`ATTACHMENTS` on real captures
+- [ ] B8: `rdc stats --no-header` produces zero section-title lines in stderr
+- [ ] B9: `rdc stats --jsonl` produces valid JSONL; `rdc stats -q` prints one pass per line
+- [ ] PR#84: `rdc assert-state --json` emits valid JSON on all error paths
+- [ ] PR#84: `rdc assert-pixel --json` emits valid JSON on validation errors
+- [ ] PR created via `gh pr create`; CodeRabbit and Greptile reviews checked and addressed
+- [ ] Squash merge via `gh pr merge --squash --delete-branch`
+- [ ] Archive OpenSpec: `mv openspec/changes/2026-02-22-bugfix-remaining-blackbox openspec/changes/archive/`
+- [ ] Update Obsidian `进度跟踪.md` (test count delta, coverage)
+- [ ] Update Obsidian `待解决.md` — mark B1, B6, B7, B8, B9 resolved
+- [ ] Record any design deviations in `归档/决策记录.md` (next D-NNN)
+- [ ] Update MEMORY.md (open bugs list)

--- a/openspec/changes/2026-02-22-bugfix-remaining-blackbox/test-plan.md
+++ b/openspec/changes/2026-02-22-bugfix-remaining-blackbox/test-plan.md
@@ -1,0 +1,562 @@
+# Test Plan: Remaining Blackbox Bug Fixes (B1, B6-B9 + PR #84) (2026-02-22)
+
+## 1. Overview
+
+**Scope:** Unit tests covering all five open blackbox bugs (B1, B6-B9) and the incomplete JSON
+error coverage left by PR #84 in `assert_ci.py`.
+
+**Strategy:** CLI-layer tests use `CliRunner` + monkeypatch on `rdc.commands._helpers`
+(`load_session`, `send_request`). Handler-layer tests call `_handle_request()` directly with a
+`DaemonState` + `MockReplayController`. B6 daemon-unit tests call `_handle_log()` directly to
+verify the caching contract without going through the CLI layer.
+
+**Regression policy:** Every test group includes at least one regression case to confirm that
+the happy paths that existed before the fix still pass.
+
+**Target files:**
+
+| Bug | Unit test file |
+|-----|---------------|
+| B6 (log caching) | `tests/unit/test_daemon_server_unit.py` |
+| B1 (debug stage extraction) | `tests/unit/test_debug_handlers.py` |
+| B7 (stats RT enrichment) | `tests/unit/test_info_commands.py` |
+| B8 (stats --no-header section titles) | `tests/unit/test_info_commands.py` |
+| B9 (stats --jsonl/-q) | `tests/unit/test_info_commands.py` |
+| PR #84 (assert_ci JSON errors) | `tests/unit/test_assert_ci_commands.py` |
+
+CI gate: `pixi run lint && pixi run test` must pass with zero failures before PR.
+
+---
+
+## 2. Test Matrix
+
+| ID | Test name | File | Layer | Bug |
+|----|-----------|------|-------|-----|
+| B6-H-01 | `test_log_cache_populated_on_first_call` | `test_daemon_server_unit.py` | Handler | B6 |
+| B6-H-02 | `test_log_cache_returned_on_second_call` | `test_daemon_server_unit.py` | Handler | B6 |
+| B6-H-03 | `test_log_cache_respects_level_filter` | `test_daemon_server_unit.py` | Handler | B6 |
+| B6-H-04 | `test_log_cache_respects_eid_filter` | `test_daemon_server_unit.py` | Handler | B6 |
+| B6-C-01 | `test_log_json_nonempty_after_prior_call` | `test_info_commands.py` | CLI | B6 |
+| B1-H-01 | `test_debug_vertex_stage_extracted_before_free` | `test_debug_handlers.py` | Handler | B1 |
+| B1-H-02 | `test_debug_pixel_stage_extracted_before_free` | `test_debug_handlers.py` | Handler | B1 |
+| B1-H-03 | `test_debug_thread_stage_extracted_before_free` | `test_debug_handlers.py` | Handler | B1 |
+| B1-H-04 | `test_debug_vertex_api_exception_structured_error` | `test_debug_handlers.py` | Handler | B1 |
+| B1-H-05 | `test_debug_pixel_api_exception_structured_error` | `test_debug_handlers.py` | Handler | B1 |
+| B1-H-06 | `test_debug_thread_api_exception_structured_error` | `test_debug_handlers.py` | Handler | B1 |
+| B1-R-01 | `test_debug_pixel_happy_path` (existing — must pass) | `test_debug_handlers.py` | Handler | B1 |
+| B7-H-01 | `test_stats_rt_dimensions_from_pipeline` | `test_info_commands.py` | CLI | B7 |
+| B7-H-02 | `test_stats_rt_fallback_on_pipeline_failure` | `test_info_commands.py` | CLI | B7 |
+| B7-H-03 | `test_stats_per_pass_rt_fields_populated` | `test_info_commands.py` | CLI | B7 |
+| B8-C-01 | `test_stats_no_header_suppresses_section_titles` | `test_info_commands.py` | CLI | B8 |
+| B8-C-02 | `test_stats_default_shows_section_titles` | `test_info_commands.py` | CLI | B8 |
+| B8-R-01 | `test_stats_no_header` (existing — must pass) | `test_info_commands.py` | CLI | B8 |
+| B9-C-01 | `test_stats_jsonl_valid_lines` | `test_info_commands.py` | CLI | B9 |
+| B9-C-02 | `test_stats_jsonl_per_pass_structure` | `test_info_commands.py` | CLI | B9 |
+| B9-C-03 | `test_stats_quiet_pass_names_only` | `test_info_commands.py` | CLI | B9 |
+| B9-R-01 | `test_stats_json` (existing — must pass) | `test_info_commands.py` | CLI | B9 |
+| P84-C-01 | `test_traverse_path_key_not_found_json_error` | `test_assert_ci_commands.py` | CLI | PR#84 |
+| P84-C-02 | `test_traverse_path_invalid_index_json_error` | `test_assert_ci_commands.py` | CLI | PR#84 |
+| P84-C-03 | `test_assert_pixel_bad_expect_json_error` | `test_assert_ci_commands.py` | CLI | PR#84 |
+| P84-C-04 | `test_assert_pixel_no_passing_mod_json_error` | `test_assert_ci_commands.py` | CLI | PR#84 |
+| P84-C-05 | `test_assert_state_invalid_section_json_error` | `test_assert_ci_commands.py` | CLI | PR#84 |
+| P84-R-01 | `test_assert_pixel_exact_match` (existing — must pass) | `test_assert_ci_commands.py` | CLI | PR#84 |
+
+Total new tests: **23** across 2 test files.
+
+---
+
+## 3. Bug-by-Bug Test Cases
+
+### B6: Log message caching
+
+**Root cause:** `controller.GetDebugMessages()` consumes the internal queue on first call.
+Subsequent calls within the same session return an empty list. Structured output modes
+(`--json`, `--jsonl`, `--no-header`, `-q`) that reach `_handle_log()` a second time receive
+nothing.
+
+**Fix:** Add `_debug_messages_cache: list[Any] | None = None` to `DaemonState`. On the
+first `_handle_log()` call, populate the cache from `GetDebugMessages()` and store it.
+On subsequent calls, read from the cache. Clear the cache on `session_open`/`session_close`.
+
+**Source under test:** `src/rdc/handlers/query.py` (`_handle_log`), `src/rdc/daemon_server.py`
+(`DaemonState`).
+
+**Test approach:** Build a `DaemonState` with a `MockReplayController` whose
+`GetDebugMessages()` returns a non-empty list exactly once (a call counter enforces this).
+Call `_handle_log()` twice and verify that both responses contain the same messages.
+
+#### B6-H-01: `test_log_cache_populated_on_first_call`
+
+Setup:
+- `MockReplayController` with `GetDebugMessages` returning two messages on the first call and
+  an empty list on every subsequent call. Track call count via a closure counter.
+- Build `DaemonState` with no prior cache (`_debug_messages_cache is None`).
+
+Assertions:
+- After calling `_handle_log(req, {}, state)` once, `state._debug_messages_cache` is not
+  `None`.
+- `len(state._debug_messages_cache) == 2`.
+- `GetDebugMessages` was called exactly once (counter == 1).
+
+#### B6-H-02: `test_log_cache_returned_on_second_call`
+
+Setup:
+- Same `MockReplayController` as B6-H-01.
+- Call `_handle_log()` once to prime the cache.
+
+Assertions:
+- Call `_handle_log()` a second time with identical params.
+- Second response `result["messages"]` has length 2 (not 0).
+- `GetDebugMessages` was NOT called a second time (counter still == 1).
+
+#### B6-H-03: `test_log_cache_respects_level_filter`
+
+Setup:
+- Two cached messages: one with severity HIGH, one with INFO.
+- Cache pre-populated via first call.
+
+Assertions:
+- Second call with `params={"level": "HIGH"}` returns only the HIGH message.
+- Third call with `params={"level": "INFO"}` returns only the INFO message.
+- `GetDebugMessages` still called exactly once total.
+
+#### B6-H-04: `test_log_cache_respects_eid_filter`
+
+Setup:
+- Two cached messages: `{"eid": 0, ...}` and `{"eid": 42, ...}`.
+- Cache pre-populated via first call.
+
+Assertions:
+- Second call with `params={"eid": 42}` returns only the eid=42 message.
+- `GetDebugMessages` called exactly once total.
+
+#### B6-C-01: `test_log_json_nonempty_after_prior_call`
+
+**Note:** This is a CLI integration test that simulates the scenario where the daemon has
+already served `log` once and a second `log --json` call returns the correct data. Since unit
+tests monkeypatch `send_request` rather than running a real daemon, this test verifies the
+CLI-layer routing rather than the caching itself (caching is verified by B6-H-01/02).
+
+Setup:
+- Monkeypatch `rdc.commands._helpers.send_request` to return
+  `{"result": {"messages": [{"level": "HIGH", "eid": 0, "message": "err"}]}}`.
+- Invoke `CliRunner().invoke(main, ["log", "--json"])`.
+
+Assertions:
+- `result.exit_code == 0`.
+- Output is valid JSON.
+- Parsed `messages` array has length 1.
+- `messages[0]["level"] == "HIGH"`.
+
+---
+
+### B1: Debug stage extraction before FreeTrace
+
+**Root cause:** In `_handle_debug_vertex/pixel/thread`, `stage_name = _STAGE_NAMES.get(int(trace.stage), ...)` is evaluated after `_run_debug_loop()`. `_run_debug_loop()` calls `controller.FreeTrace(trace)` in its `finally` block, invalidating the trace object. On real GPU traces, accessing `trace.stage` after `FreeTrace` raises a native exception caught by the daemon's generic handler as `"internal error"`.
+
+**Fix:** Extract `stage_name` immediately after the `DebugVertex`/`DebugPixel`/`DebugThread`
+API call and before `_run_debug_loop()`. Also wrap the API call itself in try/except and return
+a structured error (not an unhandled exception) if the API call fails.
+
+**Source under test:** `src/rdc/handlers/debug.py`.
+
+**Test approach:** For stage-extraction tests, produce a `MockReplayController` where
+`trace.stage` is set correctly and `FreeTrace` invalidates the trace object (sets
+`trace.stage = None` or raises on attribute access). Verify that `stage_name` in the response
+matches the stage set before `FreeTrace`. For API-exception tests, make `DebugVertex` etc.
+raise a `RuntimeError` and verify a structured error response is returned.
+
+**Fixture note:** Reuse `_make_state`, `_make_trace`, and `_req` helpers already defined in
+`test_debug_handlers.py`.
+
+#### B1-H-01: `test_debug_vertex_stage_extracted_before_free`
+
+Setup:
+- `MockReplayController` where `DebugVertex` returns a trace with `stage = rd.ShaderStage.Vertex`
+  and `debugger` is a valid object.
+- Extend `FreeTrace` to set a sentinel on the trace that would cause `int(trace.stage)` to
+  raise after the call (e.g., `trace.stage = None`).
+- `state = _make_state(ctrl)`.
+
+Assertions:
+- Call `_handle_request(_req("debug_vertex", {"eid": 100, "vtx_id": 0}), state)`.
+- Response has no `"error"` key.
+- `response["result"]["stage"] == "vs"`.
+
+#### B1-H-02: `test_debug_pixel_stage_extracted_before_free`
+
+Setup and assertions mirror B1-H-01 but for `DebugPixel`:
+- Trace has `stage = rd.ShaderStage.Pixel`.
+- Call `_handle_request(_req("debug_pixel", {"eid": 100, "x": 320, "y": 240}), state)`.
+- `response["result"]["stage"] == "ps"`.
+
+#### B1-H-03: `test_debug_thread_stage_extracted_before_free`
+
+Setup and assertions mirror B1-H-01 but for `DebugThread`:
+- Trace has `stage = rd.ShaderStage.Compute`.
+- Call `_handle_request(_req("debug_thread", {"eid": 100, "group_x": 0, "group_y": 0,
+  "group_z": 0, "thread_x": 0, "thread_y": 0, "thread_z": 0}), state)`.
+- `response["result"]["stage"] == "cs"`.
+
+#### B1-H-04: `test_debug_vertex_api_exception_structured_error`
+
+Setup:
+- `MockReplayController` where `DebugVertex` raises `RuntimeError("shader not bound")`.
+- `state = _make_state(ctrl)`.
+
+Assertions:
+- Call `_handle_request(_req("debug_vertex", {"eid": 100, "vtx_id": 0}), state)`.
+- Response has `"error"` key.
+- `response["error"]["code"]` is an integer (e.g., -32603 or -32007).
+- `response["error"]["message"]` is a non-empty string; does NOT equal `"internal error"`.
+- No unhandled exception propagates.
+
+#### B1-H-05: `test_debug_pixel_api_exception_structured_error`
+
+Setup:
+- `MockReplayController` where `DebugPixel` raises `RuntimeError("no fragment")`.
+- `state = _make_state(ctrl)`.
+
+Assertions:
+- Call `_handle_request(_req("debug_pixel", {"eid": 100, "x": 0, "y": 0}), state)`.
+- Response has `"error"` key with non-empty, non-`"internal error"` message.
+
+#### B1-H-06: `test_debug_thread_api_exception_structured_error`
+
+Setup:
+- `MockReplayController` where `DebugThread` raises `RuntimeError("compute unavailable")`.
+- `state = _make_state(ctrl)`.
+
+Assertions:
+- Call `_handle_request(_req("debug_thread", {...}), state)`.
+- Response has `"error"` key with informative message.
+
+#### B1-R-01: Regression guard
+
+`test_debug_pixel_happy_path` (already exists in `test_debug_handlers.py`) must continue to
+pass unchanged. No modification to that test case.
+
+---
+
+### B7: Stats RT info enrichment
+
+**Root cause:** `aggregate_stats()` initializes `rt_w`, `rt_h`, and `attachments` to 0/`"-"`
+and never updates them. `_handle_stats` does not query pipeline state to populate render-target
+dimensions.
+
+**Fix:** After `aggregate_stats()`, iterate per-pass rows and query `GetPipelineState()` at a
+representative EID within each pass to extract framebuffer dimensions and attachment counts.
+
+**Source under test:** `src/rdc/handlers/query.py` (`_handle_stats`).
+
+**Test approach:** CLI tests patch `send_request` to return a response that now contains
+non-zero `rt_w`/`rt_h`/`attachments`, verifying that the CLI correctly renders these fields.
+The handler-level correctness (that the enrichment actually happens) is verified by a handler
+unit test added to `test_daemon_server_unit.py` or a new handler test file if preferred.
+
+For CLI-layer tests, add to `test_info_commands.py`.
+
+#### B7-H-01: `test_stats_rt_dimensions_from_pipeline`
+
+Setup:
+- Monkeypatch `send_request` to return:
+  ```json
+  {
+    "per_pass": [{"name": "Main", "draws": 5, "dispatches": 0, "triangles": 1000,
+                  "rt_w": 1920, "rt_h": 1080, "attachments": 2}],
+    "top_draws": []
+  }
+  ```
+- Invoke `CliRunner().invoke(main, ["stats"])`.
+
+Assertions:
+- `result.exit_code == 0`.
+- `"1920"` in `result.output`.
+- `"1080"` in `result.output`.
+- `"2"` in `result.output`.
+
+#### B7-H-02: `test_stats_rt_fallback_on_pipeline_failure`
+
+Setup:
+- Monkeypatch `send_request` to return per-pass row with `rt_w=0`, `rt_h=0`,
+  `attachments=0` (the fallback values when pipeline query fails).
+- Invoke `CliRunner().invoke(main, ["stats"])`.
+
+Assertions:
+- `result.exit_code == 0`.
+- Output renders without crashing (shows `0` or `"-"` for those columns, not a traceback).
+
+#### B7-H-03: `test_stats_per_pass_rt_fields_populated`
+
+Setup:
+- Two passes in `per_pass`, each with different `rt_w`/`rt_h`/`attachments` values.
+- Invoke `CliRunner().invoke(main, ["stats", "--json"])`.
+
+Assertions:
+- `result.exit_code == 0`.
+- Parsed JSON `per_pass[0]["rt_w"]` and `per_pass[1]["rt_w"]` match the mocked values.
+- Both passes have `attachments` field present in JSON output.
+
+---
+
+### B8: Stats --no-header section titles
+
+**Root cause:** "Per-Pass Breakdown:" and "Top Draws by Triangle Count:" section titles are
+written to stderr unconditionally in `stats_cmd`, bypassing the `--no-header` flag.
+
+**Fix:** Wrap each section-title `sys.stderr.write(...)` call in `if not no_header:`.
+
+**Source under test:** `src/rdc/commands/info.py` (`stats_cmd`).
+
+**Test approach:** `CliRunner(mix_stderr=True)` (default) captures both stdout and stderr in
+`result.output`. Use `CliRunner(mix_stderr=False)` when asserting stderr-only content.
+
+#### B8-C-01: `test_stats_no_header_suppresses_section_titles`
+
+Setup:
+- Monkeypatch `send_request` with a response containing one pass and one top-draw entry.
+- Invoke `CliRunner(mix_stderr=False).invoke(main, ["stats", "--no-header"])`.
+
+Assertions:
+- `result.exit_code == 0`.
+- `result.output` (stdout) does NOT contain `"Per-Pass Breakdown:"`.
+- `result.output` does NOT contain `"Top Draws"`.
+- Captured stderr (`result.stderr` from `mix_stderr=False` runner) does NOT contain
+  `"Per-Pass Breakdown:"`.
+- Data rows ARE present (pass name appears in stdout).
+
+#### B8-C-02: `test_stats_default_shows_section_titles`
+
+Setup:
+- Same monkeypatch as B8-C-01.
+- Invoke `CliRunner(mix_stderr=True).invoke(main, ["stats"])` (default mode with header).
+
+Assertions:
+- `result.exit_code == 0`.
+- `result.output` contains `"Per-Pass Breakdown:"` or `"Top Draws"` (section titles present).
+- Column header `"PASS"` is present.
+
+#### B8-R-01: Regression guard
+
+`test_stats_no_header` (already exists in `test_info_commands.py`) must continue to pass
+unchanged. That test already asserts `"PASS" not in result.output`; after the fix it must also
+not contain section titles.
+
+---
+
+### B9: Stats --jsonl/-q support
+
+**Root cause:** `stats_cmd` uses a custom `--json`/`--no-header` option set instead of
+`@list_output_options`, so `--jsonl` and `-q` are absent.
+
+**Fix:** Replace custom options with `@list_output_options` (which provides `--json`,
+`--jsonl`, `-q`, `--no-header`). Update output routing accordingly.
+
+**Source under test:** `src/rdc/commands/info.py` (`stats_cmd`).
+
+**Monkeypatch shape for B9 tests:**
+
+```python
+_STATS_RESPONSE = {
+    "per_pass": [
+        {"name": "Main", "draws": 10, "dispatches": 0, "triangles": 5000,
+         "rt_w": 1920, "rt_h": 1080, "attachments": 3},
+        {"name": "Shadow", "draws": 4, "dispatches": 0, "triangles": 2000,
+         "rt_w": 1024, "rt_h": 1024, "attachments": 1},
+    ],
+    "top_draws": [{"eid": 42, "marker": "Geo", "triangles": 3000}],
+}
+```
+
+#### B9-C-01: `test_stats_jsonl_valid_lines`
+
+Setup:
+- Monkeypatch `send_request` with `_STATS_RESPONSE`.
+- Invoke `CliRunner().invoke(main, ["stats", "--jsonl"])`.
+
+Assertions:
+- `result.exit_code == 0`.
+- `result.output` is non-empty.
+- Every non-empty line in `result.output` is valid JSON (parse each with `json.loads`).
+- No `json.JSONDecodeError` raised during parsing.
+
+#### B9-C-02: `test_stats_jsonl_per_pass_structure`
+
+Setup:
+- Same monkeypatch.
+- Invoke `CliRunner().invoke(main, ["stats", "--jsonl"])`.
+
+Assertions:
+- `result.exit_code == 0`.
+- Lines include at least one object with `"name"` == `"Main"`.
+- Each per-pass line has at least `"draws"` and `"triangles"` keys.
+
+#### B9-C-03: `test_stats_quiet_pass_names_only`
+
+Setup:
+- Monkeypatch `send_request` with `_STATS_RESPONSE`.
+- Invoke `CliRunner().invoke(main, ["stats", "-q"])`.
+
+Assertions:
+- `result.exit_code == 0`.
+- Output contains `"Main"` and `"Shadow"`.
+- Output does NOT contain `"PASS"` (no column header).
+- Output does NOT contain `"{"` (no JSON objects, only names).
+
+#### B9-R-01: Regression guard
+
+`test_stats_json` (already exists in `test_info_commands.py`) must continue to pass. It
+invokes `stats --json` and asserts `"per_pass" in result.output`. After replacing the decorator
+this must still hold.
+
+---
+
+### PR #84: assert_ci.py JSON error formatting (incomplete coverage)
+
+**Root cause:** PR #84 applied `_json_mode()` / `_json_error()` to main success/failure paths,
+but three error paths in `assert_ci.py` still emit plain text unconditionally:
+1. `_traverse_path()` — key-not-found (line 106) and invalid-index (line 102) errors.
+2. `assert_pixel_cmd` — `--expect` format validation errors (lines 141, 146).
+3. `assert_pixel_cmd` — no-passing-modification error (line 153).
+4. `assert_state_cmd` — invalid-section error (line 299).
+
+**Fix:** In each error branch, check `_json_mode()` and emit JSON if true, else fall back to
+`click.echo(f"error: ...")`.
+
+**Source under test:** `src/rdc/commands/assert_ci.py`.
+
+**Test approach:** Use `CliRunner(mix_stderr=False)` to capture stderr separately. All error
+paths in `assert_ci.py` write to stderr (`err=True`). Monkeypatch `_assert_call` via
+`mod._assert_call` (the `assert_ci` module-level binding) to return controlled data without
+a real daemon. For path-traversal tests, use `assert-state` with a mock that returns a known
+dict, then provide a key path that is guaranteed to fail traversal.
+
+#### P84-C-01: `test_traverse_path_key_not_found_json_error`
+
+Setup:
+- Monkeypatch `mod._assert_call` (where `mod = rdc.commands.assert_ci`) to return
+  `{"topology": "TriangleList"}` (no `"eid"` key, which the real handler always returns, but
+  the test path must include a non-existent key).
+- Invoke `CliRunner(mix_stderr=False).invoke(main,
+  ["assert-state", "100", "topology.nonexistent", "--expect", "x", "--json"])`.
+
+Assertions:
+- `result.exit_code == 2`.
+- `result.stderr` is valid JSON.
+- Parsed JSON has `{"error": {"message": <str>}}` shape.
+- `"message"` contains `"not found"` or `"nonexistent"`.
+- `result.output` (stdout) is empty or does not contain a plain `"error:"` prefix.
+
+#### P84-C-02: `test_traverse_path_invalid_index_json_error`
+
+Setup:
+- Monkeypatch `mod._assert_call` to return `{"blends": [{"enabled": True}]}`.
+- Invoke `CliRunner(mix_stderr=False).invoke(main,
+  ["assert-state", "100", "blend.99", "--expect", "true", "--json"])`.
+
+Assertions:
+- `result.exit_code == 2`.
+- `result.stderr` is valid JSON `{"error": {"message": <str>}}`.
+- `"message"` references the invalid segment or index.
+
+#### P84-C-03: `test_assert_pixel_bad_expect_json_error`
+
+Setup:
+- Monkeypatch `mod._assert_call` to a no-op (not called due to early exit).
+- Invoke `CliRunner(mix_stderr=False).invoke(main,
+  ["assert-pixel", "88", "512", "384", "--expect", "1.0 2.0", "--json"])`.
+  (Only 2 floats instead of 4.)
+
+Assertions:
+- `result.exit_code == 2`.
+- `result.stderr` is valid JSON `{"error": {"message": <str>}}`.
+- `"message"` references the 4-float requirement.
+
+#### P84-C-04: `test_assert_pixel_no_passing_mod_json_error`
+
+Setup:
+- Monkeypatch `mod._assert_call` to return `{"modifications": [{"eid": 88, "passed": False,
+  "post_mod": {"r": 0.5, "g": 0.3, "b": 0.1, "a": 1.0}}]}`.
+- Invoke `CliRunner(mix_stderr=False).invoke(main,
+  ["assert-pixel", "88", "512", "384", "--expect", "0.5 0.3 0.1 1.0", "--json"])`.
+
+Assertions:
+- `result.exit_code == 2`.
+- `result.stderr` is valid JSON `{"error": {"message": <str>}}`.
+- `"message"` contains `"no passing modification"` or equivalent.
+
+#### P84-C-05: `test_assert_state_invalid_section_json_error`
+
+Setup:
+- Monkeypatch `mod._assert_call` to a no-op (not called due to early exit).
+- Invoke `CliRunner(mix_stderr=False).invoke(main,
+  ["assert-state", "100", "bogussection", "--expect", "x", "--json"])`.
+
+Assertions:
+- `result.exit_code == 2`.
+- `result.stderr` is valid JSON `{"error": {"message": <str>}}`.
+- `"message"` references `"bogussection"` or `"invalid section"`.
+
+#### P84-R-01: Regression guard
+
+`test_assert_pixel_exact_match` (already exists in `test_assert_ci_commands.py`) must
+continue to pass. That test invokes `assert-pixel` without `--json` and asserts
+`result.output.startswith("pass:")`. The fix must not alter the success path.
+
+---
+
+## 4. Assertions Summary
+
+### Global JSON error assertions (PR #84)
+
+All JSON error cases share these invariants:
+- `result.exit_code == 2` (assert_ci errors use `sys.exit(2)`).
+- `result.stderr` is parseable with `json.loads` (no `JSONDecodeError`).
+- Parsed JSON top-level key is `"error"`.
+- Parsed `"error"` dict has key `"message"` with a non-empty string value.
+- `result.output` (stdout) does not contain `"error:"` as a plain-text prefix.
+
+### B6 caching invariants
+
+- `GetDebugMessages()` is called at most once per session regardless of how many times
+  `_handle_log()` is invoked.
+- Filter params (`level`, `eid`) are applied to the cached list, not re-fetched from the API.
+- The cached list has the same length and content as what was returned on the first call.
+
+### B8 no-header invariants
+
+- Without `--no-header`: column header AND section titles are present.
+- With `--no-header`: column header AND section titles are both absent.
+- Data rows are present in both cases.
+
+### B9 output-mode invariants
+
+- `--jsonl`: every output line is valid JSON; no column headers.
+- `-q`: one pass name per line; no JSON, no column headers.
+- `--json`: full JSON object (existing behaviour unchanged).
+- `--no-header` (existing): TSV rows without column header (existing behaviour unchanged).
+
+---
+
+## 5. Regression Coverage
+
+Existing tests that must remain green after each fix:
+
+| Bug fixed | Existing tests that must still pass |
+|-----------|-------------------------------------|
+| B6 | `test_log_tsv`, `test_log_json`, `test_log_with_level_filter`, `test_log_with_eid_filter`, `test_log_no_header_regression`, `test_log_jsonl`, `test_log_quiet` |
+| B1 | `test_debug_pixel_happy_path`, `test_debug_pixel_missing_eid` in `test_debug_handlers.py` |
+| B7 | `test_stats_tsv`, `test_stats_json`, `test_stats_empty` in `test_info_commands.py` |
+| B8 | `test_stats_no_header` in `test_info_commands.py` |
+| B9 | `test_stats_json`, `test_stats_tsv`, `test_stats_no_header` in `test_info_commands.py` |
+| PR #84 | `test_assert_pixel_exact_match`, `test_assert_pixel_within_tolerance`, `test_assert_pixel_no_passing_mod`, `test_assert_call_success`, `test_assert_call_rpc_error` in `test_assert_ci_commands.py` |
+
+---
+
+## 6. Out of Scope
+
+- GPU integration tests (all bugs in this batch are unit-testable without a real capture).
+- `assert-clean` JSON error paths (not flagged as incomplete in the proposal).
+- `_traverse_path` plain-text (non-`--json`) paths — existing behaviour is correct.
+- `debug thread` beyond B1-H-03/B1-H-06 (stage extraction fix is the full scope).
+- New JSON-RPC methods or CLI commands.

--- a/src/rdc/daemon_server.py
+++ b/src/rdc/daemon_server.py
@@ -108,6 +108,7 @@ class DaemonState:
     replay_output: Any = None
     replay_output_dims: tuple[int, int] | None = None
     _shader_cache_built: bool = field(default=False, repr=False)
+    _debug_messages_cache: list[Any] | None = None
 
 
 def _detect_version(rd: Any) -> tuple[int, int]:

--- a/src/rdc/handlers/debug.py
+++ b/src/rdc/handlers/debug.py
@@ -140,15 +140,18 @@ def _handle_debug_pixel(
     inputs.primitive = int(params.get("primitive", 0xFFFFFFFF))
 
     controller = state.adapter.controller
-    trace = controller.DebugPixel(x, y, inputs)
+    try:
+        trace = controller.DebugPixel(x, y, inputs)
+    except Exception as exc:
+        return _error_response(request_id, -32603, f"DebugPixel failed: {exc}"), True
 
     if trace is None or trace.debugger is None:
         return _error_response(request_id, -32007, "no fragment at pixel"), True
 
+    stage_name = _STAGE_NAMES.get(int(trace.stage), "ps")
     steps, loop_err = _run_debug_loop(controller, trace)
     if loop_err:
         return _error_response(request_id, -32603, loop_err), True
-    stage_name = _STAGE_NAMES.get(int(trace.stage), "ps")
     inp, out = _extract_inputs_outputs(steps)
 
     return _result_response(
@@ -184,15 +187,18 @@ def _handle_debug_vertex(
         return _error_response(request_id, -32002, err), True
 
     controller = state.adapter.controller
-    trace = controller.DebugVertex(vtx_id, instance, idx, view)
+    try:
+        trace = controller.DebugVertex(vtx_id, instance, idx, view)
+    except Exception as exc:
+        return _error_response(request_id, -32603, f"DebugVertex failed: {exc}"), True
 
     if trace is None or trace.debugger is None:
         return _error_response(request_id, -32007, "vertex debug not available"), True
 
+    stage_name = _STAGE_NAMES.get(int(trace.stage), "vs")
     steps, loop_err = _run_debug_loop(controller, trace)
     if loop_err:
         return _error_response(request_id, -32603, loop_err), True
-    stage_name = _STAGE_NAMES.get(int(trace.stage), "vs")
     inp, out = _extract_inputs_outputs(steps)
 
     return _result_response(
@@ -233,15 +239,18 @@ def _handle_debug_thread(
         return _error_response(request_id, -32602, "event is not a Dispatch"), True
 
     controller = state.adapter.controller
-    trace = controller.DebugThread((gx, gy, gz), (tx, ty, tz))
+    try:
+        trace = controller.DebugThread((gx, gy, gz), (tx, ty, tz))
+    except Exception as exc:
+        return _error_response(request_id, -32603, f"DebugThread failed: {exc}"), True
 
     if trace is None or trace.debugger is None:
         return _error_response(request_id, -32007, "thread debug not available"), True
 
+    stage_name = _STAGE_NAMES.get(int(trace.stage), "cs")
     steps, loop_err = _run_debug_loop(controller, trace)
     if loop_err:
         return _error_response(request_id, -32603, loop_err), True
-    stage_name = _STAGE_NAMES.get(int(trace.stage), "cs")
     inp, out = _extract_inputs_outputs(steps)
 
     return _result_response(


### PR DESCRIPTION
## Summary

Fixes 5 remaining blackbox bugs from 2026-02-22 testing and completes PR #84 JSON error coverage:

- **B1 (P2)**: `debug vertex/pixel/thread` internal error — extract `trace.stage` before `_run_debug_loop()` calls `FreeTrace`; wrap `Debug*` API calls in try/except
- **B6 (P1)**: `log --json/--jsonl/-q` returns empty — cache `GetDebugMessages()` result on `DaemonState` (consume-once API)
- **B7 (P2)**: `stats` RT_W/RT_H/ATTACHMENTS always `-`/`0` — enrich per-pass stats with RT dimensions from pipeline state
- **B8 (P2)**: `stats --no-header` still shows section titles — gate `sys.stderr.write()` on `not no_header`
- **B9 (P3)**: `stats --jsonl` not supported — add `@list_output_options` decorator with JSONL/quiet output paths
- **PR#84**: `assert_ci.py` error paths ignore `--json` — add `_err_exit()` helper using `_json_mode()` for all validation errors

## Test plan

- [x] `pixi run lint` — zero errors (ruff check + format)
- [x] `pixi run typecheck` — zero errors (mypy strict)
- [x] `pixi run test` — 1716 tests pass, 95.51% coverage (+14 new tests)
- [x] `pixi run e2e` — 26/26 pass
- [x] Opus code review — no issues at confidence >= 80
- [ ] GPU test: `rdc log --json` on shader_debugprintf capture returns non-empty
- [ ] GPU test: `debug vertex 11 0` on hello_triangle returns summary

## Files changed

| File | Changes |
|------|---------|
| `src/rdc/daemon_server.py` | Add `_debug_messages_cache` field |
| `src/rdc/handlers/debug.py` | B1: stage extraction before FreeTrace, try/except |
| `src/rdc/handlers/query.py` | B6: cache messages; B7: RT dimensions |
| `src/rdc/commands/info.py` | B8: gate titles; B9: JSONL/quiet |
| `src/rdc/commands/assert_ci.py` | PR#84: `_err_exit()` JSON-aware errors |
| `tests/unit/test_debug_handlers.py` | +5 tests (B1) |
| `tests/unit/test_info_commands.py` | +8 tests (B6/B7/B8/B9) |
| `tests/unit/test_assert_ci_commands.py` | +5 tests (PR#84) |

Closes B1, B6, B7, B8, B9 from `待解决.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed 6 remaining issues affecting debug message handling, stats output formatting, and error reporting
  * Added JSON error formatting for assert commands
  * Improved stats command to display RT dimensions and attachment details per pass
  * Enhanced --no-header to properly suppress section titles

* **New Features**
  * Added --jsonl and -q/--quiet output modes to stats command

<!-- end of auto-generated comment: release notes by coderabbit.ai -->