### PR TITLE
fix(pixel): add bounds validation for pick-pixel and pixel-history

### DIFF
--- a/src/rdc/handlers/pixel.py
+++ b/src/rdc/handlers/pixel.py
@@ -103,6 +103,12 @@ def _handle_pixel_history(
     tex = state.tex_map.get(int(rt_rid))
     if tex is not None and getattr(tex, "msSamp", 1) > 1:
         return _error_response(request_id, -32001, "MSAA pixel history not supported"), True
+    if tex is not None and not (0 <= x < tex.width and 0 <= y < tex.height):
+        return _error_response(
+            request_id,
+            -32001,
+            f"coordinates ({x}, {y}) out of bounds for target [{tex.width}x{tex.height}]",
+        ), True
 
     rd = state.rd
     sub = rd.Subresource() if rd else type("Sub", (), {"sample": 0})()
@@ -166,6 +172,12 @@ def _handle_pick_pixel(
     tex = state.tex_map.get(int(rt_rid))
     if tex is not None and getattr(tex, "msSamp", 1) > 1:
         return _error_response(request_id, -32001, "MSAA pick-pixel not supported"), True
+    if tex is not None and not (0 <= x < tex.width and 0 <= y < tex.height):
+        return _error_response(
+            request_id,
+            -32001,
+            f"coordinates ({x}, {y}) out of bounds for target [{tex.width}x{tex.height}]",
+        ), True
 
     rd = state.rd
     sub = rd.Subresource() if rd else type("Sub", (), {"sample": 0})()


### PR DESCRIPTION
## Summary
- `pick-pixel` and `pixel-history` now validate X/Y coordinates against render target dimensions
- Returns error `-32001` with message like `coordinates (99999, 99999) out of bounds for target [603x653]` instead of silently returning zeros
- Guard is skipped when texture metadata is unavailable (preserves existing behavior)
- Applied to both `_handle_pick_pixel` and `_handle_pixel_history` in `pixel.py`

## Test plan
- [x] 5 new unit tests: out-of-bounds X, out-of-bounds Y, boundary valid, pixel-history OOB, negative coords
- [x] 1 updated test: `test_pick_pixel_unknown_pixel_returns_zero` → now expects error
- [x] 1 GPU integration test: `test_pick_pixel_out_of_bounds_real`
- [x] Manual GPU test: confirmed on hello_triangle.rdc (603x653 RT)
- [x] All 1776 tests pass, 95.50% coverage

Closes edge behavior: `pick-pixel 超大坐标：返回 0,0,0,0 无报错`