### PR TITLE
fix(ci): only merge mkdocs cli-reference into Astro output

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,10 +78,10 @@ jobs:
           npm ci
           npm run build
 
-      - name: Merge mkdocs into Astro output
+      - name: Merge mkdocs CLI reference into Astro output
         run: |
-          mkdir -p docs-astro/dist/docs
-          cp -r _site/* docs-astro/dist/docs/
+          mkdir -p docs-astro/dist/docs/cli-reference
+          cp -r _site/cli-reference/* docs-astro/dist/docs/cli-reference/
 
       - name: Generate badge endpoint JSONs
         run: |


### PR DESCRIPTION
## Summary

- Fix docs deployment where mkdocs-generated pages (usage, vfs, index, etc.) overwrite Astro pages
- Change merge step to only copy `cli-reference/` from mkdocs output, which is the sole mkdocs-click auto-generated page
- All other doc pages are now exclusively managed by Astro

## Root cause

The `cp -r _site/* docs-astro/dist/docs/` step copied **all** mkdocs output into the Astro dist directory. Since `docs/` still contained old `.md` files (usage.md, vfs.md, index.md, etc.), mkdocs compiled them into HTML that overwrote the Astro-generated pages, causing navigation to jump to the mkdocs-styled versions.

## Test plan

- [x] `pixi run check` passes (1736 tests)
- [x] E2E passes (26/26)
- [ ] Trigger docs workflow and verify all pages use Astro layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation build workflow to ensure CLI reference documentation is correctly integrated into the Astro output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->