### PR TITLE
docs(site): overhaul Astro docs with full command reference and new pages

### DIFF
--- a/docs-astro/src/components/Commands.astro
+++ b/docs-astro/src/components/Commands.astro
@@ -4,14 +4,18 @@ import stats from "../data/stats.json";
 const base = import.meta.env.BASE_URL;
 
 const categories = [
-  { name: 'Session', color: 'from-gpu-accent/20', accent: 'text-gpu-accent', commands: ['open', 'close', 'status', 'goto'] },
+  { name: 'Session', color: 'from-gpu-accent/20', accent: 'text-gpu-accent', commands: ['open', 'close', 'status', 'goto', 'capture', 'doctor'] },
   { name: 'Inspection', color: 'from-gpu-green/20', accent: 'text-gpu-green', commands: ['info', 'stats', 'events', 'draws', 'event', 'draw', 'log'] },
   { name: 'GPU State', color: 'from-gpu-purple/20', accent: 'text-gpu-purple', commands: ['pipeline', 'bindings', 'shader', 'shaders', 'shader-map'] },
+  { name: 'Debug', color: 'from-red-500/20', accent: 'text-red-400', commands: ['debug', 'pixel', 'pick-pixel', 'tex-stats'] },
+  { name: 'Shader Edit', color: 'from-yellow-500/20', accent: 'text-yellow-400', commands: ['shader-build', 'shader-replace', 'shader-restore', 'shader-restore-all', 'shader-encodings'] },
   { name: 'Resources', color: 'from-gpu-orange/20', accent: 'text-gpu-orange', commands: ['resources', 'resource', 'passes', 'pass', 'usage'] },
-  { name: 'Export', color: 'from-gpu-pink/20', accent: 'text-gpu-pink', commands: ['texture', 'rt', 'buffer'] },
-  { name: 'Search', color: 'from-yellow-500/20', accent: 'text-yellow-400', commands: ['search', 'counters'] },
+  { name: 'Export', color: 'from-gpu-pink/20', accent: 'text-gpu-pink', commands: ['texture', 'rt', 'buffer', 'mesh', 'snapshot'] },
+  { name: 'Assertions', color: 'from-emerald-500/20', accent: 'text-emerald-400', commands: ['assert-pixel', 'assert-image', 'assert-clean', 'assert-count', 'assert-state'] },
+  { name: 'Diff', color: 'from-sky-500/20', accent: 'text-sky-400', commands: ['diff'] },
+  { name: 'Search', color: 'from-amber-500/20', accent: 'text-amber-400', commands: ['search', 'counters'] },
   { name: 'VFS', color: 'from-gpu-cyan/20', accent: 'text-gpu-cyan', commands: ['ls', 'cat', 'tree'] },
-  { name: 'Utility', color: 'from-gray-500/20', accent: 'text-gray-400', commands: ['doctor', 'completion', 'capture', 'count'] },
+  { name: 'Utility', color: 'from-gray-500/20', accent: 'text-gray-400', commands: ['count', 'completion', 'script', 'install-skill'] },
 ];
 ---
 

--- a/docs-astro/src/components/Features.astro
+++ b/docs-astro/src/components/Features.astro
@@ -22,7 +22,7 @@ const features = [
     description: 'Browse captures like a filesystem. Tab-complete through draws and state.',
     color: 'text-gpu-green',
     glow: 'rgba(0,230,118,0.15)',
-    example: 'rdc cat /draws/142/pipeline/shader/ps',
+    example: 'rdc cat /draws/142/shader/ps',
   },
   {
     icon: '\u25C8',
@@ -31,6 +31,22 @@ const features = [
     color: 'text-gpu-orange',
     glow: 'rgba(255,145,0,0.15)',
     example: 'rdc open cap.rdc && rdc draws && rdc close',
+  },
+  {
+    icon: '\u2713',
+    title: 'CI Assertions',
+    description: 'Built-in pixel, image, state, and count assertions. Exit code 0/1/2 for pass/fail/error.',
+    color: 'text-emerald-400',
+    glow: 'rgba(52,211,153,0.15)',
+    example: 'rdc assert-pixel 142 400 300 --expect "1 0 0 1"',
+  },
+  {
+    icon: '\u26A1',
+    title: 'AI Agent Ready',
+    description: 'Claude Code skill auto-installs. VFS paths + JSON output make captures agent-navigable.',
+    color: 'text-gpu-purple',
+    glow: 'rgba(179,136,255,0.15)',
+    example: 'rdc install-skill && rdc ls /draws/142/',
   },
 ];
 ---
@@ -44,7 +60,7 @@ const features = [
       Every design decision optimized for pipelines, scripting, and agent-driven workflows.
     </p>
 
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-5" id="features-grid">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5" id="features-grid">
       {features.map((f, i) => (
         <div
           class="feature-card glass-card p-7 opacity-0"

--- a/docs-astro/src/components/Navbar.astro
+++ b/docs-astro/src/components/Navbar.astro
@@ -5,6 +5,7 @@ const base = import.meta.env.BASE_URL;
 const navLinks = [
   { label: 'Docs', href: `${base}docs/` },
   { label: 'Commands', href: `${base}docs/commands/` },
+  { label: 'Examples', href: `${base}docs/examples/` },
   { label: 'Install', href: `${base}docs/install/` },
 ];
 ---

--- a/docs-astro/src/components/Philosophy.astro
+++ b/docs-astro/src/components/Philosophy.astro
@@ -1,0 +1,80 @@
+---
+---
+
+<section id="philosophy" class="py-32 relative section-glow">
+  <div class="max-w-6xl mx-auto px-6">
+    <h2 class="text-3xl md:text-5xl font-extrabold text-center mb-4 tracking-tight">
+      <span class="gradient-text">Design Philosophy</span>
+    </h2>
+    <p class="text-center text-gray-400 mb-20 max-w-2xl mx-auto">
+      rdc-cli is <strong class="text-gray-200">not</strong> a replacement for RenderDoc.
+      It turns <code class="text-gpu-accent">.rdc</code> capture data into pipe-friendly text streams
+      that integrate with Unix tools, CI systems, and AI agents.
+    </p>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+      <div class="glass-card p-7">
+        <div class="flex items-start gap-4">
+          <div class="font-mono font-bold text-2xl text-gpu-green shrink-0 w-10 h-10 flex items-center justify-center rounded-lg" style="background: rgba(0,230,118,0.15); text-shadow: 0 0 20px currentColor;">
+            &gt;
+          </div>
+          <div>
+            <h3 class="text-lg font-bold text-gray-100 mb-2">TSV by Default</h3>
+            <p class="text-sm text-gray-400 leading-relaxed">
+              Every command outputs tab-separated values. Pipe through
+              <code>grep</code>, <code>awk</code>, <code>cut</code>, <code>sort</code> &mdash;
+              standard Unix tools just work. Add <code>--json</code> for structured output.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="glass-card p-7">
+        <div class="flex items-start gap-4">
+          <div class="font-mono font-bold text-2xl text-gpu-orange shrink-0 w-10 h-10 flex items-center justify-center rounded-lg" style="background: rgba(255,145,0,0.15); text-shadow: 0 0 20px currentColor;">
+            2
+          </div>
+          <div>
+            <h3 class="text-lg font-bold text-gray-100 mb-2">Two-Layer Architecture</h3>
+            <p class="text-sm text-gray-400 leading-relaxed">
+              A background daemon holds the capture open. CLI commands send JSON-RPC
+              queries over TCP. Load once, query many &mdash; no per-command startup cost.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="glass-card p-7">
+        <div class="flex items-start gap-4">
+          <div class="font-mono font-bold text-2xl text-red-400 shrink-0 w-10 h-10 flex items-center justify-center rounded-lg" style="background: rgba(248,113,113,0.15); text-shadow: 0 0 20px currentColor;">
+            !
+          </div>
+          <div>
+            <h3 class="text-lg font-bold text-gray-100 mb-2">Stderr for Metadata</h3>
+            <p class="text-sm text-gray-400 leading-relaxed">
+              Data goes to stdout, diagnostics to stderr. Pipes never break because
+              of progress messages or warnings. Exit codes follow Unix convention:
+              0 success, 1 failure, 2 error.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="glass-card p-7">
+        <div class="flex items-start gap-4">
+          <div class="font-mono font-bold text-2xl text-gpu-purple shrink-0 w-10 h-10 flex items-center justify-center rounded-lg" style="background: rgba(179,136,255,0.15); text-shadow: 0 0 20px currentColor;">
+            /
+          </div>
+          <div>
+            <h3 class="text-lg font-bold text-gray-100 mb-2">Stable VFS Paths</h3>
+            <p class="text-sm text-gray-400 leading-relaxed">
+              Every piece of capture data has a stable path like
+              <code>/draws/142/shader/ps</code>. Paths are deterministic across
+              sessions &mdash; safe for scripts and agents.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/docs-astro/src/layouts/Docs.astro
+++ b/docs-astro/src/layouts/Docs.astro
@@ -15,9 +15,11 @@ const currentPath = Astro.url.pathname.replace(/\/$/, '');
 const sidebar = [
   { label: 'Overview', href: `${base}docs/` },
   { label: 'Installation', href: `${base}docs/install/` },
-  { label: 'Usage', href: `${base}docs/usage/` },
+  { label: 'Usage Patterns', href: `${base}docs/usage/` },
   { label: 'Commands', href: `${base}docs/commands/` },
   { label: 'VFS Paths', href: `${base}docs/vfs/` },
+  { label: 'AI Agent Integration', href: `${base}docs/ai-integration/` },
+  { label: 'Examples', href: `${base}docs/examples/` },
 ];
 ---
 

--- a/docs-astro/src/pages/docs/ai-integration.astro
+++ b/docs-astro/src/pages/docs/ai-integration.astro
@@ -1,0 +1,116 @@
+---
+import Docs from '../../layouts/Docs.astro';
+
+const base = import.meta.env.BASE_URL;
+---
+
+<Docs title="AI Agent Integration">
+  <p>
+    rdc-cli is designed from the ground up for AI agent consumption &mdash;
+    not just human users. Every command outputs machine-parseable TSV or JSON,
+    and the VFS path system lets agents explore captures without memorizing
+    command arguments.
+  </p>
+
+  <h2 id="claude-code-skill">Claude Code Skill</h2>
+
+  <p>
+    rdc-cli ships with a built-in Claude Code skill. After installing, Claude Code
+    auto-discovers rdc-cli commands and can open, inspect, and debug GPU captures
+    on your behalf.
+  </p>
+
+  <pre><code>rdc install-skill</code></pre>
+
+  <p>
+    This copies skill definition files to <code>~/.claude/skills/rdc-cli/</code>.
+    Once installed, Claude Code recognizes trigger phrases like:
+  </p>
+
+  <ul>
+    <li><em>"open capture"</em>, <em>".rdc"</em>, <em>"renderdoc"</em></li>
+    <li><em>"shader debug"</em>, <em>"pixel trace"</em></li>
+    <li><em>"GPU state"</em>, <em>"draw calls"</em>, <em>"pipeline"</em></li>
+  </ul>
+
+  <h2 id="agent-friendly-design">Agent-Friendly Design</h2>
+
+  <h3>VFS Path Navigation</h3>
+  <p>
+    The virtual filesystem lets agents explore capture structure iteratively.
+    Start broad with <code>rdc ls /</code> and drill down into specific draws,
+    shaders, and state &mdash; no need to know the exact command for each query.
+  </p>
+
+  <h3>Machine-Parseable Output</h3>
+  <p>
+    TSV output works with standard Unix tools. <code>--json</code> output works
+    with <code>jq</code> and any JSON parser. Metadata goes to stderr so stdout
+    is always clean data.
+  </p>
+
+  <h3>Stable Paths</h3>
+  <p>
+    Every piece of data has a deterministic path like
+    <code>/draws/142/shader/ps</code>. Paths are stable across
+    sessions, so agents can build reliable scripts.
+  </p>
+
+  <h2 id="recommended-workflow">Recommended Agent Workflow</h2>
+
+  <p>A typical agent session follows this pattern:</p>
+
+  <pre><code># Open the capture
+rdc open capture.rdc
+
+# Discover structure
+rdc ls /
+
+# Find draw calls
+rdc draws
+
+# Explore a specific draw
+rdc ls /draws/142/
+
+# Read shader source
+rdc cat /draws/142/shader/ps
+
+# Check constant buffer values
+rdc shader 142 ps --constants
+
+# Done
+rdc close</code></pre>
+
+  <h2 id="system-prompt">System Prompt Snippet</h2>
+
+  <p>
+    If you are building a custom AI agent that uses rdc-cli, include this
+    context in your system prompt:
+  </p>
+
+  <pre><code>You have access to rdc-cli, a Unix CLI for RenderDoc .rdc captures.
+
+Key commands:
+- rdc open &lt;file.rdc&gt;   Open a capture (starts daemon)
+- rdc ls [PATH]          Browse capture via VFS paths
+- rdc cat &lt;PATH&gt;         Read VFS leaf content
+- rdc draws              List draw calls
+- rdc pipeline &lt;EID&gt;     Show GPU pipeline state
+- rdc shader &lt;EID&gt; &lt;STAGE&gt; --source   Read shader code
+- rdc debug pixel &lt;EID&gt; &lt;X&gt; &lt;Y&gt;      Debug pixel shader
+- rdc close              Close session
+
+All commands support --json for structured output.
+VFS root: / (explore with ls, drill down with cat)
+Paths: /draws/&lt;EID&gt;/, /resources/&lt;ID&gt;/, /passes/&lt;N&gt;/</code></pre>
+
+  <h2 id="tips">Tips for Agent Developers</h2>
+
+  <ul>
+    <li>Always use <code>--json</code> when parsing output programmatically</li>
+    <li>Use <code>rdc count draws</code> to get counts without parsing lists</li>
+    <li>Check <code>rdc status</code> before commands to verify a session is open</li>
+    <li>Use <code>rdc doctor</code> to verify the environment is configured correctly</li>
+    <li>The <code>rdc script</code> command runs arbitrary Python inside the daemon for advanced queries</li>
+  </ul>
+</Docs>

--- a/docs-astro/src/pages/docs/commands.astro
+++ b/docs-astro/src/pages/docs/commands.astro
@@ -5,28 +5,37 @@ import Docs from '../../layouts/Docs.astro';
 <Docs title="Command Reference">
   <p>
     All commands support <code>--json</code> for machine-readable output and
-    <code>--help</code> for detailed usage. This reference is auto-generated
-    from <code>rdc --help</code>.
+    <code>--help</code> for detailed usage. TSV is the default output format.
   </p>
 
+  <!-- Session -->
   <h2 id="session">Session</h2>
 
   <h3 id="open">open</h3>
-  <p>Open a <code>.rdc</code> capture file and start a daemon session.</p>
-  <pre><code>rdc open capture.rdc [--port PORT]</code></pre>
+  <p>Create local default session and start daemon skeleton.</p>
+  <pre><code>rdc open &lt;capture.rdc&gt; [--port PORT]</code></pre>
 
   <h3 id="close">close</h3>
-  <p>Close the current session and stop the daemon.</p>
+  <p>Close daemon-backed session.</p>
   <pre><code>rdc close</code></pre>
 
   <h3 id="status">status</h3>
-  <p>Show the current session status (daemon PID, capture path, port).</p>
+  <p>Show current daemon-backed session status.</p>
   <pre><code>rdc status</code></pre>
 
   <h3 id="goto">goto</h3>
-  <p>Navigate to a specific event ID in the capture.</p>
-  <pre><code>rdc goto &lt;eid&gt;</code></pre>
+  <p>Update current event id via daemon.</p>
+  <pre><code>rdc goto &lt;EID&gt;</code></pre>
 
+  <h3 id="capture">capture</h3>
+  <p>Thin wrapper around <code>renderdoccmd capture</code>.</p>
+  <pre><code>rdc capture &lt;executable&gt; [args...]</code></pre>
+
+  <h3 id="doctor">doctor</h3>
+  <p>Run environment checks for rdc-cli.</p>
+  <pre><code>rdc doctor</code></pre>
+
+  <!-- Inspection -->
   <h2 id="inspection">Inspection</h2>
 
   <h3 id="info">info</h3>
@@ -34,7 +43,7 @@ import Docs from '../../layouts/Docs.astro';
   <pre><code>rdc info</code></pre>
 
   <h3 id="stats">stats</h3>
-  <p>Show summary statistics for the capture.</p>
+  <p>Show per-pass breakdown, top draws, largest resources.</p>
   <pre><code>rdc stats</code></pre>
 
   <h3 id="events">events</h3>
@@ -42,118 +51,217 @@ import Docs from '../../layouts/Docs.astro';
   <pre><code>rdc events [--type TYPE]</code></pre>
 
   <h3 id="draws">draws</h3>
-  <p>List draw calls, with optional filtering by pass or flags.</p>
-  <pre><code>rdc draws [--pass PASS] [--flags FLAGS]</code></pre>
+  <p>List draw calls, with optional filtering and sorting.</p>
+  <pre><code>rdc draws [--pass PASS] [--sort FIELD] [--limit N]</code></pre>
 
   <h3 id="event">event</h3>
-  <p>Show details for a single event.</p>
-  <pre><code>rdc event &lt;eid&gt;</code></pre>
+  <p>Show single API call detail.</p>
+  <pre><code>rdc event &lt;EID&gt;</code></pre>
 
   <h3 id="draw">draw</h3>
-  <p>Show details for a single draw call.</p>
-  <pre><code>rdc draw &lt;eid&gt;</code></pre>
+  <p>Show draw call detail.</p>
+  <pre><code>rdc draw &lt;EID&gt;</code></pre>
 
   <h3 id="log">log</h3>
-  <p>Show the capture's debug log messages.</p>
-  <pre><code>rdc log</code></pre>
+  <p>Show debug/validation messages from the capture.</p>
+  <pre><code>rdc log [--level LEVEL]</code></pre>
 
-  <h2 id="gpu-state">GPU State</h2>
+  <h3 id="counters">counters</h3>
+  <p>Query GPU performance counters.</p>
+  <pre><code>rdc counters [--list] [--ids ID,...] [--eid EID]</code></pre>
+
+  <!-- Draw Analysis -->
+  <h2 id="draw-analysis">Draw Analysis</h2>
 
   <h3 id="pipeline">pipeline</h3>
-  <p>Show the full pipeline state at a given event.</p>
-  <pre><code>rdc pipeline &lt;eid&gt; [--section SECTION]</code></pre>
+  <p>Show pipeline summary for current or specified EID.</p>
+  <pre><code>rdc pipeline &lt;EID&gt; [SECTION]</code></pre>
 
   <h3 id="bindings">bindings</h3>
-  <p>Show resource bindings at a given event.</p>
-  <pre><code>rdc bindings &lt;eid&gt; [--set SET]</code></pre>
+  <p>Show bound resources per shader stage.</p>
+  <pre><code>rdc bindings &lt;EID&gt; [--stage STAGE]</code></pre>
 
-  <h3 id="shader">shader</h3>
-  <p>Disassemble a shader at a given event and stage.</p>
-  <pre><code>rdc shader &lt;eid&gt; &lt;stage&gt; [--target TARGET]</code></pre>
+  <!-- Resources -->
+  <h2 id="resources-section">Resources</h2>
 
-  <h3 id="shaders">shaders</h3>
-  <p>List all shaders bound at a given event.</p>
-  <pre><code>rdc shaders &lt;eid&gt;</code></pre>
-
-  <h3 id="shader-map">shader-map</h3>
-  <p>Show the shader map across all draw calls.</p>
-  <pre><code>rdc shader-map</code></pre>
-
-  <h2 id="resources">Resources</h2>
-
-  <h3 id="resources-cmd">resources</h3>
+  <h3 id="resources">resources</h3>
   <p>List all resources in the capture.</p>
   <pre><code>rdc resources [--type TYPE] [--name NAME] [--sort FIELD]</code></pre>
 
   <h3 id="resource">resource</h3>
-  <p>Show details for a single resource.</p>
-  <pre><code>rdc resource &lt;id&gt;</code></pre>
+  <p>Show details of a specific resource.</p>
+  <pre><code>rdc resource &lt;ID&gt;</code></pre>
+
+  <h3 id="usage">usage</h3>
+  <p>Show resource usage (which events read/write a resource).</p>
+  <pre><code>rdc usage &lt;ID&gt;</code></pre>
+
+  <h3 id="shader">shader</h3>
+  <p>Show shader metadata for a stage at EID (<code>--reflect</code>, <code>--constants</code>, <code>--source</code>, <code>--target</code>, <code>--all</code>).</p>
+  <pre><code>rdc shader &lt;EID&gt; &lt;STAGE&gt; [--reflect] [--constants] [--source] [--target TARGET] [-o FILE]</code></pre>
+
+  <h3 id="shaders">shaders</h3>
+  <p>List unique shaders in capture.</p>
+  <pre><code>rdc shaders</code></pre>
+
+  <h3 id="shader-map">shader-map</h3>
+  <p>Output EID-to-shader mapping as TSV.</p>
+  <pre><code>rdc shader-map</code></pre>
+
+  <h3 id="search">search</h3>
+  <p>Search shader disassembly text for PATTERN (regex).</p>
+  <pre><code>rdc search &lt;PATTERN&gt;</code></pre>
 
   <h3 id="passes">passes</h3>
   <p>List render passes.</p>
   <pre><code>rdc passes</code></pre>
 
   <h3 id="pass">pass</h3>
-  <p>Show details for a single render pass.</p>
-  <pre><code>rdc pass &lt;id&gt;</code></pre>
+  <p>Show detail for a single render pass by index or name.</p>
+  <pre><code>rdc pass &lt;INDEX|NAME&gt;</code></pre>
 
-  <h3 id="usage">usage</h3>
-  <p>Show usage of a resource across the frame.</p>
-  <pre><code>rdc usage &lt;id&gt; [--all]</code></pre>
-
+  <!-- Export -->
   <h2 id="export">Export</h2>
 
   <h3 id="texture">texture</h3>
-  <p>Export a texture to PNG/EXR.</p>
-  <pre><code>rdc texture &lt;id&gt; [-o OUTPUT]</code></pre>
-
-  <h3 id="rt">rt</h3>
-  <p>Export render targets at a given event.</p>
-  <pre><code>rdc rt &lt;eid&gt; [-o OUTPUT]</code></pre>
+  <p>Export texture as PNG.</p>
+  <pre><code>rdc texture &lt;ID&gt; [-o OUTPUT]</code></pre>
 
   <h3 id="buffer">buffer</h3>
-  <p>Export buffer data.</p>
-  <pre><code>rdc buffer &lt;id&gt; [-o OUTPUT] [--format FORMAT]</code></pre>
+  <p>Export buffer raw data.</p>
+  <pre><code>rdc buffer &lt;ID&gt; [-o OUTPUT]</code></pre>
 
-  <h2 id="search-section">Search</h2>
+  <h3 id="rt">rt</h3>
+  <p>Export render target as PNG (supports <code>--overlay wireframe|depth|stencil|overdraw</code>).</p>
+  <pre><code>rdc rt &lt;EID&gt; [-o OUTPUT] [--overlay TYPE]</code></pre>
 
-  <h3 id="search">search</h3>
-  <p>Search for strings in draw calls, shaders, or resources.</p>
-  <pre><code>rdc search &lt;query&gt; [--scope SCOPE]</code></pre>
+  <h3 id="mesh">mesh</h3>
+  <p>Export post-transform mesh as OBJ.</p>
+  <pre><code>rdc mesh &lt;EID&gt; [-o OUTPUT]</code></pre>
 
-  <h3 id="counters">counters</h3>
-  <p>Fetch or list GPU hardware performance counters.</p>
-  <pre><code>rdc counters [--list]</code></pre>
+  <h3 id="snapshot">snapshot</h3>
+  <p>Export a complete rendering state snapshot for a draw event.</p>
+  <pre><code>rdc snapshot &lt;EID&gt; [-o DIR]</code></pre>
 
-  <h2 id="vfs">VFS</h2>
+  <!-- Pixel & Debug -->
+  <h2 id="pixel-debug">Pixel &amp; Debug</h2>
+
+  <h3 id="pixel">pixel</h3>
+  <p>Query pixel history at (X, Y) for the current or specified event.</p>
+  <pre><code>rdc pixel &lt;EID&gt; &lt;X&gt; &lt;Y&gt;</code></pre>
+
+  <h3 id="pick-pixel">pick-pixel</h3>
+  <p>Read pixel color at (X, Y) from the current render target.</p>
+  <pre><code>rdc pick-pixel &lt;EID&gt; &lt;X&gt; &lt;Y&gt;</code></pre>
+
+  <h3 id="tex-stats">tex-stats</h3>
+  <p>Show texture min/max statistics and optional histogram.</p>
+  <pre><code>rdc tex-stats &lt;EID&gt; [--histogram]</code></pre>
+
+  <h3 id="debug-pixel">debug pixel</h3>
+  <p>Debug pixel shader at (X, Y) for event EID.</p>
+  <pre><code>rdc debug pixel &lt;EID&gt; &lt;X&gt; &lt;Y&gt; [--trace] [--dump-at LINE]</code></pre>
+
+  <h3 id="debug-vertex">debug vertex</h3>
+  <p>Debug vertex shader for vertex VTX_ID at event EID.</p>
+  <pre><code>rdc debug vertex &lt;EID&gt; &lt;VTX_ID&gt; [--trace] [--dump-at LINE]</code></pre>
+
+  <h3 id="debug-thread">debug thread</h3>
+  <p>Debug compute shader thread at workgroup (GX,GY,GZ) thread (TX,TY,TZ).</p>
+  <pre><code>rdc debug thread &lt;EID&gt; &lt;GX&gt; &lt;GY&gt; &lt;GZ&gt; &lt;TX&gt; &lt;TY&gt; &lt;TZ&gt; [--trace] [--dump-at LINE]</code></pre>
+
+  <!-- Shader Edit-Replay -->
+  <h2 id="shader-edit-replay">Shader Edit-Replay</h2>
+
+  <h3 id="shader-encodings">shader-encodings</h3>
+  <p>List available shader encodings for this capture.</p>
+  <pre><code>rdc shader-encodings</code></pre>
+
+  <h3 id="shader-build">shader-build</h3>
+  <p>Build a shader from source file (GLSL only).</p>
+  <pre><code>rdc shader-build &lt;FILE&gt; --stage &lt;STAGE&gt; [--entry ENTRY]</code></pre>
+
+  <h3 id="shader-replace">shader-replace</h3>
+  <p>Replace shader at EID/STAGE with a built shader.</p>
+  <pre><code>rdc shader-replace &lt;EID&gt; &lt;STAGE&gt; --with &lt;SHADER_ID&gt;</code></pre>
+
+  <h3 id="shader-restore">shader-restore</h3>
+  <p>Restore original shader at EID/STAGE.</p>
+  <pre><code>rdc shader-restore &lt;EID&gt; &lt;STAGE&gt;</code></pre>
+
+  <h3 id="shader-restore-all">shader-restore-all</h3>
+  <p>Restore all replaced shaders and free built resources.</p>
+  <pre><code>rdc shader-restore-all</code></pre>
+
+  <!-- CI Assertions -->
+  <h2 id="ci-assertions">CI Assertions</h2>
+
+  <h3 id="assert-pixel">assert-pixel</h3>
+  <p>Assert pixel RGBA at (x, y) matches expected value within tolerance.</p>
+  <pre><code>rdc assert-pixel &lt;EID&gt; &lt;X&gt; &lt;Y&gt; --expect "&lt;R G B A&gt;" [--tolerance T]</code></pre>
+
+  <h3 id="assert-image">assert-image</h3>
+  <p>Compare two images pixel-by-pixel.</p>
+  <pre><code>rdc assert-image &lt;EXPECTED&gt; &lt;ACTUAL&gt; [--threshold T]</code></pre>
+
+  <h3 id="assert-clean">assert-clean</h3>
+  <p>Assert capture log has no messages at or above given severity.</p>
+  <pre><code>rdc assert-clean [--min-severity LEVEL]</code></pre>
+
+  <h3 id="assert-count">assert-count</h3>
+  <p>Assert a capture metric satisfies a numeric comparison.</p>
+  <pre><code>rdc assert-count &lt;WHAT&gt; --expect &lt;N&gt; --op &lt;eq|lt|le|gt|ge&gt;</code></pre>
+
+  <h3 id="assert-state">assert-state</h3>
+  <p>Assert pipeline state value at EID matches expected.</p>
+  <pre><code>rdc assert-state &lt;EID&gt; &lt;PATH&gt; --expect &lt;VALUE&gt;</code></pre>
+
+  <!-- Capture Diff -->
+  <h2 id="capture-diff">Capture Diff</h2>
+
+  <h3 id="diff">diff</h3>
+  <p>Compare two RenderDoc captures side-by-side. Supports multiple diff modes.</p>
+  <pre><code>rdc diff &lt;FILE_A&gt; &lt;FILE_B&gt; [MODE]
+
+Modes:
+  --draws          Compare draw call lists
+  --resources      Compare resource lists
+  --passes         Compare render passes
+  --stats          Compare per-pass statistics
+  --framebuffer    Pixel-level framebuffer diff
+  --pipeline       Compare pipeline states at matching EIDs</code></pre>
+
+  <!-- VFS Navigation -->
+  <h2 id="vfs">VFS Navigation</h2>
 
   <h3 id="ls">ls</h3>
-  <p>List nodes at a VFS path.</p>
+  <p>List VFS directory contents.</p>
   <pre><code>rdc ls [PATH]</code></pre>
 
   <h3 id="cat">cat</h3>
-  <p>Read the content of a VFS leaf node.</p>
-  <pre><code>rdc cat &lt;path&gt;</code></pre>
+  <p>Output VFS leaf node content.</p>
+  <pre><code>rdc cat &lt;PATH&gt;</code></pre>
 
   <h3 id="tree">tree</h3>
-  <p>Show a tree view of the VFS hierarchy.</p>
+  <p>Display VFS subtree structure.</p>
   <pre><code>rdc tree [PATH] [--depth DEPTH]</code></pre>
 
-  <h2 id="utility">Utility</h2>
-
-  <h3 id="doctor">doctor</h3>
-  <p>Check system configuration and renderdoc module availability.</p>
-  <pre><code>rdc doctor</code></pre>
-
-  <h3 id="completion">completion</h3>
-  <p>Generate shell completions for bash, zsh, or fish.</p>
-  <pre><code>rdc completion &lt;shell&gt;</code></pre>
-
-  <h3 id="capture">capture</h3>
-  <p>Capture a new frame from a running application.</p>
-  <pre><code>rdc capture &lt;executable&gt; [args...]</code></pre>
+  <!-- Utilities -->
+  <h2 id="utilities">Utilities</h2>
 
   <h3 id="count">count</h3>
-  <p>Show count of events, draws, resources, or passes.</p>
-  <pre><code>rdc count [--type TYPE]</code></pre>
+  <p>Output a single integer count to stdout.</p>
+  <pre><code>rdc count &lt;WHAT&gt;</code></pre>
+
+  <h3 id="completion">completion</h3>
+  <p>Generate shell completion script.</p>
+  <pre><code>rdc completion &lt;bash|zsh|fish&gt;</code></pre>
+
+  <h3 id="script">script</h3>
+  <p>Execute a Python script inside the daemon process.</p>
+  <pre><code>rdc script &lt;FILE&gt; [-- ARGS...]</code></pre>
+
+  <h3 id="install-skill">install-skill</h3>
+  <p>Install rdc-cli skill files to <code>~/.claude/skills/rdc-cli/</code>.</p>
+  <pre><code>rdc install-skill</code></pre>
 </Docs>

--- a/docs-astro/src/pages/docs/examples.astro
+++ b/docs-astro/src/pages/docs/examples.astro
@@ -1,0 +1,115 @@
+---
+import Docs from '../../layouts/Docs.astro';
+
+const shellPipelines = `# Find all draws using a specific shader
+rdc shader-map | grep "HASH_PREFIX" | cut -f1
+
+# Export all textures
+for id in $(rdc resources --type texture -q); do
+  rdc texture "$id" -o "tex_\${id}.png"
+done
+
+# Count triangles per pass
+rdc draws --json | jq 'group_by(.pass) | .[] | {pass: .[0].pass, tris: [.[].tri_count] | add}'`;
+---
+
+<Docs title="Examples">
+  <p>
+    Real-world workflow recipes for common rdc-cli tasks. Each example
+    assumes a daemon session is running (<code>rdc open capture.rdc</code>).
+  </p>
+
+  <h2 id="basic-analysis">Basic Capture Analysis</h2>
+
+  <pre><code>rdc open scene.rdc
+rdc info                        # API, GPU, driver
+rdc stats                       # per-pass breakdown
+rdc draws --limit 10            # top draw calls
+rdc close</code></pre>
+
+  <h2 id="heaviest-draw">Find the Heaviest Draw Call</h2>
+
+  <pre><code>{"# TSV approach"}
+rdc draws --sort tri_count | tail -1
+
+{"# JSON approach"}
+rdc draws --json | jq 'sort_by(.tri_count) | last'</code></pre>
+
+  <h2 id="debug-pixel">Debug a Pixel Color</h2>
+
+  <pre><code>{"# Quick result"}
+rdc debug pixel 142 400 300
+
+{"# Full step-by-step trace"}
+rdc debug pixel 142 400 300 --trace
+
+{"# Dump variables at a specific source line"}
+rdc debug pixel 142 400 300 --dump-at 15</code></pre>
+
+  <h2 id="ci-assertions">CI/CD Pipeline Assertions</h2>
+
+  <pre><code>{"#!/bin/bash"}
+set -e
+rdc open test_capture.rdc
+
+{"# No validation errors"}
+rdc assert-clean
+
+{"# At least 12 draw calls"}
+rdc assert-count draws --expect 12 --op ge
+
+{"# Verify pixel color at coordinates"}
+rdc assert-pixel 142 256 256 --expect "1.0 0.0 0.0 1.0"
+
+{"# Visual regression test"}
+rdc assert-image expected.png actual.png --threshold 1.0
+
+rdc close</code></pre>
+
+  <h2 id="comparing-captures">Comparing Two Captures</h2>
+
+  <pre><code>{"# Overall summary"}
+rdc diff before.rdc after.rdc
+
+{"# Draw call changes"}
+rdc diff before.rdc after.rdc --draws
+
+{"# Pixel-level framebuffer diff"}
+rdc diff before.rdc after.rdc --framebuffer
+
+{"# Per-pass statistics diff"}
+rdc diff before.rdc after.rdc --stats</code></pre>
+
+  <h2 id="shader-hot-reload">Shader Hot-Reload</h2>
+
+  <pre><code>{"# Extract current shader"}
+rdc shader 142 ps --source -o original.frag
+
+{"# ... edit original.frag in your editor ..."}
+
+{"# Compile the modified shader (returns shader_id)"}
+rdc shader-build original.frag --stage ps
+
+{"# Hot-swap the shader in the capture"}
+rdc shader-replace 142 ps --with 1
+
+{"# Check the visual result"}
+rdc rt 142 -o modified.png
+
+{"# Revert all changes"}
+rdc shader-restore-all</code></pre>
+
+  <h2 id="export-offline">Export Everything for Offline Analysis</h2>
+
+  <pre><code>{"# Complete snapshot: pipeline + shaders + render target"}
+rdc snapshot 142 -o ./snapshot/
+
+{"# Individual exports"}
+rdc texture 5 -o albedo.png             {"# specific texture"}
+rdc buffer 3 -o vertex_data.bin         {"# raw buffer data"}
+rdc mesh 142 -o geometry.obj            {"# post-transform mesh"}</code></pre>
+
+  <h2 id="shell-pipelines">Shell Pipeline Power</h2>
+
+  <pre><code set:text={shellPipelines}></code></pre>
+</Docs>

--- a/docs-astro/src/pages/docs/index.astro
+++ b/docs-astro/src/pages/docs/index.astro
@@ -47,7 +47,7 @@ rdc close</code></pre>
     rdc-cli exposes capture data through a virtual filesystem. You can browse
     it with <code>rdc ls</code>, <code>rdc cat</code>, and <code>rdc tree</code>.
     Every piece of data has a stable path like
-    <code>/draws/142/pipeline/shader/ps</code>.
+    <code>/draws/142/shader/ps</code>.
   </p>
 
   <h2>Sections</h2>
@@ -57,5 +57,7 @@ rdc close</code></pre>
     <li><a href={`${base}docs/usage/`}>Usage Patterns</a> — common workflows and examples</li>
     <li><a href={`${base}docs/commands/`}>Command Reference</a> — all {stats.command_count} commands</li>
     <li><a href={`${base}docs/vfs/`}>VFS Paths</a> — virtual filesystem namespace</li>
+    <li><a href={`${base}docs/ai-integration/`}>AI Agent Integration</a> — Claude Code skill, agent-friendly design</li>
+    <li><a href={`${base}docs/examples/`}>Examples</a> — real-world workflow recipes</li>
   </ul>
 </Docs>

--- a/docs-astro/src/pages/index.astro
+++ b/docs-astro/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Base from '../layouts/Base.astro';
 import Navbar from '../components/Navbar.astro';
 import Hero from '../components/Hero.astro';
+import Philosophy from '../components/Philosophy.astro';
 import Features from '../components/Features.astro';
 import Demo from '../components/Demo.astro';
 import Commands from '../components/Commands.astro';
@@ -13,6 +14,7 @@ import Footer from '../components/Footer.astro';
   <Navbar />
   <main>
     <Hero />
+    <Philosophy />
     <Features />
     <Demo />
     <Commands />

--- a/docs-astro/tests/validate.mjs
+++ b/docs-astro/tests/validate.mjs
@@ -55,6 +55,8 @@ const expectedPages = [
   'docs/usage/index.html',
   'docs/commands/index.html',
   'docs/vfs/index.html',
+  'docs/ai-integration/index.html',
+  'docs/examples/index.html',
 ];
 
 for (const page of expectedPages) {
@@ -151,8 +153,8 @@ test('landing page has dynamic command count from stats.json', () => {
   assert(indexHtml.includes(count), `Missing "${count}" commands count (from stats.json)`);
 });
 
-test('landing page has all 8 command categories', () => {
-  const categories = ['Session', 'Inspection', 'GPU State', 'Resources', 'Export', 'Search', 'VFS', 'Utility'];
+test('landing page has all 12 command categories', () => {
+  const categories = ['Session', 'Inspection', 'GPU State', 'Debug', 'Shader Edit', 'Resources', 'Export', 'Assertions', 'Diff', 'Search', 'VFS', 'Utility'];
   for (const cat of categories) {
     assert(indexHtml.includes(cat), `Missing command category: ${cat}`);
   }


### PR DESCRIPTION
## Summary

- Add Philosophy section to landing page explaining rdc-cli design principles
- Expand homepage command grid from 8 to 12 categories (Debug, Shader Edit, Assertions, Diff)
- Add CI Assertions and AI Agent Ready feature cards
- Rewrite command reference with all 51 commands in 11 categories
- Create AI Agent Integration page (Claude Code skill install, agent workflow, system prompt)
- Create Examples page with 8 real-world workflow recipes
- Update sidebar navigation (7 items) and navbar links
- Fix incorrect CLI syntax in docs (count, log, pipeline, assert-clean, assert-count)
- Fix invalid VFS path `/draws/142/pipeline/shader/ps` across 3 files
- Add new pages to validation test suite (308 tests passing)

## Test plan

- [x] `npm run build` succeeds (8 pages generated)
- [x] `npm run test:only` passes (308 validation tests)
- [x] `pixi run check` passes (1736 unit tests, 95.53% coverage)
- [x] E2E tests pass (26/26)
- [x] Manual verification with `npx astro dev`
- [ ] Review landing page layout and navigation
- [ ] Verify new pages render correctly (AI Integration, Examples)
- [ ] Check dark/light mode on all pages