### PR TITLE
fix(debug): guard trace attrs with getattr for SWIG compat

### DIFF
--- a/src/rdc/handlers/debug.py
+++ b/src/rdc/handlers/debug.py
@@ -52,13 +52,15 @@ def _format_step(state_obj: Any, trace: Any) -> dict[str, Any]:
     inst = state_obj.nextInstruction
     file_name = ""
     line_num = -1
-    if trace.instInfo and inst < len(trace.instInfo):
-        info = trace.instInfo[inst]
+    inst_info = getattr(trace, "instInfo", None)
+    source_files = getattr(trace, "sourceFiles", None)
+    if inst_info and inst < len(inst_info):
+        info = inst_info[inst]
         li = info.lineInfo
         line_num = li.lineStart
         fi = li.fileIndex
-        if trace.sourceFiles and 0 <= fi < len(trace.sourceFiles):
-            file_name = trace.sourceFiles[fi].filename
+        if source_files and 0 <= fi < len(source_files):
+            file_name = source_files[fi].filename
 
     changes: list[dict[str, Any]] = []
     for ch in state_obj.changes:


### PR DESCRIPTION
## Summary
- Fix `debug thread` AttributeError when `ShaderDebugTrace` lacks `sourceFiles`/`instInfo` attributes on real RenderDoc v1.41 SWIG wrapper
- Use `getattr(trace, "instInfo", None)` and `getattr(trace, "sourceFiles", None)` instead of bare attribute access
- Add test for trace objects missing these attributes

Blackbox test report: Bug 10 (P1)

## Test plan
- [x] `pixi run lint && pixi run test` — 1737 tests, 95.53% coverage
- [x] Pre-push e2e: 26/26 passed
- [ ] GPU manual test: `rdc open compute_nbody.rdc && rdc debug thread 8 0 0 0 0 0 0`