### PR TITLE
chore(release): bump version to 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rdc-cli"
-version = "0.3.0"
+version = "0.3.1"
 description = "Unix-friendly CLI for RenderDoc .rdc captures"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Patch release to deliver the dynamic version fix (PR #98) to PyPI and AUR users
- Only change: `pyproject.toml` version `0.3.0` → `0.3.1`

## After merge
- Tag `v0.3.1` → triggers PyPI publish CI
- AUR `rdc-cli` PKGBUILD update `pkgver=0.3.1`