### PR TITLE
fix(version): use importlib.metadata for dynamic version resolution

### DIFF
--- a/src/rdc/__init__.py
+++ b/src/rdc/__init__.py
@@ -1,4 +1,10 @@
 """rdc package."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 __all__ = ["__version__"]
-__version__ = "0.2.0"
+
+try:
+    __version__ = version("rdc-cli")
+except PackageNotFoundError:
+    __version__ = "0.0.0-dev"


### PR DESCRIPTION
## Summary
- Replace hardcoded `__version__ = "0.2.0"` with `importlib.metadata.version("rdc-cli")` so `rdc --version` always matches `pyproject.toml`
- Add `PackageNotFoundError` fallback to `"0.0.0-dev"` for uninstalled source-tree usage
- Fixes B10: PyPI 0.3.0 and AUR 0.3.0 both incorrectly displayed version 0.2.0

## Test plan
- [x] `pixi run lint` — all checks passed
- [x] `pixi run test` — 1736 passed, 95.53% coverage
- [x] e2e — 26/26 passed
- [ ] After merge: verify `pip install rdc-cli && rdc --version` shows correct version
- [ ] After AUR rebuild: verify `rdc --version` shows correct version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package version resolution to automatically synchronize with package metadata, ensuring version consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->