### PR TITLE
fix(debug,shader,events): fix transport overflow, shader-map columns, mesh draw classification

### DIFF
--- a/openspec/changes/2026-02-23-fix-bugs-b10-b15-b16/proposal.md
+++ b/openspec/changes/2026-02-23-fix-bugs-b10-b15-b16/proposal.md
@@ -1,0 +1,239 @@
+# Fix Bugs B10 + B15 + B16
+
+## Summary
+
+Three bugs in the query and debug subsystems: B10 causes `debug thread` to crash with a transport overflow for large compute shader traces (and masks the error in `--json` mode); B15 causes `shader-map` to report incorrect stage columns for Dispatch events due to stale pipeline references; B16 causes `vkCmdDrawMeshTasksEXT` draw calls to be classified as "Other" instead of "Draw" because the `MeshDispatch` action flag is not recognized.
+
+## Motivation
+
+B10 makes compute shader debugging completely unusable — the most common use case for `debug thread`. B15 makes `shader-map` output misleading for any capture with mixed draw+dispatch (e.g., physics or particle simulations). B16 makes `events`, `draws`, `info`, and all stats incorrect for any mesh shading capture; mesh shading is a modern GPU feature that will become increasingly common.
+
+---
+
+## Bug Analysis
+
+### B10: `debug thread` transport overflow (P1)
+
+#### Current behavior
+
+Running `rdc debug thread <eid> <gx> <gy> <gz> <tx> <ty> <tz>` against a compute-heavy shader raises:
+
+```
+ValueError: recv_line: message exceeds max_bytes limit
+```
+
+- Default mode: exits RC=1 (unhandled `ValueError` propagates, Python exits with non-zero).
+- `--trace` mode: exits RC=1 (same path).
+- `--json` mode: exits RC=0 — the error is silently swallowed, making the failure invisible to scripts.
+
+#### Root cause
+
+Two separate defects:
+
+**Defect 1 — response too large.**
+`src/rdc/handlers/debug.py:88` (`_run_debug_loop`) collects up to `_MAX_STEPS = 50_000` step dicts. Each step contains a `changes` list of variable dicts with `before`/`after` float arrays. A complex compute shader can easily produce 50,000 steps × multiple variables per step, yielding a JSON response well above 10 MB.
+
+`src/rdc/daemon_client.py:19` calls `_recv_line(sock)` (imported from `src/rdc/_transport.py:8`) with the default `max_bytes=10 * 1024 * 1024` (10 MB hard cap). When the serialized JSON response exceeds this, `_transport.py:29` raises `ValueError("recv_line: message exceeds max_bytes limit")`.
+
+**Defect 2 — `ValueError` not caught, RC wrong in `--json` mode.**
+`src/rdc/commands/_helpers.py:58-66` (`call()`) only catches `OSError`; `ValueError` propagates unhandled. Click's `standalone_mode=True` does not catch arbitrary exceptions and re-raises them. Depending on Click version and context teardown order, the process may exit RC=0 instead of RC=1 when the exception escapes from inside a Click command — this is the RC=0 masked failure in `--json` mode.
+
+#### Proposed fix
+
+**Fix 1 — raise the transport limit to 256 MB.**
+Change `src/rdc/_transport.py:8`:
+
+```python
+# before
+def recv_line(sock: socket.socket, max_bytes: int = 10 * 1024 * 1024) -> str:
+
+# after
+def recv_line(sock: socket.socket, max_bytes: int = 256 * 1024 * 1024) -> str:
+```
+
+256 MB is a practical upper bound for a single JSON-RPC response; any legitimate debug trace will be smaller. This unblocks all failing modes immediately.
+
+**Fix 2 — catch `ValueError` in `call()` with proper RC.**
+Change `src/rdc/commands/_helpers.py:58-66`:
+
+```python
+    try:
+        response = send_request(host, port, payload)
+    except (OSError, ValueError) as exc:
+        msg = f"daemon unreachable: {exc}"
+        if _json_mode():
+            click.echo(json.dumps({"error": {"message": msg}}), err=True)
+        else:
+            click.echo(f"error: {msg}", err=True)
+        raise SystemExit(1) from exc
+```
+
+This ensures any transport-level failure (including future limit breaches) always exits RC=1 in all modes, with a structured JSON error in `--json` mode.
+
+---
+
+### B15: `shader-map` Dispatch EID column mapping (P2)
+
+#### Current behavior
+
+For `compute_nbody.rdc` (which has both Draw and Dispatch events), `rdc shader-map` shows non-zero shader IDs in the VS and PS columns for Dispatch EIDs 8 and 11, when those EIDs use compute pipelines that have no VS or PS shader bound. The CS shader ID may appear in VS/PS columns or unrelated shader IDs appear.
+
+#### Root cause
+
+`src/rdc/handlers/_helpers.py:140-195` (`_build_shader_cache`) walks all draw/dispatch actions in sequence, calling `_set_frame_event(state, a.eventId)` then storing the result of `state.adapter.get_pipeline_state()` in `state._pipe_states_cache[a.eventId]`.
+
+`src/rdc/adapter.py:39-41` shows `get_pipeline_state()` calls `controller.GetPipelineState()` which — per the RenderDoc API gotcha documented in MEMORY.md — returns a **mutable reference** to a single live object. Every entry stored in `_pipe_states_cache` is the same Python/SWIG proxy object; after the walk completes, it reflects only the pipeline state of the **last** event visited.
+
+`src/rdc/services/query_service.py:300-322` (`_collect_recursive`) then iterates the cached entries and calls `state.GetShader(stage_val)` on each — but all `state` values are the same stale object. For `stage_cols = {0: "vs", 1: "hs", 2: "ds", 3: "gs", 4: "ps", 5: "cs"}`, calling `GetShader(0..5)` on a compute pipeline (the last-visited state) returns the compute shader for slot 5, and may return non-zero garbage or the CS shader ID for slots 0–4 depending on the Vulkan/RenderDoc pipeline abstraction.
+
+#### Proposed fix
+
+Stop caching the live pipeline reference. Instead, during `_build_shader_cache`, snapshot the shader IDs per stage immediately and store a plain dict. Modify `_build_shader_cache` in `src/rdc/handlers/_helpers.py` to store a snapshot dict instead of the live pipeline:
+
+```python
+# Replace:
+state._pipe_states_cache[a.eventId] = pipe
+
+# With: snapshot shader IDs immediately while pipeline is live
+stage_snap: dict[int, int] = {}
+for sv in range(6):
+    stage_snap[sv] = int(pipe.GetShader(sv))
+state._pipe_states_cache[a.eventId] = stage_snap  # type: ignore[assignment]
+```
+
+Update `_collect_recursive` in `src/rdc/services/query_service.py:300-322` to read from the snapshot dict (no more `.GetShader()` calls — just dict lookups):
+
+```python
+def _collect_recursive(
+    actions: list[Any],
+    pipe_states: dict[int, dict[int, int]],
+    rows: list[dict[str, Any]],
+) -> None:
+    stage_cols = {0: "vs", 1: "hs", 2: "ds", 3: "gs", 4: "ps", 5: "cs"}
+    for a in actions:
+        flags = int(a.flags)
+        if (flags & _DRAWCALL) or (flags & _DISPATCH):
+            eid = a.eventId
+            snap = pipe_states.get(eid)
+            if snap is not None:
+                row: dict[str, Any] = {"eid": eid}
+                for stage_val, col in stage_cols.items():
+                    sid_int = snap[stage_val]
+                    row[col] = sid_int if sid_int != 0 else "-"
+                rows.append(row)
+        if a.children:
+            _collect_recursive(a.children, pipe_states, rows)
+```
+
+Note: `_handle_pipeline` and `_handle_bindings` in `src/rdc/handlers/query.py` call `get_pipeline_state()` fresh (they do NOT use `_pipe_states_cache`), so they are unaffected. The only consumer of `_pipe_states_cache` is `collect_shader_map` via `_collect_recursive`. The `_pipe_states_cache` type annotation should change to `dict[int, dict[int, int]]`.
+
+Also note: for Dispatch EIDs, stages 0–4 (VS/HS/DS/GS/PS) should display as `"-"`. Since a compute pipeline binds only CS (stage 5), the snapshot will have `0` for all graphics stages, which correctly renders as `"-"` in the output.
+
+---
+
+### B16: `vkCmdDrawMeshTasksEXT` draw classification (P2)
+
+#### Current behavior
+
+For `mesh_shading.rdc`, `rdc events` shows EID 10 with `TYPE=Other`, `rdc draws` does not include EID 10, and `rdc info` does not count EID 10 as a draw call.
+
+#### Root cause
+
+RenderDoc sets `ActionFlags.MeshDispatch = 0x0008` for `vkCmdDrawMeshTasksEXT` actions (confirmed by `tests/mocks/mock_renderdoc.py:53`). This flag is distinct from `ActionFlags.Drawcall = 0x0002`.
+
+All classification logic in `src/rdc/services/query_service.py` only tests `_DRAWCALL = 0x0002`:
+
+- `_action_type_str` in `src/rdc/handlers/_helpers.py:104`: `if flags & _DRAWCALL` → returns `"Draw"` or `"DrawIndexed"`, otherwise falls through to `"Other"`. EID 10 has `0x0008` only, so it returns `"Other"`.
+- `filter_by_type` in `src/rdc/services/query_service.py:133-138`: `type_map = {"draw": _DRAWCALL, ...}` — only checks `0x0002`.
+- `_triangles_for_action` at line 182: `if not (a.flags & _DRAWCALL)` — returns 0 for mesh draws.
+- `aggregate_stats` at lines 193, 221: counts only `_DRAWCALL` for `total_draws`.
+- `get_top_draws` at line 221: `[a for a in flat if a.flags & _DRAWCALL]` — misses mesh draws.
+- `_subtree_has_draws` at line 440: checks only `_DRAWCALL`.
+- `_collect_recursive` at line 308: already includes `_DISPATCH` but not `_MESHDRAW`.
+- `_build_shader_cache` in `src/rdc/handlers/_helpers.py:144`: `(flags & _DRAWCALL) or (flags & _QS_DISPATCH)` — misses mesh draws.
+- `_handle_stats` RT enrichment in `src/rdc/handlers/query.py:290`: `a.flags & _DRAWCALL` for `pass_first_draw` — misses mesh draws.
+
+#### Proposed fix
+
+Add `_MESHDRAW = 0x0008` constant to `src/rdc/services/query_service.py` alongside existing constants, then update all affected locations to treat `_MESHDRAW` as a draw variant:
+
+```python
+# src/rdc/services/query_service.py — add constant
+_MESHDRAW = 0x0008
+```
+
+Update `_action_type_str` in `src/rdc/handlers/_helpers.py`:
+
+```python
+# import _MESHDRAW alongside _DRAWCALL
+if flags & (_DRAWCALL | _MESHDRAW):
+    return "DrawIndexed" if flags & _INDEXED else "Draw"
+```
+
+Update `filter_by_type` in `src/rdc/services/query_service.py`:
+
+```python
+type_map = {"draw": _DRAWCALL | _MESHDRAW, "dispatch": _DISPATCH, "clear": _CLEAR, "copy": _COPY}
+```
+
+Update `_triangles_for_action`:
+
+```python
+if not (a.flags & (_DRAWCALL | _MESHDRAW)):
+    return 0
+```
+
+Update `aggregate_stats` draw counting:
+
+```python
+if a.flags & (_DRAWCALL | _MESHDRAW):
+    stats.total_draws += 1
+    ...
+```
+
+Update `_subtree_has_draws`:
+
+```python
+if int(action.flags) & (_DRAWCALL | _MESHDRAW):
+    return True
+```
+
+Update `_collect_recursive` (already fixed for B15; ensure mesh draws are included):
+
+```python
+if (flags & _DRAWCALL) or (flags & _DISPATCH) or (flags & _MESHDRAW):
+```
+
+Update `_build_shader_cache` in `src/rdc/handlers/_helpers.py`:
+
+```python
+from rdc.services.query_service import _MESHDRAW as _QS_MESHDRAW
+...
+if (flags & _DRAWCALL) or (flags & _QS_DISPATCH) or (flags & _QS_MESHDRAW):
+```
+
+Also update `get_top_draws` (query_service.py:221) and `_handle_stats` RT enrichment (query.py:290 `pass_first_draw`) to include mesh draws.
+
+Mesh draws do not have index-based triangle counts (`numIndices` is 0); `_triangles_for_action` should return 0 for them (or a mesh-specific estimate if available), which is already handled by returning `(0 // 3) * num_instances = 0` — acceptable.
+
+---
+
+## Risk Assessment
+
+**B10 fix 1 (raise `max_bytes`):** Low risk. The limit is a safety guard against runaway data; 256 MB is still a hard cap. No behavioral change for normal responses. The daemon's `sendall` already handles large writes correctly.
+
+**B10 fix 2 (catch `ValueError`):** Very low risk. Adds `ValueError` to an existing `except OSError` clause. No behavior change for the normal path.
+
+**B15 fix (snapshot shader IDs):** Medium risk. Changes the type of `_pipe_states_cache` values from a live pipeline object to `dict[int, int]`. Any handler that uses `_pipe_states_cache` as a live pipeline (e.g., `_handle_pipeline`, `_handle_bindings`) will break unless also updated. Must audit all usages of `state._pipe_states_cache` in `src/rdc/handlers/query.py` and other handlers. The `_collect_recursive` and `_build_shader_cache` paths are fully controlled; risk is limited to missed usages.
+
+**B16 fix (add `_MESHDRAW`):** Low risk for new captures; zero risk for existing non-mesh captures. The `0x0008` flag is only set by `vkCmdDrawMeshTasksEXT`; no existing action type reuses it. The triangle count for mesh draws will be 0 (correct, since mesh shaders don't use index buffers).
+
+## Alternatives Considered
+
+**B10 — chunked/streaming transport:** Replace `recv_line` with a length-prefixed framing protocol to eliminate the size cap entirely. Rejected: requires protocol breaking change and daemon/client coordination changes across all callers. The 256 MB bump achieves the same practical result with minimal change.
+
+**B10 — server-side trace truncation:** Cap `_MAX_STEPS` lower or paginate the trace response. Rejected: the existing `_MAX_STEPS = 50_000` guard is already present; the problem is the response size cap, not the step count. Lowering `_MAX_STEPS` further would degrade the debugging experience.
+
+**B15 — call `_set_frame_event` inside `_collect_recursive`:** Re-run the replay seek per EID during the shader-map collection. Rejected: this is a O(N) replay seeks during output formatting, causing severe performance regression for large captures. Snapshotting during `_build_shader_cache` (which already seeks) is the correct approach.
+
+**B16 — string-match on action name:** Detect `vkCmdDrawMeshTasksEXT` by action name string. Rejected: fragile, not portable across API backends (DX12 has `DispatchMesh`), and the flag-based approach is the canonical RenderDoc pattern already used for all other action types.

--- a/openspec/changes/2026-02-23-fix-bugs-b10-b15-b16/tasks.md
+++ b/openspec/changes/2026-02-23-fix-bugs-b10-b15-b16/tasks.md
@@ -1,0 +1,131 @@
+# Tasks: Fix Bugs B10 + B15 + B16
+
+## Task 1: Raise transport max_bytes limit (B10)
+
+- **Files**: `src/rdc/_transport.py`
+- **Changes**:
+  - In `recv_line`, increase the default `max_bytes` from `10 * 1024 * 1024` (10 MB) to `256 * 1024 * 1024` (256 MB). A compute shader trace of up to 50,000 steps with many changed variables can easily produce a JSON response exceeding 10 MB.
+  - Verify that any call site passing an explicit `max_bytes` argument also uses an adequate limit.
+- **Depends on**: nothing
+- **Estimated complexity**: S
+
+## Task 2: Catch `ValueError` in `call()` for proper error handling (B10)
+
+- **Files**: `src/rdc/commands/_helpers.py`
+- **Changes**:
+  - In `call()` (line 58-66), the `except OSError` clause must also catch `ValueError`. When `recv_line` raises `ValueError` (e.g., message exceeds max_bytes), it propagates unhandled through Click, and in `--json` mode the process may exit RC=0 instead of RC=1.
+  - Change `except OSError as exc:` to `except (OSError, ValueError) as exc:`. This ensures all transport-level failures produce RC=1 with a structured error message in all output modes.
+  - Note: `_check_debug_result(result)` already runs before the `if use_json:` branch in all three debug commands (lines 101, 154, 192 of `debug.py`), so no reordering is needed there. The issue is purely that `ValueError` is not caught in `call()`.
+- **Depends on**: nothing (independent of Task 1)
+- **Estimated complexity**: S
+
+## Task 3: Fix shader-map column mapping for compute dispatches (B15)
+
+- **Files**: `src/rdc/handlers/_helpers.py`, `src/rdc/services/query_service.py`, `src/rdc/daemon_server.py`
+- **Changes**:
+  Two changes needed — snapshot fix + stage restriction:
+
+  **3a. Snapshot shader IDs in `_build_shader_cache`** (`src/rdc/handlers/_helpers.py`):
+  - Root cause: `get_pipeline_state()` returns a **mutable reference** (documented in MEMORY.md). All entries in `_pipe_states_cache` point to the same live object, reflecting only the last event visited.
+  - Fix: Replace `state._pipe_states_cache[a.eventId] = pipe` with a snapshot:
+    ```python
+    stage_snap: dict[int, int] = {}
+    for sv in range(6):
+        stage_snap[sv] = int(pipe.GetShader(sv))
+    state._pipe_states_cache[a.eventId] = stage_snap
+    ```
+  - Update `_pipe_states_cache` type annotation in `DaemonState` (`daemon_server.py`) to `dict[int, dict[int, int]]`.
+
+  **3b. Restrict stage queries per action type in `_collect_recursive`** (`src/rdc/services/query_service.py`):
+  - Since `_pipe_states_cache` now stores `dict[int, int]` snapshots, update `_collect_recursive` to do dict lookups instead of `.GetShader()` calls.
+  - For dispatches (`flags & _DISPATCH`): only read stage 5 (cs); set stages 0–4 to `"-"`.
+  - For draws (`flags & _DRAWCALL`): only read stages 0–4; set stage 5 (cs) to `"-"`.
+  - Note: `_handle_pipeline` and `_handle_bindings` use fresh `get_pipeline_state()` calls (not `_pipe_states_cache`), so they are unaffected.
+- **Depends on**: nothing
+- **Estimated complexity**: M
+
+## Task 4: Add mesh shader draw classification for MeshDispatch flag (B16)
+
+- **Files**: `src/rdc/services/query_service.py`, `src/rdc/handlers/_helpers.py`
+- **Changes**:
+  - Add `_MESH_DISPATCH = 0x0008` constant to `query_service.py` alongside the other ActionFlags constants. This corresponds to `ActionFlags.MeshDispatch` in the RenderDoc API (confirmed in `tests/mocks/mock_renderdoc.py`).
+  - In `_action_type_str` (`src/rdc/handlers/_helpers.py`): add a branch to import and check `_MESH_DISPATCH` alongside `_DRAWCALL`. If `flags & _MESH_DISPATCH`, return `"Draw"` (mesh draw calls are draw calls for reporting purposes). Insert this check before the `_DISPATCH` branch, since `MeshDispatch` is semantically a draw variant.
+  - In `filter_by_type` (`src/rdc/services/query_service.py`): update the `"draw"` entry to match both `_DRAWCALL` and `_MESH_DISPATCH`. Replace `"draw": _DRAWCALL` with a lambda or a combined flag check. Since `filter_by_type` currently uses a simple bitmask `flags & flag`, introduce a helper or change the map to use a combined mask: `"draw": _DRAWCALL | _MESH_DISPATCH`.
+  - In `aggregate_stats` (`src/rdc/services/query_service.py`): the `if a.flags & _DRAWCALL:` branch must also cover `_MESH_DISPATCH`. Change to `if a.flags & (_DRAWCALL | _MESH_DISPATCH):`.
+  - In `_subtree_has_draws`, `_window_stats`, `_subtree_stats` (all in `query_service.py`): the `flags & _DRAWCALL` checks used for pass stats must also include `_MESH_DISPATCH`.
+  - In `get_top_draws` (`src/rdc/services/query_service.py:221`): `[a for a in flat if a.flags & _DRAWCALL]` must also include `_MESH_DISPATCH`.
+  - In `_handle_stats` RT enrichment (`src/rdc/handlers/query.py:290`): `a.flags & _DRAWCALL` for `pass_first_draw` must also include `_MESH_DISPATCH`.
+  - In `_build_shader_cache` (`src/rdc/handlers/_helpers.py`): the condition `(flags & _DRAWCALL) or (flags & _QS_DISPATCH)` must also include `_MESH_DISPATCH` so mesh draws are included in the shader cache and `_pipe_states_cache`.
+  - In `_collect_recursive` (`src/rdc/services/query_service.py`): the condition `(flags & _DRAWCALL) or (flags & _DISPATCH)` must also cover `_MESH_DISPATCH`. Treat mesh draws like graphics draws for stage column purposes (query stages 0–4, not stage 7). Adding a mesh-specific stage column is out of scope for this fix.
+- **Depends on**: nothing
+- **Estimated complexity**: M
+
+## Task 5: Write tests for B10 (transport overflow + RC masking)
+
+- **Files**: `tests/unit/test_daemon_transport.py`, `tests/unit/test_debug_commands.py`
+- **Changes**:
+  - In `test_daemon_transport.py`, add:
+    - `test_recv_line_default_limit_is_large`: verify that `recv_line` with default `max_bytes` can accumulate at least 50 MB of data without raising (simulate large message by mocking `sock.recv` to return multiple 4096-byte chunks containing no newline, then a final chunk with `\n`).
+    - `test_recv_line_explicit_small_limit_raises`: verify that passing `max_bytes=100` still raises `ValueError` on oversized input (regression guard; existing test `test_recv_line_exceeds_max_bytes` already covers this).
+  - In `test_debug_commands.py`, add for `thread_cmd`, `pixel_cmd`, and `vertex_cmd`:
+    - `test_thread_json_rc_on_incomplete_result`: mock `_daemon_call` to return a dict missing `"total_steps"` (incomplete result); invoke with `--json`; assert `exit_code == 1` (not 0).
+    - `test_pixel_json_rc_on_incomplete_result`: same for `debug pixel`.
+    - `test_vertex_json_rc_on_incomplete_result`: same for `debug vertex`.
+    - Use `CliRunner` and `monkeypatch` (or `unittest.mock.patch`) on `rdc.commands._helpers._daemon_call` (or the appropriate import path used in `debug.py`: `rdc.commands.info._daemon_call`).
+- **Depends on**: Task 1, Task 2
+- **Estimated complexity**: S
+
+## Task 6: Write tests for B15 (shader-map dispatch column mapping)
+
+- **Files**: `tests/unit/test_count_shadermap.py`
+- **Changes**:
+  - In `TestShaderMapCollection`, add:
+    - `test_shader_map_dispatch_only_shows_cs_column`: create a dispatch action (EID 8) with a pipe state that has ONLY a CS shader bound (e.g., `cs=99`) but whose `GetShader(0)` through `GetShader(4)` would return non-zero values (simulate the stale pipeline bug by setting `vs=10, ps=11, cs=99` in the mock pipe state). Assert that in the resulting row: `cs == 99` and `vs == "-"`, `ps == "-"`. This verifies the fix prevents graphics-stage IDs from leaking into dispatch rows.
+    - `test_shader_map_mixed_draw_and_dispatch`: create a list with one draw action (EID 1, vs+ps bound) and one dispatch action (EID 2, cs-only bound). Assert that EID 1 has `vs != "-"` and `cs == "-"`, and EID 2 has `cs != "-"` and `vs == "-"`.
+  - These tests require that `MockPipeState.GetShader` be callable and return configured shaders; the existing `_make_pipe_state` helper already supports this.
+- **Depends on**: Task 3
+- **Estimated complexity**: S
+
+## Task 7: Write tests for B16 (mesh dispatch classification)
+
+- **Files**: `tests/unit/test_draws_events_daemon.py`, `tests/unit/test_query_service.py`
+- **Changes**:
+  - In `test_draws_events_daemon.py` (or `test_query_service.py`), add:
+    - `test_mesh_dispatch_classified_as_draw_in_events`: build an `ActionDescription` with `flags=ActionFlags.MeshDispatch` (value `0x0008`) and EID 10. Create daemon state, send `events` request, assert that the event with EID 10 has `type == "Draw"` (not `"Other"`).
+    - `test_mesh_dispatch_included_in_draws_list`: send `draws` request; assert EID 10 appears in `result["draws"]`.
+    - `test_mesh_dispatch_counted_in_stats`: send `stats` request; assert `result["total_draws"] >= 1`.
+    - `test_filter_by_type_draw_includes_mesh_dispatch`: unit-test `filter_by_type` directly with a `FlatAction` that has `flags=0x0008`; assert it appears in `filter_by_type(flat, "draw")`.
+    - `test_action_type_str_mesh_dispatch_returns_draw`: unit-test `_action_type_str(0x0008)` directly; assert it returns `"Draw"`.
+  - Use `mrd.ActionFlags.MeshDispatch` (already defined as `0x0008` in `mock_renderdoc.py`) to construct mock actions.
+- **Depends on**: Task 4
+- **Estimated complexity**: S
+
+---
+
+## Parallelism
+
+All implementation tasks are independent and can run in parallel:
+
+- **Task 1** (transport limit) and **Task 2** (RC masking) touch different files and are fully independent.
+- **Task 3** (shader-map dispatch columns) touches only `query_service.py` `_collect_recursive`.
+- **Task 4** (mesh dispatch) touches `query_service.py` (different functions from Task 3) and `_helpers.py`. If Task 3 and Task 4 are assigned to the same agent, they must coordinate on `_collect_recursive` changes to avoid conflicts.
+
+Test tasks depend on their corresponding implementation tasks:
+- **Task 5** depends on Tasks 1 + 2
+- **Task 6** depends on Task 3
+- **Task 7** depends on Task 4
+
+## Implementation order
+
+1. **Phase A (parallel)**: Tasks 1, 2, 3, 4 — implementation fixes
+2. **Phase B (parallel)**: Tasks 5, 6, 7 — test coverage (after Phase A completes)
+3. **Verification**: `pixi run lint && pixi run test` — zero failures required
+
+### Notes for implementers
+
+- **Task 3 + Task 4 conflict**: both modify `query_service.py`. If done by separate agents, split as follows:
+  - Task 3 agent: only modifies `_collect_recursive`
+  - Task 4 agent: modifies `_MESH_DISPATCH` constant, `_action_type_str`, `filter_by_type`, `aggregate_stats`, `_subtree_has_draws`, `_window_stats`, `_subtree_stats`, `_build_shader_cache`
+  - Merge both sets of changes to `query_service.py` carefully before running tests.
+- **B15 root cause**: `get_pipeline_state()` returns a **mutable reference** (MEMORY.md gotcha). All entries in `_pipe_states_cache` share the same stale object reflecting only the last event visited. Fix requires **both** snapshotting shader IDs in `_build_shader_cache` (Task 3a) **and** restricting stage queries per action type in `_collect_recursive` (Task 3b).
+- **B16 scope**: `vkCmdDrawMeshTasksEXT` sets `ActionFlags.MeshDispatch` (0x0008) only, not `ActionFlags.Drawcall` (0x0002). The fix must not alter the `_DISPATCH` (0x0004) classification — mesh draws are not dispatches.

--- a/openspec/changes/2026-02-23-fix-bugs-b10-b15-b16/test-plan.md
+++ b/openspec/changes/2026-02-23-fix-bugs-b10-b15-b16/test-plan.md
@@ -1,0 +1,327 @@
+# Test Plan: Fix Bugs B10 + B15 + B16
+
+## B10: Transport overflow for `debug thread`
+
+### Root Cause Summary
+
+`send_request` in `daemon_client.py` calls `recv_line(sock)` with the default
+`max_bytes=10 * 1024 * 1024` (10 MB). Large compute shader debug traces (many
+steps × many variables) serialize to JSON that exceeds this limit, raising
+`ValueError: recv_line: message exceeds max_bytes limit`. The fix must raise
+the limit or stream the response differently. A secondary defect is that when
+`_daemon_call` receives an error response (via `SystemExit` or the raw error
+dict path), the `--json` mode does not propagate `rc=1`.
+
+### Unit tests — `tests/unit/test_daemon_transport.py`
+
+**`test_recv_line_large_message_at_limit`**
+- Create a mock socket returning a single chunk of exactly `max_bytes` bytes
+  containing a newline at the end.
+- Call `recv_line(sock, max_bytes=N)`.
+- Assert: returns the decoded string without raising.
+
+**`test_recv_line_large_message_just_over_limit`**
+- Mock socket emits two chunks; combined length is `max_bytes + 1`.
+- Assert: `ValueError` with message matching `"max_bytes"`.
+
+**`test_recv_line_multi_chunk_large_valid`**
+- Mock socket returns 3 chunks totalling less than `max_bytes`, newline in
+  final chunk.
+- Assert: result equals the expected decoded string.
+
+**`test_recv_line_default_limit_is_large_enough_for_debug`**
+- Construct a JSON payload resembling a debug trace with 2000 steps and 10
+  variables per step (~1 MB of JSON).
+- Encode as bytes + `\n`, serve via a mock socket in 4096-byte chunks.
+- Call `recv_line(sock)` (default limit).
+- Assert: does not raise; returns the full JSON string.
+
+### Unit tests — `tests/unit/test_debug_commands.py`
+
+These extend the existing `_patch_helpers` pattern in the file.
+
+**`test_debug_thread_error_json_rc1`**
+- Patch `_helpers.send_request` to return `_ERROR_RESPONSE`.
+- Invoke `["debug", "thread", "150", "0", "0", "0", "0", "0", "0", "--json"]`.
+- Assert: `result.exit_code == 1`.
+- Rationale: B10 symptom says `--json` mode returns `rc=0` on daemon error;
+  this must become `rc=1`.
+
+**`test_debug_thread_error_trace_rc1`**
+- Same error response, invoke with `["...", "--trace"]`.
+- Assert: `result.exit_code == 1`.
+
+**`test_debug_thread_error_plain_rc1`**
+- Same error response, plain invocation.
+- Assert: `result.exit_code == 1`.
+
+**`test_debug_thread_success_json_rc0`**
+- Patch to return `{"result": _THREAD_HAPPY_RESPONSE}`.
+- Invoke with `["...", "--json"]`.
+- Assert: `result.exit_code == 0`; output is valid JSON with `stage == "cs"`.
+
+**`test_debug_thread_transport_error_json_rc1`**
+- Patch `_helpers.send_request` to raise `ValueError("recv_line: message exceeds max_bytes limit")`.
+- Invoke with `["debug", "thread", "150", "0", "0", "0", "0", "0", "0", "--json"]`.
+- Assert: `result.exit_code == 1`; stderr contains an informative message.
+
+**`test_debug_thread_transport_error_plain_rc1`**
+- Same `ValueError` raise, plain invocation.
+- Assert: `result.exit_code == 1`.
+
+**`test_call_catches_value_error`**
+- Directly test the `call()` function in `_helpers.py` with `send_request` raising `ValueError`.
+- Assert: `SystemExit(1)` is raised. This covers all commands since `call()` is shared.
+
+### Integration tests — `tests/unit/test_debug_handlers.py`
+
+**`test_debug_thread_large_trace_handler_level`**
+- Build a dispatch state with a mock controller whose `ContinueDebug` returns
+  a list of 2000 `ShaderDebugState` objects, each with 10 variable changes.
+- Call `_handle_request(_req("debug_thread", {...}), state)`.
+- Assert: `"result" in resp`; `resp["result"]["total_steps"] == 2000`.
+- This validates the handler does not truncate internally; overflow only occurs
+  in the transport layer.
+
+### GPU tests — `tests/integration/test_daemon_handlers_real.py`
+
+No new GPU test is required for B10 because the transport limit is a
+protocol-layer concern tested above. If a `compute_nbody.rdc` fixture is
+available, add:
+
+**`test_debug_thread_compute_nbody`** *(conditional, skip if fixture absent)*
+- `pytest.importorskip` / `pytest.mark.skipif` guards.
+- Call `_call(state, "debug_thread", {"eid": <dispatch_eid>, "gx": 0, ...})`.
+- Assert: `"total_steps"` key present; no exception raised.
+
+---
+
+## B15: `shader-map` Dispatch EID column mapping
+
+### Root Cause Summary
+
+`collect_shader_map` in `query_service.py` uses `STAGE_MAP` (integer keys
+`0..5`). When iterating `stage_cols = {0: "vs", ..., 5: "cs"}`, it calls
+`state.GetShader(stage_val)` for every stage regardless of pipeline type. For
+a Dispatch action the compute pipeline only binds `cs` (stage 5), yet
+`GetShader(4)` (PS) accidentally returns the CS shader ID because the mock (or
+real API) falls back to a non-zero value. The fix must ensure that for
+Dispatch-flagged actions only the `cs` column is populated, and for Draw-
+flagged actions only graphics columns (`vs`, `hs`, `ds`, `gs`, `ps`) are
+populated.
+
+### Unit tests — `tests/unit/test_count_shadermap.py`
+
+Add inside `TestShaderMapCollection`:
+
+**`test_shader_map_dispatch_only_populates_cs`**
+- Build actions with one `_dispatch(eid=8, ...)`.
+- Build `pipe_states = {8: _make_pipe_state(cs=99)}` where `vs=ps=0`.
+- Call `collect_shader_map(actions, pipe_states)`.
+- Assert: `rows[0]["cs"] == 99`.
+- Assert: `rows[0]["vs"] == "-"` and `rows[0]["ps"] == "-"`.
+
+**`test_shader_map_dispatch_no_graphics_shader_leak`**
+- Build actions with one `_dispatch(eid=11, ...)`.
+- Build a `MockPipeState` where `GetShader(4)` (PS stage) returns a non-zero
+  ID (simulating the bug: CS shader leaking into PS slot).
+- Call `collect_shader_map(actions, pipe_states)`.
+- Assert: `rows[0]["ps"] == "-"` (the fix must enforce this for Dispatch).
+- Assert: `rows[0]["cs"]` is the expected non-zero value.
+
+**`test_shader_map_mixed_draw_and_dispatch`**
+- Actions: `[_indexed_draw(8, "draw"), _dispatch(11, "dispatch")]`.
+- `pipe_states`: draw has VS+PS shaders, dispatch has only CS shader.
+- Call `collect_shader_map(actions, pipe_states)`.
+- Assert: row for EID 8 has `vs != "-"`, `ps != "-"`, `cs == "-"`.
+- Assert: row for EID 11 has `cs != "-"`, `vs == "-"`, `ps == "-"`.
+
+**`test_shader_map_draw_does_not_show_cs`**
+- Build a `_indexed_draw(42, ...)` with a `MockPipeState` where `GetShader(5)`
+  (CS) would return a non-zero sentinel (bug scenario for graphics draws).
+- Call `collect_shader_map(actions, pipe_states)`.
+- Assert: `rows[0]["cs"] == "-"` (CS must not appear for a Draw action).
+
+### Integration tests — daemon handler level
+
+**`test_shader_map_dispatch_columns_daemon`** in `tests/unit/test_count_shadermap.py`
+inside `TestDaemonShaderMapMethod`:
+
+- Build actions with both a draw (EID 8, VS+PS) and a dispatch (EID 11, CS).
+- Set up adapter mocks so `get_root_actions` returns both actions and
+  `get_pipeline_state` returns the correct state per EID.
+- Call `_handle_request({"method": "shader_map", ...}, state)`.
+- Assert: row for EID 8 has non-null `vs` and `ps`, `cs == "-"`.
+- Assert: row for EID 11 has non-null `cs`, `vs == "-"`, `ps == "-"`.
+
+### GPU tests
+
+**`test_shader_map_compute_nbody_dispatch_columns`** *(skip if fixture absent)*
+- Load `compute_nbody.rdc`; it contains 2 Dispatch + 3 Draw actions.
+- Call `_call(state, "shader_map")`.
+- Assert: rows for EIDs 8 and 11 (Dispatch) have `cs != "-"`, `vs == "-"`, `ps == "-"`.
+- Assert: rows for Draw EIDs have `ps != "-"`, `cs == "-"`.
+
+---
+
+## B16: `vkCmdDrawMeshTasksEXT` classified as "Other"
+
+### Root Cause Summary
+
+`_action_type_str` in `handlers/_helpers.py` checks for `_DRAWCALL (0x0002)`,
+`_DISPATCH (0x0004)`, `_CLEAR`, `_COPY`, `_BEGIN_PASS`, `_END_PASS` and falls
+through to `"Other"`. RenderDoc sets `ActionFlags.MeshDispatch (0x0008)` for
+`vkCmdDrawMeshTasksEXT`. This flag is not `_DRAWCALL`, so the action is never
+classified as a draw. The fix must:
+1. Add `MeshDispatch` recognition in `_action_type_str` → return `"Draw"` (or
+   `"MeshDraw"`).
+2. Add `_MESH_DISPATCH = 0x0008` constant in `query_service.py` and include it
+   in the draw-detection predicate used by `filter_by_type`, `aggregate_stats`,
+   `count_from_actions`, and `collect_shader_map`.
+
+### Unit tests — `tests/unit/test_draws_events_daemon.py`
+
+**`test_mesh_dispatch_action_type_str`**
+- Import `_action_type_str` from `rdc.handlers._helpers`.
+- Call with `flags = 0x0008` (MeshDispatch only).
+- Assert: return value is `"Draw"` or `"MeshDraw"` (not `"Other"`).
+
+**`test_mesh_dispatch_classified_as_draw_in_events`**
+- Build a single `ActionDescription(eventId=10, flags=ActionFlags.MeshDispatch, _name="vkCmdDrawMeshTasksEXT")`.
+- Build `DaemonState` with this action tree.
+- Call `_handle_request({"method": "events", ...}, state)`.
+- Assert: the event row for EID 10 has `"type"` not equal to `"Other"`.
+- Assert: `"type"` equals `"Draw"` or `"MeshDraw"`.
+
+**`test_mesh_dispatch_included_in_draws_list`**
+- Same action tree.
+- Call `_handle_request({"method": "draws", ...}, state)`.
+- Assert: `resp["result"]["draws"]` contains an entry with `"eid" == 10`.
+
+**`test_mesh_dispatch_counted_as_draw`**
+- Same action tree.
+- Call `_handle_request({"method": "count", "params": {"_token": "tok", "what": "draws"}}, state)`.
+- Assert: `resp["result"]["value"] == 1`.
+
+**`test_mesh_dispatch_in_info_draw_calls`**
+- Call `_handle_request({"method": "info", ...}, state)`.
+- Assert: `"Draw Calls"` field in result contains `"1"` (not `"0"`).
+
+**`test_mesh_dispatch_not_classified_as_dispatch`**
+- Call `count` with `what="dispatches"` on a mesh-dispatch-only action tree.
+- Assert: `value == 0` (mesh draw is not a compute dispatch).
+
+### Unit tests — `tests/unit/test_count_shadermap.py`
+
+**`test_count_mesh_dispatch_as_draw`** in `TestCountAggregation`:
+- Build actions with one `ActionDescription(flags=ActionFlags.MeshDispatch)`.
+- Call `count_from_actions(actions, "draws")`.
+- Assert: returns `1`.
+
+**`test_shader_map_includes_mesh_dispatch`** in `TestShaderMapCollection`:
+- Build actions with one `ActionDescription(flags=ActionFlags.MeshDispatch, eventId=10)`.
+- Build `pipe_states = {10: _make_pipe_state(vs=1, ps=2)}`.
+- Call `collect_shader_map(actions, pipe_states)`.
+- Assert: `len(rows) == 1`; `rows[0]["eid"] == 10`.
+
+### Unit tests — `tests/unit/test_draws_events_cli.py` (or new file)
+
+**`test_events_mesh_draw_type`**
+- Patch `_daemon_call` to return events with `type="MeshDraw"` or `"Draw"` for EID 10.
+- Invoke `["events"]` via `CliRunner`.
+- Assert: EID 10 appears in output; `"Other"` does not appear for it.
+
+**`test_draws_mesh_draw_included`**
+- Patch `_daemon_call` to return draws including EID 10.
+- Invoke `["draws"]` via `CliRunner`.
+- Assert: EID 10 appears in draw output.
+
+### GPU tests
+
+**`test_events_mesh_shading_type`** *(skip if `mesh_shading.rdc` absent)*
+- Load `mesh_shading.rdc`.
+- Call `_call(state, "events")`.
+- Assert: the event for EID 10 (`vkCmdDrawMeshTasksEXT`) has `type != "Other"`.
+
+**`test_draws_includes_mesh_shading_eid`** *(skip if fixture absent)*
+- Call `_call(state, "draws")`.
+- Assert: EID 10 appears in `draws` list.
+
+**`test_info_counts_mesh_draw`** *(skip if fixture absent)*
+- Call `_call(state, "info")`.
+- Assert: `"Draw Calls"` contains `"1"` (not `"0"`).
+
+---
+
+## Regression tests
+
+**`test_recv_line_eof_still_returns_empty`**
+- Existing test in `test_daemon_transport.py`; verify it still passes unchanged.
+
+**`test_recv_line_within_limit`**
+- Existing test; verify the small-message path is unaffected by any limit change.
+
+**`test_debug_thread_happy_path`**
+- Existing test in `test_debug_handlers.py`; must still pass — the fix must not
+  break the successful 2-step trace.
+
+**`test_debug_pixel_error_json_rc1`**
+- Already present in `test_debug_commands.py`; must still pass (regression guard
+  for `debug pixel`'s `--json` exit-code fix, analogous to B10 for `debug thread`).
+
+**`test_shader_map_basic`**
+- Existing test in `test_count_shadermap.py`; must still pass — the Draw-only
+  path must not be broken by the B15 fix.
+
+**`test_shader_map_compute_only`**
+- Existing test; must still pass — the CS-only path is the canonical positive
+  case for B15.
+
+**`test_count_draws`** / **`test_count_dispatches`**
+- Existing tests; must still pass to confirm B16 fix does not double-count.
+
+---
+
+## Test matrix
+
+| Test | Type | File | Covers |
+|------|------|------|--------|
+| `test_recv_line_large_message_at_limit` | unit | `test_daemon_transport.py` | B10 |
+| `test_recv_line_large_message_just_over_limit` | unit | `test_daemon_transport.py` | B10 |
+| `test_recv_line_multi_chunk_large_valid` | unit | `test_daemon_transport.py` | B10 |
+| `test_recv_line_default_limit_is_large_enough_for_debug` | unit | `test_daemon_transport.py` | B10 |
+| `test_debug_thread_error_json_rc1` | unit | `test_debug_commands.py` | B10 |
+| `test_debug_thread_error_trace_rc1` | unit | `test_debug_commands.py` | B10 |
+| `test_debug_thread_error_plain_rc1` | unit | `test_debug_commands.py` | B10 |
+| `test_debug_thread_success_json_rc0` | unit | `test_debug_commands.py` | B10 |
+| `test_debug_thread_transport_error_json_rc1` | unit | `test_debug_commands.py` | B10 |
+| `test_debug_thread_transport_error_plain_rc1` | unit | `test_debug_commands.py` | B10 |
+| `test_debug_thread_large_trace_handler_level` | unit | `test_debug_handlers.py` | B10 |
+| `test_debug_thread_compute_nbody` | gpu | `test_daemon_handlers_real.py` | B10 |
+| `test_shader_map_dispatch_only_populates_cs` | unit | `test_count_shadermap.py` | B15 |
+| `test_shader_map_dispatch_no_graphics_shader_leak` | unit | `test_count_shadermap.py` | B15 |
+| `test_shader_map_mixed_draw_and_dispatch` | unit | `test_count_shadermap.py` | B15 |
+| `test_shader_map_draw_does_not_show_cs` | unit | `test_count_shadermap.py` | B15 |
+| `test_shader_map_dispatch_columns_daemon` | unit | `test_count_shadermap.py` | B15 |
+| `test_shader_map_compute_nbody_dispatch_columns` | gpu | `test_daemon_handlers_real.py` | B15 |
+| `test_mesh_dispatch_action_type_str` | unit | `test_draws_events_daemon.py` | B16 |
+| `test_mesh_dispatch_classified_as_draw_in_events` | unit | `test_draws_events_daemon.py` | B16 |
+| `test_mesh_dispatch_included_in_draws_list` | unit | `test_draws_events_daemon.py` | B16 |
+| `test_mesh_dispatch_counted_as_draw` | unit | `test_draws_events_daemon.py` | B16 |
+| `test_mesh_dispatch_in_info_draw_calls` | unit | `test_draws_events_daemon.py` | B16 |
+| `test_mesh_dispatch_not_classified_as_dispatch` | unit | `test_draws_events_daemon.py` | B16 |
+| `test_count_mesh_dispatch_as_draw` | unit | `test_count_shadermap.py` | B16 |
+| `test_shader_map_includes_mesh_dispatch` | unit | `test_count_shadermap.py` | B16 |
+| `test_events_mesh_draw_type` | unit | `test_draws_events_cli.py` | B16 |
+| `test_draws_mesh_draw_included` | unit | `test_draws_events_cli.py` | B16 |
+| `test_events_mesh_shading_type` | gpu | `test_daemon_handlers_real.py` | B16 |
+| `test_draws_includes_mesh_shading_eid` | gpu | `test_daemon_handlers_real.py` | B16 |
+| `test_info_counts_mesh_draw` | gpu | `test_daemon_handlers_real.py` | B16 |
+| `test_recv_line_eof_still_returns_empty` | regression | `test_daemon_transport.py` | B10 |
+| `test_recv_line_within_limit` | regression | `test_daemon_transport.py` | B10 |
+| `test_debug_thread_happy_path` | regression | `test_debug_handlers.py` | B10 |
+| `test_debug_pixel_error_json_rc1` | regression | `test_debug_commands.py` | B10 |
+| `test_shader_map_basic` | regression | `test_count_shadermap.py` | B15 |
+| `test_shader_map_compute_only` | regression | `test_count_shadermap.py` | B15 |
+| `test_count_draws` | regression | `test_count_shadermap.py` | B15/B16 |
+| `test_count_dispatches` | regression | `test_count_shadermap.py` | B15/B16 |

--- a/src/rdc/_transport.py
+++ b/src/rdc/_transport.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import socket
 
 
-def recv_line(sock: socket.socket, max_bytes: int = 10 * 1024 * 1024) -> str:
+def recv_line(sock: socket.socket, max_bytes: int = 256 * 1024 * 1024) -> str:
     """Read one newline-terminated line from a socket.
 
     Args:

--- a/src/rdc/commands/_helpers.py
+++ b/src/rdc/commands/_helpers.py
@@ -57,7 +57,7 @@ def call(method: str, params: dict[str, Any]) -> dict[str, Any]:
     payload = _request(method, 1, {"_token": token, **params}).to_dict()
     try:
         response = send_request(host, port, payload)
-    except OSError as exc:
+    except (OSError, ValueError) as exc:
         msg = f"daemon unreachable: {exc}"
         if _json_mode():
             click.echo(json.dumps({"error": {"message": msg}}), err=True)

--- a/src/rdc/daemon_server.py
+++ b/src/rdc/daemon_server.py
@@ -104,7 +104,7 @@ class DaemonState:
     rd: Any = None
     disasm_cache: dict[int, str] = field(default_factory=dict)
     shader_meta: dict[int, dict[str, Any]] = field(default_factory=dict)
-    _pipe_states_cache: dict[int, Any] = field(default_factory=dict)
+    _pipe_states_cache: dict[int, dict[int, int]] = field(default_factory=dict)
     built_shaders: dict[int, Any] = field(default_factory=dict)
     shader_replacements: dict[int, Any] = field(default_factory=dict)
     replay_output: Any = None

--- a/src/rdc/handlers/query.py
+++ b/src/rdc/handlers/query.py
@@ -283,11 +283,11 @@ def _handle_stats(
     top = get_top_draws(flat, limit=3)
 
     # Find a representative draw EID per pass for RT enrichment
-    from rdc.services.query_service import _DRAWCALL
+    from rdc.services.query_service import _DRAWCALL, _MESHDRAW
 
     pass_first_draw: dict[str, int] = {}
     for a in flat:
-        if (a.flags & _DRAWCALL) and a.pass_name not in pass_first_draw:
+        if (a.flags & (_DRAWCALL | _MESHDRAW)) and a.pass_name not in pass_first_draw:
             pass_first_draw[a.pass_name] = a.eid
     for ps in stats.per_pass:
         draw_eid = pass_first_draw.get(ps.name)


### PR DESCRIPTION
## Summary
- **B10 (P1)**: Raise `recv_line` max_bytes from 10MB to 256MB and catch `ValueError` in `call()` — fixes `debug thread` crash on large compute shader traces and `--json` mode silently returning RC=0
- **B15 (P2)**: Snapshot shader IDs in `_build_shader_cache` instead of storing mutable pipeline reference, and restrict `_collect_recursive` stage queries per action type — fixes `shader-map` showing CS shader IDs in VS/PS columns for Dispatch events
- **B16 (P2)**: Add `_MESHDRAW` (0x0008) constant and include in all draw predicates — fixes `vkCmdDrawMeshTasksEXT` being classified as "Other" instead of "Draw"

## Test plan
- [x] 1857 unit tests pass, 95.25% coverage
- [x] 19 new tests covering all three fixes
- [x] Manual test: `debug thread` on `compute_nbody.rdc` — 15.08 MB payload succeeds (was crashing at 10 MB)
- [x] Manual test: `shader-map` on `compute_nbody.rdc` — Dispatch EIDs show CS only, Draw EIDs show VS/PS only
- [x] Manual test: `events`/`draws`/`info` on `mesh_shading.rdc` — `vkCmdDrawMeshTasksEXT` classified as "Draw", counted in draw calls
- [x] Pre-push e2e: 26/26 passed
- [x] Lint + typecheck + test all clean