### PR TITLE
fix(stats): match RT enrichment by draw EID instead of pass name

### DIFF
--- a/.claude/skills/rdc-cli/references/commands-quick-ref.md
+++ b/.claude/skills/rdc-cli/references/commands-quick-ref.md
@@ -795,6 +795,8 @@ Show per-pass breakdown, top draws, largest resources.
 |------|------|------|---------|
 | `--json` | JSON output | flag |  |
 | `--no-header` | Omit TSV header | flag |  |
+| `--jsonl` | JSONL output | flag |  |
+| `-q, --quiet` | Print primary key column only | flag |  |
 
 ## `rdc status`
 


### PR DESCRIPTION
## Summary
- Fix RT dimension enrichment in `stats` handler: `_build_pass_list()` applies `_friendly_pass_name()` which renames passes, causing name mismatch with `aggregate_stats()`. Now uses first draw EID per pass from flat actions for reliable lookup.
- Regenerate SKILL.md command reference (stats gained `--jsonl`/`-q` from PR #88).

## Verified
- `rdc stats` on `terrain_tessellation.rdc`: `RT_W=1280 RT_H=720 ATTACHMENTS=2`
- `rdc stats --json`: `rt_w`, `rt_h`, `attachments` fields populated
- 1729 tests pass, 95.51% coverage, e2e 26/26

## Test plan
- [x] Manual GPU test with `terrain_tessellation.rdc`
- [x] Unit tests (existing B7 tests still pass)
- [x] Lint + typecheck + e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--jsonl` option to `rdc stats` command for JSON Lines formatted output
  * Added `-q, --quiet` option to `rdc stats` command to display only the primary key column

<!-- end of auto-generated comment: release notes by coderabbit.ai -->