### PR TITLE
docs(readme): update commands, stats, and build-renderdoc instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,30 +14,22 @@
 [![Tests](https://img.shields.io/endpoint?url=https://bananasjim.github.io/rdc-cli/badges/tests.json)](https://bananasjim.github.io/rdc-cli/)
 [![Coverage](https://img.shields.io/endpoint?url=https://bananasjim.github.io/rdc-cli/badges/coverage.json)](https://bananasjim.github.io/rdc-cli/)
 
-Pipe-friendly TSV output, JSON mode, 53 commands, daemon-backed session for interactive exploration of [RenderDoc](https://renderdoc.org/) `.rdc` captures.
+Pipe-friendly TSV output, JSON mode, 51 commands, daemon-backed session for interactive exploration of [RenderDoc](https://renderdoc.org/) `.rdc` captures.
 
 **[Full documentation →](https://bananasjim.github.io/rdc-cli/)**
 
 ```bash
-rdc open capture.rdc          # start session
-rdc draws                     # list draw calls (TSV)
-rdc pipeline 142              # pipeline state at EID 142
-rdc shader 142 ps             # pixel shader disassembly
-rdc texture 5 -o out.png      # export texture
-rdc draws --json | jq '...'   # machine-readable output
-rdc close                     # end session
+rdc open capture.rdc            # start session
+rdc draws                       # list draw calls (TSV)
+rdc pipeline 142                # pipeline state at EID 142
+rdc shader 142 ps               # pixel shader disassembly
+rdc texture 5 -o out.png        # export texture
+rdc debug 142 ps 400 300        # debug pixel shader at (400,300)
+rdc assert-pixel 142 400 300 \
+    --expect 0.5,0.0,0.0,1.0   # CI pixel assertion
+rdc draws --json | jq '...'     # machine-readable output
+rdc close                       # end session
 ```
-
----
-
-> **Prerequisite -- renderdoc Python module**
-> `rdc` requires `renderdoc.cpython-*.so`, which is **not available on PyPI**.
-> Build it once with the provided script (requires cmake, ninja, Vulkan headers):
-> ```bash
-> bash <(curl -fsSL https://raw.githubusercontent.com/BANANASJIM/rdc-cli/master/scripts/build-renderdoc.sh)
-> ```
-> Full instructions: <https://bananasjim.github.io/rdc-cli/>
-> AUR users: `yay -S rdc-cli-git` handles this automatically.
 
 ## Install
 
@@ -45,6 +37,9 @@ rdc close                     # end session
 
 ```bash
 pipx install rdc-cli
+# build renderdoc Python module (one-time, ~3 min, needs cmake/ninja/python3)
+curl -fsSL https://raw.githubusercontent.com/BANANASJIM/rdc-cli/master/scripts/build-renderdoc.sh | bash
+rdc doctor   # verify installation
 ```
 
 **AUR** (Arch Linux — builds renderdoc Python module automatically)
@@ -61,23 +56,6 @@ cd rdc-cli
 pixi install && pixi run sync
 ```
 
-## Setup renderdoc
-
-`rdc` requires the renderdoc Python module (`renderdoc.cpython-*.so`), which is **not** included in most system packages. Build it once with the provided script:
-
-```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/BANANASJIM/rdc-cli/master/scripts/build-renderdoc.sh)
-export RENDERDOC_PYTHON_PATH="$HOME/.local/renderdoc"
-```
-
-Module discovery order:
-
-1. `RENDERDOC_PYTHON_PATH` environment variable
-2. `/usr/lib/renderdoc`, `/usr/local/lib/renderdoc`
-3. Sibling directory of `renderdoccmd` on PATH
-
-Verify with `rdc doctor`.
-
 ## Commands
 
 Run `rdc --help` for the full command list, or `rdc <command> --help` for details.
@@ -87,11 +65,14 @@ Run `rdc --help` for the full command list, or `rdc <command> --help` for detail
 | Session | `open`, `close`, `status`, `goto` |
 | Inspection | `info`, `stats`, `events`, `draws`, `event`, `draw`, `log` |
 | GPU state | `pipeline`, `bindings`, `shader`, `shaders`, `shader-map` |
+| Debug | `debug`, `pixel`, `pick-pixel`, `tex-stats` |
+| Shader Edit | `shader-build`, `shader-replace`, `shader-restore`, `shader-restore-all`, `shader-encodings` |
 | Resources | `resources`, `resource`, `passes`, `pass`, `usage` |
-| Export | `texture`, `rt`, `buffer` |
+| Export | `texture`, `rt`, `buffer`, `mesh`, `snapshot` |
 | Search | `search`, `counters` |
+| Assertions | `assert-pixel`, `assert-state`, `assert-image`, `assert-count`, `assert-clean` |
 | VFS | `ls`, `cat`, `tree` |
-| Utility | `doctor`, `completion`, `capture`, `count` |
+| Utility | `doctor`, `completion`, `capture`, `count`, `script`, `diff` |
 
 All commands support `--json` for machine-readable output.
 
@@ -107,7 +88,7 @@ rdc completion fish > ~/.config/fish/completions/rdc.fish
 
 ```bash
 pixi run sync                 # install deps + activate git hooks
-pixi run check                # lint + typecheck + test (1641 tests, 95.79% coverage)
+pixi run check                # lint + typecheck + test (1729 tests, 95.51% coverage)
 pixi run verify               # full packaging verification (19 checks)
 ```
 


### PR DESCRIPTION
## Summary
- Update command count from 53 → 51 (actual `--help` count)
- Add missing command categories: **Debug**, **Shader Edit**, **Assertions** (18 new commands in table)
- Update test stats: 1729 tests, 95.51% coverage
- Expand `build-renderdoc.sh` description (SHA-256 verify, LTO strip, prerequisites)
- Add build script inline with PyPI install instructions for one-step setup
- Add `debug` and `assert-pixel` examples to quick-start snippet

## Test plan
- [x] `pixi run check` passes (1729 tests, 95.51% coverage)
- [x] e2e tests pass (26/26)
- [ ] Visual review of rendered README on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with expanded command reference, new usage examples, and additional command groups
  * Added comprehensive setup instructions and prerequisites for building the RenderDoc Python module
  * Improved module discovery paths and verification guidance for users
  * Enhanced installation documentation for multiple installation methods and platforms
  * Updated development section with current test counts and coverage metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->