### PR TITLE
ci(docs): update repo description to match new branding

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -121,8 +121,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOC_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          CMD=$(python3 -c "import json; print(json.load(open('docs-astro/src/data/stats.json'))['command_count'])")
           gh repo edit \
-            --description "Unix-friendly CLI for RenderDoc — ${CMD} commands, TSV/JSON, daemon sessions (v${DOC_VERSION})" \
+            --description "Scriptable CLI for RenderDoc captures — built for terminal workflows, CI pipelines, and AI agents (v${DOC_VERSION})" \
             || true
           gh repo edit --homepage "https://bananasjim.github.io/rdc-cli/" || true


### PR DESCRIPTION
## Summary
- Remove hardcoded command count from docs workflow repo description
- Use consistent branding: "Scriptable CLI for RenderDoc captures — built for terminal workflows, CI pipelines, and AI agents (vX.Y.Z)"
- Append version suffix from deploy tag

## Test plan
- [x] `pixi run check` passes
- [ ] Next `v*` tag deploy writes correct description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository description to highlight CLI features, including support for terminal workflows, CI pipelines, and AI agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->