### PR TITLE
build: use setuptools-scm for dynamic versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,15 +167,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify tag matches pyproject.toml version
-        run: |
-          TAG="${GITHUB_REF_NAME#v}"
-          VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)".*/\1/')
-          if [ "$TAG" != "$VERSION" ]; then
-            echo "::error::Tag $GITHUB_REF_NAME does not match pyproject.toml version $VERSION"
-            exit 1
-          fi
-
       - name: Download dist artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=68", "setuptools-scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "rdc-cli"
-version = "0.3.1"
+dynamic = ["version"]
 description = "Unix-friendly CLI for RenderDoc .rdc captures"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -51,6 +51,10 @@ where = ["src"]
 addopts = "-q"
 testpaths = ["tests"]
 markers = ["gpu: requires real renderdoc module and GPU"]
+
+[tool.setuptools_scm]
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
## Summary

- Replace hardcoded `version = "0.3.1"` in pyproject.toml with `dynamic = ["version"]` + `setuptools-scm`
- Version is now derived from git tags automatically (e.g. `v0.3.2` tag → version `0.3.2`)
- Remove the "Verify tag matches pyproject.toml version" CI step (no longer needed)
- No more manual version bumps before tagging a release

## Test plan

- [x] `pixi run check` — 1838 tests pass
- [x] E2E — 26 pass
- [x] `setuptools_scm.get_version()` returns correct version from git tags
- [ ] After merge: tag `v0.3.2` on master → CI publishes to PyPI with correct version