### PR TITLE
feat(platform): add Windows CI, doctor checks, and platform stubs (W3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,12 +95,13 @@ jobs:
         run: uv run mypy src
 
   test:
-    name: Test (py${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    name: Test (py${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.12", "3.14"]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/docs-astro/src/layouts/Docs.astro
+++ b/docs-astro/src/layouts/Docs.astro
@@ -15,6 +15,7 @@ const currentPath = Astro.url.pathname.replace(/\/$/, '');
 const sidebar = [
   { label: 'Overview', href: `${base}docs/` },
   { label: 'Installation', href: `${base}docs/install/` },
+  { label: 'Windows Install', href: `${base}docs/install/windows/` },
   { label: 'Usage Patterns', href: `${base}docs/usage/` },
   { label: 'Commands', href: `${base}docs/commands/` },
   { label: 'VFS Paths', href: `${base}docs/vfs/` },

--- a/docs-astro/src/pages/docs/install/windows.astro
+++ b/docs-astro/src/pages/docs/install/windows.astro
@@ -1,0 +1,105 @@
+---
+import Docs from '../../../layouts/Docs.astro';
+---
+
+<Docs title="Windows Installation">
+  <h2>Prerequisites</h2>
+  <ul>
+    <li>Windows 10 / 11 64-bit</li>
+    <li>Python 3.12.x (exact minor version must match the renderdoc <code>.pyd</code>)</li>
+    <li>Visual Studio 2022 Build Tools with "Desktop development with C++" workload</li>
+    <li>Git (for building renderdoc from source)</li>
+  </ul>
+
+  <h2>Install rdc-cli</h2>
+  <pre><code>pip install rdc-cli</code></pre>
+  <p>
+    This installs the <code>rdc</code> command. You still need the renderdoc
+    Python module &mdash; see below.
+  </p>
+
+  <h2>RenderDoc Python Module</h2>
+  <p>
+    The renderdoc Python module (<code>renderdoc.cpython-3*.pyd</code>) is
+    <strong>not</strong> available on PyPI. Your Python minor version must
+    exactly match the one used to compile the module.
+  </p>
+
+  <h3>Option A: RenderDoc Installer</h3>
+  <p>
+    Download and install
+    <a href="https://renderdoc.org/builds">RenderDoc for Windows</a>.
+    The installer places <code>renderdoc.dll</code> in
+    <code>C:\Program Files\RenderDoc</code>. The Python bindings
+    (<code>.pyd</code>) may be included depending on the installer version.
+  </p>
+
+  <h3>Option B: Build from Source</h3>
+  <p>
+    A cross-platform build script is planned for Phase W2. In the meantime,
+    see <code>scripts/build_renderdoc.py</code> (coming in Phase W2) or
+    build manually:
+  </p>
+  <pre><code>git clone --depth 1 https://github.com/baldurk/renderdoc.git
+cd renderdoc
+cmake -B build -G "Visual Studio 17 2022" -DENABLE_PYRENDERDOC=ON -DENABLE_QRENDERDOC=OFF
+cmake --build build --config Release
+set RENDERDOC_PYTHON_PATH=%cd%\build\lib\Release</code></pre>
+
+  <h2>Configure RENDERDOC_PYTHON_PATH</h2>
+  <p>
+    Set the environment variable to point at the directory containing the
+    <code>.pyd</code> file:
+  </p>
+  <pre><code>set RENDERDOC_PYTHON_PATH=C:\path\to\renderdoc\build\lib</code></pre>
+  <p>
+    To make it permanent, add it via
+    <strong>System Properties &rarr; Environment Variables</strong>.
+  </p>
+
+  <h2>Validate with rdc doctor</h2>
+  <pre><code>rdc doctor</code></pre>
+  <p>
+    A successful output on Windows shows 8 checks, including the three
+    Windows-specific checks:
+  </p>
+  <ul>
+    <li><code>win-python-version</code> &mdash; Python version matches <code>.pyd</code></li>
+    <li><code>win-vs-build-tools</code> &mdash; Visual Studio Build Tools detected</li>
+    <li><code>win-renderdoc-install</code> &mdash; RenderDoc <code>.dll</code> found</li>
+  </ul>
+
+  <h2>Known Limitations</h2>
+  <ul>
+    <li>
+      Daemon process management (<code>rdc session start</code>) is not yet
+      functional on Windows. Phase W2 will implement the required OS-level
+      process APIs.
+    </li>
+    <li>
+      All analysis commands (<code>rdc open</code>, <code>rdc info</code>,
+      <code>rdc shaders</code>, etc.) will work once the daemon is running.
+    </li>
+  </ul>
+
+  <h2>Troubleshooting</h2>
+  <h3>Python version mismatch</h3>
+  <p>
+    If <code>rdc doctor</code> reports a version mismatch between your
+    running Python and the <code>.pyd</code>, install the matching Python
+    version or rebuild renderdoc with your current Python.
+  </p>
+
+  <h3>renderdoc module not found</h3>
+  <p>
+    Ensure <code>RENDERDOC_PYTHON_PATH</code> points to the directory
+    containing <code>renderdoc.pyd</code> (not <code>renderdoc.dll</code>).
+  </p>
+
+  <h3>vswhere.exe not found</h3>
+  <p>
+    Install <a href="https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022">
+    Visual Studio 2022 Build Tools</a> with the "Desktop development with
+    C++" workload selected.
+  </p>
+</Docs>

--- a/tests/unit/test_build_renderdoc.py
+++ b/tests/unit/test_build_renderdoc.py
@@ -64,11 +64,13 @@ def test_default_install_dir_windows() -> None:
 
 
 def test_default_install_dir_windows_no_localappdata() -> None:
+    fake_home = Path("/fake/home")
     with (
         patch("build_renderdoc._platform", return_value="windows"),
         patch.dict("os.environ", {}, clear=True),
+        patch("build_renderdoc.Path.home", return_value=fake_home),
     ):
-        assert br.default_install_dir() == Path.home() / "rdc" / "renderdoc"
+        assert br.default_install_dir() == fake_home / "rdc" / "renderdoc"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -327,7 +328,8 @@ def test_fallback_capture_path_on_stdout(monkeypatch: Any) -> None:
 
     result = CliRunner().invoke(capture_cmd, ["-o", "/tmp/out.rdc", "--", "/usr/bin/app"])
     assert result.exit_code == 0
-    assert any("/tmp/out.rdc" in s for s in stdout_lines)
+    expected_path = str(Path("/tmp/out.rdc"))
+    assert any(expected_path in s for s in stdout_lines)
     assert all("next:" not in s for s in stdout_lines)
 
 

--- a/tests/unit/test_capture_control.py
+++ b/tests/unit/test_capture_control.py
@@ -21,7 +21,7 @@ from rdc.target_state import TargetControlState, save_target_state
 
 @pytest.fixture(autouse=True)
 def _isolate_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
 
 
 def _make_mock_tc(

--- a/tests/unit/test_capture_core.py
+++ b/tests/unit/test_capture_core.py
@@ -250,6 +250,9 @@ class TestExecuteAndCapture:
 
 
 class TestTerminateProcess:
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Unix signals: Windows uses TerminateProcess"
+    )
     def test_sends_sigterm(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from rdc.capture_core import terminate_process
 

--- a/tests/unit/test_cli_session_flag.py
+++ b/tests/unit/test_cli_session_flag.py
@@ -76,6 +76,7 @@ def test_session_flag_valid_chars(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
 def test_two_sessions_isolated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Two named sessions return independent data from their respective files."""
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.delenv("RDC_SESSION", raising=False)
     monkeypatch.setattr("rdc.services.session_service._renderdoc_available", lambda: False)
     runner = CliRunner()

--- a/tests/unit/test_daemon_server_unit.py
+++ b/tests/unit/test_daemon_server_unit.py
@@ -251,6 +251,7 @@ class TestTempDirCleanup:
 class TestSigtermHandler:
     """SIGTERM handler installation in main()."""
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Unix signals: SIGTERM not used on Windows")
     def test_main_installs_sigterm_handler(self) -> None:
         """main() installs a SIGTERM handler that calls sys.exit(0)."""
         with (

--- a/tests/unit/test_diff_framebuffer.py
+++ b/tests/unit/test_diff_framebuffer.py
@@ -492,7 +492,7 @@ class TestCliFramebufferOutput:
         )
         a, b = _setup_cli(monkeypatch, tmp_path, fb_result=fb)
         result = CliRunner().invoke(diff_cmd, [str(a), str(b), "--framebuffer"])
-        assert "diff image: /tmp/d.png" in result.output
+        assert f"diff image: {Path('/tmp/d.png')}" in result.output
 
     def test_no_diff_output_line(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         fb = FramebufferDiffResult(

--- a/tests/unit/test_session_commands.py
+++ b/tests/unit/test_session_commands.py
@@ -13,7 +13,7 @@ def _session_file(home: Path) -> Path:
 
 
 def test_open_status_goto_close_flow(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.delenv("RDC_SESSION", raising=False)
     monkeypatch.setattr("rdc.services.session_service._renderdoc_available", lambda: False)
     runner = CliRunner()
@@ -40,7 +40,7 @@ def test_open_status_goto_close_flow(monkeypatch: pytest.MonkeyPatch, tmp_path: 
 
 
 def test_goto_without_session_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.delenv("RDC_SESSION", raising=False)
     runner = CliRunner()
 
@@ -49,7 +49,7 @@ def test_goto_without_session_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: P
 
 
 def test_close_without_session_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.delenv("RDC_SESSION", raising=False)
     runner = CliRunner()
 
@@ -58,7 +58,7 @@ def test_close_without_session_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: 
 
 
 def test_goto_rejects_negative_eid(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.delenv("RDC_SESSION", raising=False)
     monkeypatch.setattr("rdc.services.session_service._renderdoc_available", lambda: False)
     runner = CliRunner()
@@ -70,7 +70,7 @@ def test_goto_rejects_negative_eid(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
 
 def test_status_shows_session_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """rdc status first line is 'session: <name>' matching active RDC_SESSION."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.setenv("RDC_SESSION", "mytest")
     monkeypatch.setattr("rdc.services.session_service._renderdoc_available", lambda: False)
     runner = CliRunner()
@@ -84,7 +84,7 @@ def test_status_shows_session_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
 
 def test_status_shows_default_session_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Without --session, status first line is 'session: default'."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.delenv("RDC_SESSION", raising=False)
     monkeypatch.setattr("rdc.services.session_service._renderdoc_available", lambda: False)
     runner = CliRunner()
@@ -122,7 +122,7 @@ def test_require_session_cleans_stale_pid(monkeypatch: pytest.MonkeyPatch) -> No
 
 def test_open_no_replay_mode_warning(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """B23: open command warns when renderdoc is unavailable."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.delenv("RDC_SESSION", raising=False)
     monkeypatch.setattr("rdc.services.session_service._renderdoc_available", lambda: False)
     runner = CliRunner()

--- a/tests/unit/test_session_service.py
+++ b/tests/unit/test_session_service.py
@@ -38,7 +38,7 @@ def test_open_session_cross_name_no_conflict(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Opening session 'b' while 'a' is alive succeeds (conflict is per-name)."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.setattr(session_service, "_renderdoc_available", lambda: False)
 
     # Open session "a"
@@ -56,7 +56,7 @@ def test_open_session_same_name_alive_fails(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Opening the same session name twice (alive pid) returns error."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.setenv("RDC_SESSION", "alpha")
     monkeypatch.setattr(session_service, "_renderdoc_available", lambda: False)
 
@@ -114,7 +114,7 @@ def test_wait_for_ping_works_without_proc(monkeypatch: pytest.MonkeyPatch) -> No
 def test_open_session_reports_stderr_on_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.setattr(session_service, "load_session", lambda: None)
     monkeypatch.setattr(session_service, "_renderdoc_available", lambda: False)
 
@@ -137,7 +137,7 @@ def test_open_session_reports_stderr_on_failure(
 def test_open_session_failure_with_empty_stderr(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.setattr(session_service, "load_session", lambda: None)
     monkeypatch.setattr(session_service, "_renderdoc_available", lambda: False)
 
@@ -189,7 +189,7 @@ def test_open_session_retries_on_port_conflict(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """B22: open_session retries up to 3 times on daemon start failure."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.delenv("RDC_SESSION", raising=False)
     monkeypatch.setattr(session_service, "load_session", lambda: None)
     monkeypatch.setattr(session_service, "_renderdoc_available", lambda: False)
@@ -217,7 +217,7 @@ def test_open_session_retries_on_port_conflict(
 
 def test_open_session_all_retries_fail(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """B22: open_session returns error after 3 failed attempts."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.delenv("RDC_SESSION", raising=False)
     monkeypatch.setattr(session_service, "load_session", lambda: None)
     monkeypatch.setattr(session_service, "_renderdoc_available", lambda: False)
@@ -239,7 +239,7 @@ def test_close_session_fallback_kill_on_shutdown_error(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """B25: close_session sends SIGTERM as fallback when shutdown RPC fails."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
     monkeypatch.delenv("RDC_SESSION", raising=False)
     monkeypatch.setattr(session_service, "_renderdoc_available", lambda: False)
 

--- a/tests/unit/test_shader_preload.py
+++ b/tests/unit/test_shader_preload.py
@@ -253,7 +253,7 @@ class TestHandlePreload:
 
 class TestOpenPreloadFlag:
     def test_preload_calls_rpc(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
         monkeypatch.delenv("RDC_SESSION", raising=False)
         monkeypatch.setattr("rdc.services.session_service._renderdoc_available", lambda: False)
 
@@ -279,7 +279,7 @@ class TestOpenPreloadFlag:
     def test_no_preload_does_not_call_rpc(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
         monkeypatch.delenv("RDC_SESSION", raising=False)
         monkeypatch.setattr("rdc.services.session_service._renderdoc_available", lambda: False)
 

--- a/tests/unit/test_target_state.py
+++ b/tests/unit/test_target_state.py
@@ -25,7 +25,7 @@ _SAMPLE = TargetControlState(
 
 @pytest.fixture(autouse=True)
 def _isolate_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
 
 
 def test_save_load() -> None:

--- a/tests/unit/test_tooling_files.py
+++ b/tests/unit/test_tooling_files.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
+import pytest
 
+
+@pytest.mark.skipif(sys.platform == "win32", reason="bash not available on Windows CI")
 def test_build_renderdoc_script_syntax() -> None:
     subprocess.run(["bash", "-n", "scripts/build-renderdoc.sh"], check=True)
 


### PR DESCRIPTION
## Summary

- Add `windows-latest` to CI test matrix (`test` job only, 3 Python versions x 2 OS = 6 jobs)
- Add three Windows-specific `rdc doctor` checks: `win-python-version`, `win-vs-build-tools`, `win-renderdoc-install`
- Extract `_make_build_hint(platform)` helper for testable platform-conditional build hints
- Implement `_platform.py` Windows stubs: `terminate_process`, `is_pid_alive`, `install_shutdown_signal`, `popen_flags`, `renderdoc_search_paths`, `renderdoccmd_search_paths`
- Add Windows installation docs page with sidebar navigation entry
- 17 new unit tests (TP-W3-001 through TP-W3-017) covering all Windows doctor check functions

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Add `os: [ubuntu-latest, windows-latest]` matrix dimension to `test` job |
| `src/rdc/_platform.py` | Replace `NotImplementedError` stubs with real Windows implementations (behind `# pragma: no cover`) |
| `src/rdc/commands/doctor.py` | Add `_make_build_hint()`, `_check_win_python_version()`, `_check_win_vs_build_tools()`, `_check_win_renderdoc_install()` |
| `tests/unit/test_doctor.py` | 17 new tests (4 existing unchanged), total 21 tests |
| `docs-astro/src/pages/docs/install/windows.astro` | New Windows installation guide |
| `docs-astro/src/layouts/Docs.astro` | Add "Windows Install" sidebar entry |

## Review fixes applied

1. Renamed `_check_win_renderdoc_paths` to `_check_win_renderdoc_install` -- checks for `.dll` as basic install verification
2. Extracted `_make_build_hint(platform: str) -> str` helper -- avoids `importlib.reload` in tests
3. Windows build hint references `scripts/build_renderdoc.py` with placeholder note for W2
4. Existing `test_doctor_shows_build_hint_when_renderdoc_missing` verified passing (Linux hint unchanged)
5. TP-W3-017 asserts Windows has exactly 3 MORE checks than Linux (not hardcoded totals)

## Test plan

- [x] `pixi run lint` -- zero errors
- [x] `pixi run typecheck` -- mypy strict passes
- [x] `pixi run test` -- 1916 tests pass, 95.22% coverage
- [x] `rdc doctor` on Linux shows exactly 5 checks, exit 0
- [x] E2E tests: 26/26 pass
- [ ] CI: verify 6 test matrix jobs (3 Linux + 3 Windows) all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full Windows platform support, including process management and system detection capabilities.
  * Added Windows-specific health checks in the doctor diagnostic command.

* **Documentation**
  * Added comprehensive Windows installation guide with prerequisites, setup, and troubleshooting.

* **Tests**
  * Expanded CI testing to run across both Windows and Linux environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->