### PR TITLE
docs(readme): rewrite README + fix CI badge stats

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,9 +90,9 @@ jobs:
           import json, pathlib
           s = json.loads(pathlib.Path('docs-astro/src/data/stats.json').read_text())
           badges = [
-              ('commands', str(s.get('command_count', '')), 'brightgreen'),
-              ('tests',    str(s.get('test_count', '')),    'blue'),
-              ('coverage', s.get('coverage', ''),           'green'),
+              ('commands', str(s.get('command_count', '?')), 'brightgreen'),
+              ('tests',    str(s.get('test_count', 0) or '?'), 'blue'),
+              ('coverage', s.get('coverage', '') or '?',       'green'),
           ]
           for name, message, color in badges:
               pathlib.Path(f'docs-astro/dist/badges/{name}.json').write_text(


### PR DESCRIPTION
## Summary
- Rewrite README with "Why rdc-cli?" philosophy section, categorized examples, and accurate CLI reference
- Fix docs workflow badge generation: `uv sync` → `uv sync --extra dev` (pytest was missing)
- Fix pytest 9.x collection output grep: `--co -q` no longer emits summary line

Root cause of broken badges: pytest was never installed in the docs CI (dev-only dep), and `2>/dev/null` silenced the failure → tests=0, coverage="".

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Trigger `workflow_dispatch` after merge and verify badges show correct stats
- [ ] Confirm all three custom badges render (commands, tests, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)