### PR TITLE
docs: add design page, expand commands and examples

### DIFF
--- a/docs-astro/src/data/stats.json
+++ b/docs-astro/src/data/stats.json
@@ -1,7 +1,7 @@
 {
-  "command_count": 53,
-  "test_count": 1641,
-  "coverage": "95.79%",
-  "version": "0.2.0",
+  "command_count": 61,
+  "test_count": 1838,
+  "coverage": "95.25%",
+  "version": "0.3.1",
   "description": "Unix-friendly CLI for RenderDoc .rdc captures"
 }

--- a/docs-astro/src/layouts/Docs.astro
+++ b/docs-astro/src/layouts/Docs.astro
@@ -19,6 +19,7 @@ const sidebar = [
   { label: 'Commands', href: `${base}docs/commands/` },
   { label: 'VFS Paths', href: `${base}docs/vfs/` },
   { label: 'AI Agent Integration', href: `${base}docs/ai-integration/` },
+  { label: 'Design', href: `${base}docs/design/` },
   { label: 'Examples', href: `${base}docs/examples/` },
 ];
 ---
@@ -78,6 +79,7 @@ const sidebar = [
         prose-a:text-gpu-accent prose-a:no-underline hover:prose-a:underline
         prose-code:text-gpu-accent prose-code:bg-[#0a1525] prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-none prose-code:after:content-none
         prose-pre:bg-[#060d18] prose-pre:border prose-pre:border-[#1e3050] prose-pre:rounded-xl
+        [&_pre_code]:p-0 [&_pre_code]:bg-transparent
         prose-td:text-gray-400 prose-th:text-gray-300
         prose-strong:text-gray-200
         prose-li:text-gray-400

--- a/docs-astro/src/pages/docs/commands.astro
+++ b/docs-astro/src/pages/docs/commands.astro
@@ -28,8 +28,14 @@ import Docs from '../../layouts/Docs.astro';
   <pre><code>rdc goto &lt;EID&gt;</code></pre>
 
   <h3 id="capture">capture</h3>
-  <p>Thin wrapper around <code>renderdoccmd capture</code>.</p>
-  <pre><code>rdc capture &lt;executable&gt; [args...]</code></pre>
+  <p>Execute an application and capture a GPU frame. Uses the RenderDoc Python API
+    (<code>ExecuteAndInject</code>) when available, falling back to <code>renderdoccmd</code>.</p>
+  <pre><code>rdc capture &lt;executable&gt; [args...] [-o OUTPUT]
+  [--frame N] [--trigger] [--timeout N] [--wait-for-exit]
+  [--auto-open] [--api-validation] [--callstacks]
+  [--hook-children] [--ref-all-resources]
+  [--soft-memory-limit N] [--delay-for-debugger N]
+  [--json]</code></pre>
 
   <h3 id="doctor">doctor</h3>
   <p>Run environment checks for rdc-cli.</p>
@@ -230,6 +236,46 @@ Modes:
   --stats          Compare per-pass statistics
   --framebuffer    Pixel-level framebuffer diff
   --pipeline       Compare pipeline states at matching EIDs</code></pre>
+
+  <!-- Target Control -->
+  <h2 id="target-control">Target Control</h2>
+  <p>Live interaction with a running RenderDoc-injected target process.</p>
+
+  <h3 id="attach">attach</h3>
+  <p>Attach to a running RenderDoc target by ident.</p>
+  <pre><code>rdc attach &lt;IDENT&gt;</code></pre>
+
+  <h3 id="capture-trigger">capture-trigger</h3>
+  <p>Trigger a capture on the attached target.</p>
+  <pre><code>rdc capture-trigger [--frames N]</code></pre>
+
+  <h3 id="capture-list">capture-list</h3>
+  <p>List captures from the attached target.</p>
+  <pre><code>rdc capture-list [--timeout N] [--json]</code></pre>
+
+  <h3 id="capture-copy">capture-copy</h3>
+  <p>Copy a capture from the target to a local path.</p>
+  <pre><code>rdc capture-copy &lt;CAPTURE_ID&gt; &lt;DEST&gt;</code></pre>
+
+  <!-- Capture Metadata -->
+  <h2 id="capture-metadata">Capture Metadata</h2>
+  <p>Inspect capture file metadata without full replay.</p>
+
+  <h3 id="thumbnail">thumbnail</h3>
+  <p>Export capture thumbnail image.</p>
+  <pre><code>rdc thumbnail [-o OUTPUT] [--maxsize N]</code></pre>
+
+  <h3 id="gpus">gpus</h3>
+  <p>List GPUs available at capture time.</p>
+  <pre><code>rdc gpus [--json]</code></pre>
+
+  <h3 id="sections">sections</h3>
+  <p>List all embedded sections with properties.</p>
+  <pre><code>rdc sections [--json]</code></pre>
+
+  <h3 id="section">section</h3>
+  <p>Extract named section contents to file or stdout.</p>
+  <pre><code>rdc section &lt;NAME&gt; [-o OUTPUT]</code></pre>
 
   <!-- VFS Navigation -->
   <h2 id="vfs">VFS Navigation</h2>

--- a/docs-astro/src/pages/docs/design.astro
+++ b/docs-astro/src/pages/docs/design.astro
@@ -1,0 +1,191 @@
+---
+import Docs from '../../layouts/Docs.astro';
+---
+
+<Docs title="Why This Design">
+  <p>
+    rdc-cli exists because RenderDoc captures GPU data but traps it behind a GUI.
+    Scripts, CI pipelines, and AI agents cannot access this data programmatically.
+    rdc-cli solves this by exposing capture data through a Unix-friendly CLI with
+    pipe-friendly output.
+  </p>
+
+  <h2 id="problem">The Problem</h2>
+
+  <p>
+    RenderDoc is the industry-standard open-source GPU debugger. It captures every
+    API call, shader, texture, buffer, and render target in a single .rdc file. But
+    all this data is locked inside a GUI application. There is no built-in way to:
+  </p>
+
+  <ul>
+    <li>Query capture data from a script or CI pipeline</li>
+    <li>Diff two captures programmatically</li>
+    <li>Assert rendering correctness in automated tests</li>
+    <li>Let an AI agent explore GPU state iteratively</li>
+  </ul>
+
+  <p>
+    rdc-cli bridges this gap: it turns .rdc files into streams of tab-separated
+    text that Unix tools can process.
+  </p>
+
+  <h2 id="daemon">Why a Daemon</h2>
+
+  <p>
+    A 1 GB capture takes 30&ndash;60 seconds to load via
+    <code>OpenCapture()</code>. Reloading for every command is impractical.
+    rdc-cli uses a daemon architecture:
+  </p>
+
+  <ul>
+    <li><code>rdc open capture.rdc</code> starts a background daemon that loads the capture once</li>
+    <li>Subsequent commands (<code>draws</code>, <code>pipeline</code>, <code>shader</code>, etc.) send JSON-RPC requests over TCP localhost</li>
+    <li>The daemon holds the ReplayController in memory &mdash; queries complete in milliseconds</li>
+    <li><code>rdc close</code> shuts down the daemon</li>
+  </ul>
+
+  <p>
+    <strong>Why TCP instead of Unix sockets?</strong> TCP works identically on Linux,
+    macOS, and Windows &mdash; zero platform-specific code.
+  </p>
+
+  <p>
+    <strong>Why single-threaded?</strong> RenderDoc's ReplayController must be called
+    from the thread that created it. The daemon uses an asyncio event loop and
+    serializes all requests.
+  </p>
+
+  <h2 id="tsv">Why TSV by Default</h2>
+
+  <p>
+    Every command outputs tab-separated values by default. This means:
+  </p>
+
+  <ul>
+    <li>Pipe to <code>grep</code>, <code>awk</code>, <code>cut</code>, <code>sort</code>, <code>diff</code>, <code>join</code> &mdash; they all just work</li>
+    <li>Add <code>--json</code> for structured output when you need it (jq, CI assertions, AI agents)</li>
+    <li>Add <code>--jsonl</code> for streaming JSON (one object per line)</li>
+    <li>stderr carries metadata and summaries &mdash; stdout is always clean data</li>
+  </ul>
+
+  <p>Composability in practice:</p>
+
+  <pre><code>rdc draws --sort tri_count | tail -5        # heaviest 5 draws
+rdc resources --type texture | wc -l        # count textures
+rdc shader-map | grep "a1b2" | cut -f1      # find EIDs using a shader</code></pre>
+
+  <p>
+    Exit codes follow <code>diff(1)</code> semantics: 0 = success/no difference,
+    1 = difference found, 2 = error.
+  </p>
+
+  <h2 id="vfs">Why VFS Paths</h2>
+
+  <p>
+    Capture data is organized as a virtual filesystem. Two layers with strict separation:
+  </p>
+
+  <p>
+    <strong>Navigation layer</strong> (ls, cat, tree) &mdash; pure addressing, no business logic:
+  </p>
+
+  <pre><code>rdc ls /draws/142/shader     # &rarr; vs  ps
+rdc cat /draws/142/shader/ps # &rarr; shader disassembly
+rdc tree / --depth 2         # &rarr; full structure</code></pre>
+
+  <p>
+    <strong>Query layer</strong> (draws, resources, pipeline, etc.) &mdash; business logic with filtering:
+  </p>
+
+  <pre><code>rdc draws --sort tri_count --limit 10
+rdc resources --type texture --sort size</code></pre>
+
+  <p>
+    <strong>Why not FUSE?</strong> FUSE adds kernel module complexity, mount/unmount
+    management, and platform dependencies. Path-string addressing with ls/cat/tree
+    covers every use case without any of that overhead.
+  </p>
+
+  <p>
+    Every piece of data has a stable, deterministic path like
+    <code>/draws/142/shader/ps/disasm</code>. AI agents can navigate iteratively
+    &mdash; <code>ls</code> to discover, <code>cat</code> to read.
+  </p>
+
+  <h2 id="ci">Why CI Assertions</h2>
+
+  <p>
+    Five purpose-built assertion commands cover the most common CI checks:
+  </p>
+
+  <ul>
+    <li><strong>assert-pixel</strong> &mdash; verify pixel color at (x,y) within tolerance</li>
+    <li><strong>assert-image</strong> &mdash; pixel-by-pixel image comparison</li>
+    <li><strong>assert-clean</strong> &mdash; no validation errors above severity threshold</li>
+    <li><strong>assert-count</strong> &mdash; numeric metric assertions (draws, triangles, etc.)</li>
+    <li><strong>assert-state</strong> &mdash; pipeline state value at EID matches expected</li>
+  </ul>
+
+  <p>For anything else, compose with Unix tools:</p>
+
+  <pre><code>test "$(rdc count draws)" -ge 10   # at least 10 draws
+rdc log | grep -i error &amp;&amp; exit 1  # fail on errors</code></pre>
+
+  <h2 id="ai-agents">Why AI-Agent Friendly</h2>
+
+  <p>
+    rdc-cli is designed for programmatic consumption:
+  </p>
+
+  <ul>
+    <li><strong>Deterministic paths</strong> &mdash; <code>/draws/142/shader/ps</code> always means the same thing</li>
+    <li><strong>Machine-parseable output</strong> &mdash; TSV and JSON, never mixed formats on stdout</li>
+    <li><strong>Iterative exploration</strong> &mdash; <code>ls</code> to discover structure, <code>cat</code> to read data, just like a real filesystem</li>
+    <li><strong>Escape hatch</strong> &mdash; <code>rdc script</code> executes arbitrary Python inside the daemon when the 60 built-in commands aren't enough</li>
+  </ul>
+
+  <p>
+    The Claude Code skill (<code>rdc install-skill</code>) teaches AI agents the
+    full command vocabulary and VFS namespace.
+  </p>
+
+  <h2 id="tradeoffs">Key Trade-offs</h2>
+
+  <p>Design decisions have trade-offs:</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Decision</th>
+        <th>Trade-off</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Single-threaded daemon</td>
+        <td>No parallel queries, but zero race conditions and simpler code</td>
+      </tr>
+      <tr>
+        <td>TSV default (not JSON)</td>
+        <td>Requires <code>--json</code> flag for structured data, but pipes work out of the box</td>
+      </tr>
+      <tr>
+        <td>GLSL-only shader edit</td>
+        <td>SPIR-V text assembly causes segfaults in RenderDoc; safety over coverage</td>
+      </tr>
+      <tr>
+        <td>No FUSE</td>
+        <td>Cannot mount as real filesystem, but no kernel dependencies</td>
+      </tr>
+      <tr>
+        <td>Session token auth</td>
+        <td>Security relies on file permissions (0600), not encryption</td>
+      </tr>
+      <tr>
+        <td>TCP localhost</td>
+        <td>No TLS currently; remote capture support is planned for a future phase</td>
+      </tr>
+    </tbody>
+  </table>
+</Docs>

--- a/docs-astro/src/pages/docs/examples.astro
+++ b/docs-astro/src/pages/docs/examples.astro
@@ -112,4 +112,251 @@ rdc mesh 142 -o geometry.obj            {"# post-transform mesh"}</code></pre>
   <h2 id="shell-pipelines">Shell Pipeline Power</h2>
 
   <pre><code set:text={shellPipelines}></code></pre>
+
+  <h2 id="capture-frame">Capture a Frame</h2>
+
+  <pre><code>{"# Basic capture"}
+rdc capture ./myapp -o frame.rdc
+
+{"# Capture with API validation and callstacks"}
+rdc capture ./myapp -o frame.rdc --api-validation --callstacks
+
+{"# Capture specific frame number"}
+rdc capture ./myapp -o frame.rdc --frame 100
+
+{"# Capture and immediately open for analysis"}
+rdc capture ./myapp -o frame.rdc --auto-open
+
+{"# JSON output for CI pipelines"}
+rdc capture ./myapp -o frame.rdc --json</code></pre>
+
+  <h2 id="e2e-ci">End-to-End CI Pipeline</h2>
+
+  <pre><code>{"#!/bin/bash"}
+set -e
+
+{"# 1. Capture a frame"}
+rdc capture ./myapp -o test.rdc --api-validation --timeout 30
+
+{"# 2. Open for analysis"}
+rdc open test.rdc
+
+{"# 3. Assert no validation errors"}
+rdc assert-clean
+
+{"# 4. Assert expected draw count"}
+rdc assert-count draws --expect 50 --op ge
+
+{"# 5. Assert pixel color"}
+rdc assert-pixel 142 256 256 --expect "1.0 0.0 0.0 1.0"
+
+{"# 6. Clean up"}
+rdc close</code></pre>
+
+  <h2 id="target-control">Target Control (Live Capture)</h2>
+
+  <pre><code>{"# Inject and get target ident"}
+rdc capture ./myapp --trigger
+{"# → prints ident=12345"}
+
+{"# Attach to running target"}
+rdc attach 12345
+
+{"# Trigger a capture manually"}
+rdc capture-trigger
+
+{"# List captured frames"}
+rdc capture-list
+
+{"# Copy a capture locally"}
+rdc capture-copy 0 snapshot.rdc
+
+{"# Open and analyze"}
+rdc open snapshot.rdc</code></pre>
+
+  <h2 id="multi-session">Multi-Session A/B Comparison</h2>
+
+  <pre><code>{"# Open two captures in named sessions"}
+rdc --session before open before.rdc
+rdc --session after open after.rdc
+
+{"# Compare draws side-by-side"}
+diff &lt;(rdc --session before draws) &lt;(rdc --session after draws)
+
+{"# Compare specific pipeline states"}
+diff &lt;(rdc --session before pipeline 142) &lt;(rdc --session after pipeline 142)
+
+{"# Compare shader disassembly"}
+diff &lt;(rdc --session before cat /draws/142/shader/ps) \
+     &lt;(rdc --session after cat /draws/142/shader/ps)
+
+{"# Clean up both sessions"}
+rdc --session before close
+rdc --session after close</code></pre>
+
+  <h2 id="render-pass">Render Pass Analysis</h2>
+
+  <pre><code>{"# List all render passes"}
+rdc passes
+
+{"# Inspect a specific pass"}
+rdc pass GBuffer
+
+{"# List draws in a pass"}
+rdc draws --pass GBuffer
+
+{"# Find passes with many draws"}
+rdc passes --json | jq '.[] | select(.draw_count > 50)'</code></pre>
+
+  <h2 id="pixel-ladder">Pixel Investigation Ladder</h2>
+
+  <pre><code>{"# Step 1: Read pixel color at (400, 300)"}
+rdc pick-pixel 142 400 300
+
+{"# Step 2: Full pixel history — who modified this pixel?"}
+rdc pixel 142 400 300
+
+{"# Step 3: Debug the pixel shader that drew it"}
+rdc debug pixel 142 400 300
+
+{"# Step 4: Step-by-step shader trace"}
+rdc debug pixel 142 400 300 --trace
+
+{"# Step 5: Dump variables at a specific line"}
+rdc debug pixel 142 400 300 --dump-at 15</code></pre>
+
+  <h2 id="buffer-decode">Buffer Decode via VFS</h2>
+
+  <pre><code>{"# Read decoded constant buffer values"}
+rdc cat /draws/142/cbuffer/0/0
+
+{"# Read decoded vertex buffer"}
+rdc cat /draws/142/vbuffer
+
+{"# Read decoded index buffer"}
+rdc cat /draws/142/ibuffer
+
+{"# View descriptor bindings"}
+rdc cat /draws/142/descriptors
+
+{"# Export raw buffer data"}
+rdc cat /buffers/55/data > vertex_buffer.bin</code></pre>
+
+  <h2 id="rdc-script">Custom Queries with rdc script</h2>
+
+  <pre><code>{"# Inline Python: count unique shader hashes"}
+rdc script -c "
+shaders = set()
+for a in controller.GetRootActions():
+    if a.flags &amp; rd.ActionFlags.Drawcall:
+        controller.SetFrameEvent(a.eventId, True)
+        pipe = controller.GetPipelineState()
+        ps = pipe.GetShader(rd.ShaderStage.Pixel)
+        if int(ps):
+            shaders.add(int(ps))
+print(len(shaders))
+"
+
+{"# Run a script file"}
+rdc script analysis.py -- --verbose</code></pre>
+
+  <h2 id="perf-profiling">Performance Profiling</h2>
+
+  <pre><code>{"# List available GPU counters"}
+rdc counters --list
+
+{"# Profile a specific draw call"}
+rdc counters --eid 142
+
+{"# Profile with specific counter IDs"}
+rdc counters --ids 1,2,5 --eid 142
+
+{"# JSON output for analysis"}
+rdc counters --eid 142 --json</code></pre>
+
+  <h2 id="resource-hunting">Resource Hunting</h2>
+
+  <pre><code>{"# Find largest resources"}
+rdc resources --sort size | tail -10
+
+{"# Find all textures"}
+rdc resources --type texture
+
+{"# Search by name"}
+rdc resources --name "albedo"
+
+{"# Trace a resource's usage across the frame"}
+rdc usage 88
+
+{"# Detailed resource metadata"}
+rdc resource 88</code></pre>
+
+  <h2 id="shader-search">Shader Search &amp; Analysis</h2>
+
+  <pre><code>{"# Search all shaders for a pattern"}
+rdc search "shadowMap"
+
+{"# Find which draws use a shader"}
+rdc shader-map | grep "a1b2c3"
+
+{"# List unique shaders"}
+rdc shaders
+
+{"# View shader reflection data"}
+rdc shader 142 ps --reflect
+
+{"# View constant buffer values"}
+rdc shader 142 ps --constants</code></pre>
+
+  <h2 id="validation-debug">Validation Error Debugging</h2>
+
+  <pre><code>{"# Check for validation errors"}
+rdc log
+
+{"# Filter by severity"}
+rdc log --level error
+
+{"# Assert no errors in CI"}
+rdc assert-clean --min-severity error
+
+{"# Check pipeline state for issues"}
+rdc pipeline 142
+rdc bindings 142</code></pre>
+
+  <h2 id="texture-analysis">Texture Analysis</h2>
+
+  <pre><code>{"# Texture statistics (min/max values)"}
+rdc tex-stats 142
+
+{"# With histogram"}
+rdc tex-stats 142 --histogram
+
+{"# Export texture as PNG"}
+rdc texture 88 -o albedo.png
+
+{"# Export render target"}
+rdc rt 142 -o render_target.png
+
+{"# Export with debug overlay"}
+rdc rt 142 -o wireframe.png --overlay wireframe</code></pre>
+
+  <h2 id="vfs-exploration">VFS Deep Exploration</h2>
+
+  <pre><code>{"# Top-level structure"}
+rdc tree / --depth 1
+
+{"# Browse draw calls"}
+rdc ls /draws
+rdc ls /draws/142
+
+{"# Explore shader stages"}
+rdc ls /draws/142/shader
+rdc cat /draws/142/shader/ps/disasm
+
+{"# Browse passes"}
+rdc ls -l /passes
+
+{"# Navigate via current event alias"}
+rdc goto 142
+rdc cat /current/shader/ps</code></pre>
 </Docs>

--- a/docs-astro/src/pages/docs/index.astro
+++ b/docs-astro/src/pages/docs/index.astro
@@ -58,6 +58,7 @@ rdc close</code></pre>
     <li><a href={`${base}docs/commands/`}>Command Reference</a> — all {stats.command_count} commands</li>
     <li><a href={`${base}docs/vfs/`}>VFS Paths</a> — virtual filesystem namespace</li>
     <li><a href={`${base}docs/ai-integration/`}>AI Agent Integration</a> — Claude Code skill, agent-friendly design</li>
+    <li><a href={`${base}docs/design/`}>Why This Design</a> — daemon architecture, TSV-first output, VFS paths, and key trade-offs</li>
     <li><a href={`${base}docs/examples/`}>Examples</a> — real-world workflow recipes</li>
   </ul>
 </Docs>

--- a/openspec/changes/2026-02-23-docs-polish/proposal.md
+++ b/openspec/changes/2026-02-23-docs-polish/proposal.md
@@ -1,0 +1,66 @@
+# Proposal: docs-polish
+
+**Date:** 2026-02-23
+**Phase:** Docs
+**Status:** Draft
+
+---
+
+## Problem Statement
+
+The Astro docs site (GitHub Pages) has three significant gaps:
+
+1. **Examples page incomplete** — Only 8 use cases covering ~15 of 60 commands. Major workflows (capture, target control, render pass analysis, pixel investigation, buffer decode, performance profiling) are undocumented.
+
+2. **Commands page outdated** — Missing 8 Phase 5B commands (`attach`, `capture-trigger`, `capture-list`, `capture-copy`, `thumbnail`, `gpus`, `sections`, `section`). The `capture` command docs don't reflect the Python API rewrite with new options. `stats.json` reports 53 commands; actual count is 60.
+
+3. **No design rationale page** — Users and contributors cannot understand *why* rdc-cli uses a daemon, TSV-first output, VFS paths, or CI assertions. The Obsidian vault has 25 decision records (D-001 through D-025) that are not publicly accessible.
+
+---
+
+## Proposed Solution
+
+### 1. New page: "Why This Design" (`design.astro`)
+
+A design rationale page sourced from Obsidian decision records covering:
+- The Problem (RenderDoc is GUI-only)
+- Why a Daemon (D-002: OpenCapture 30-60s, JSON-RPC over TCP)
+- Why TSV by Default (D-003: pipe to grep/awk/sort/diff)
+- Why VFS Paths (D-001, D-016: two-layer architecture, not FUSE)
+- Why CI Assertions (D-011: 5 purpose-built + Unix composability)
+- Why AI-Agent Friendly (D-009: rdc script escape hatch)
+- Key Trade-offs (single-threaded daemon, GLSL-only shader edit)
+
+### 2. Update commands page
+
+- Add **Target Control** section (Phase 5B, marked 🚧): `attach`, `capture-trigger`, `capture-list`, `capture-copy`
+- Add **Capture Metadata** section (Phase 5B, marked 🚧): `thumbnail`, `gpus`, `sections`, `section`
+- Update `capture` command with new Python API options
+- Update `stats.json` to reflect 60 commands
+
+### 3. Expand examples page (~14 new use cases)
+
+Add workflow recipes for: frame capture, end-to-end CI pipeline, target control, multi-session comparison, render pass analysis, pixel investigation ladder, buffer decode, rdc script, performance profiling, resource hunting, shader search, validation debugging, texture analysis, VFS deep exploration.
+
+### 4. Update navigation
+
+- Add "Design" entry to sidebar in `Docs.astro`
+- Add "Design" link to sections list in `index.astro`
+
+---
+
+## Non-Goals
+
+- No changes to CLI code or daemon handlers
+- No changes to Obsidian vault files
+- No automated doc generation (manual curation for quality)
+
+---
+
+## Acceptance Criteria
+
+1. `cd docs-astro && npm run build` succeeds without errors
+2. All 60 commands documented on commands page
+3. Examples page has ~22 total use cases covering all major workflows
+4. Design page accurately reflects Obsidian decision records
+5. Navigation links work correctly across all pages

--- a/openspec/changes/2026-02-23-docs-polish/tasks.md
+++ b/openspec/changes/2026-02-23-docs-polish/tasks.md
@@ -1,0 +1,32 @@
+# Tasks: docs-polish
+
+**Date:** 2026-02-23
+
+---
+
+## Task Breakdown
+
+### T1: Create design.astro
+- [ ] Create `docs-astro/src/pages/docs/design.astro`
+- [ ] Write 7 sections sourced from Obsidian decision records
+- [ ] Follow existing page styling (Docs layout, prose classes)
+
+### T2: Update commands.astro
+- [ ] Add Target Control section (attach, capture-trigger, capture-list, capture-copy) with 🚧 badge
+- [ ] Add Capture Metadata section (thumbnail, gpus, sections, section) with 🚧 badge
+- [ ] Update `capture` command entry with new Python API options
+- [ ] Verify all 60 commands are documented
+
+### T3: Expand examples.astro
+- [ ] Add ~14 new use case sections
+- [ ] Mark Phase 5B examples with 🚧 badge
+- [ ] Ensure code examples are accurate and runnable
+
+### T4: Update navigation and metadata
+- [ ] Add "Design" to sidebar in `layouts/Docs.astro`
+- [ ] Add "Design" link to sections list in `pages/docs/index.astro`
+- [ ] Update `data/stats.json` (command_count, test_count, version)
+
+### T5: Build and verify
+- [ ] `npm run build` passes
+- [ ] Visual check of all modified/new pages

--- a/openspec/changes/2026-02-23-docs-polish/test-plan.md
+++ b/openspec/changes/2026-02-23-docs-polish/test-plan.md
@@ -1,0 +1,48 @@
+# Test Plan: docs-polish
+
+**Date:** 2026-02-23
+
+---
+
+## Verification Steps
+
+### 1. Build Verification
+
+```bash
+cd docs-astro && npm run build
+```
+
+- Must complete without errors
+- All pages generated in `dist/`
+
+### 2. Page Completeness
+
+| Check | Expected |
+|-------|----------|
+| `design.astro` exists | New page renders with 7 sections |
+| Commands page sections | 12 sections (existing 10 + Target Control + Capture Metadata) |
+| Commands total | 60 commands documented |
+| Examples count | ~22 use cases (8 existing + 14 new) |
+| 🚧 badges | Visible on Phase 5B commands and examples |
+
+### 3. Navigation
+
+| Link | Target |
+|------|--------|
+| Sidebar "Design" | `/docs/design/` |
+| Index "Design" link | `/docs/design/` |
+| All existing sidebar links | Still work correctly |
+
+### 4. Content Accuracy
+
+- Design page rationale matches Obsidian decision records (D-001 through D-025)
+- Phase 5B commands match `openspec/changes/2026-02-23-phase5b-capture-unified/proposal.md`
+- Command syntax matches `rdc --help` output
+- `stats.json` values updated (command_count: 60)
+
+### 5. Visual Check
+
+- Dark mode renders correctly
+- Light mode renders correctly
+- Mobile responsive layout works
+- Code blocks properly formatted


### PR DESCRIPTION
## Summary

- Add **"Why This Design"** page (`design.astro`) — explains daemon architecture, TSV-first output, VFS paths, CI assertions, AI-agent friendliness, and key trade-offs, sourced from Obsidian decision records (D-001 through D-025)
- Add **Target Control** section to commands page — `attach`, `capture-trigger`, `capture-list`, `capture-copy`
- Add **Capture Metadata** section to commands page — `thumbnail`, `gpus`, `sections`, `section`
- Update `capture` command docs with full Python API options
- Expand examples page with **14 new use cases** (22 total): frame capture, end-to-end CI pipeline, target control, multi-session comparison, render pass analysis, pixel investigation ladder, buffer decode, rdc script, performance profiling, resource hunting, shader search, validation debugging, texture analysis, VFS deep exploration
- Fix prose `<pre><code>` first-line alignment bug (reset padding inside pre blocks)
- Update stats: 61 commands, 1838 tests, 95.25% coverage, v0.3.1
- Add "Design" to sidebar navigation and docs index

## Test plan

- [x] `npm run build` — 9 pages built without errors
- [x] `pixi run check` — lint + typecheck + 1838 tests pass
- [x] E2E tests — 26 passed
- [ ] Visual review: new pages render correctly in dark/light mode