### PR TITLE
fix(handlers): align GetConstantBlock/push constants with real API (B29-B31)

### DIFF
--- a/src/rdc/handlers/buffer.py
+++ b/src/rdc/handlers/buffer.py
@@ -140,7 +140,8 @@ def _handle_cbuffer_decode(  # noqa: PLR0912
     shader = pipe_state.GetShader(stage_val)
     entry = pipe_state.GetShaderEntryPoint(stage_val)
     if hasattr(pipe_state, "GetConstantBlock"):
-        cb_desc = pipe_state.GetConstantBlock(stage_val, target_idx, 0)
+        cb_used = pipe_state.GetConstantBlock(stage_val, target_idx, 0)
+        cb_desc = cb_used.descriptor
         cb_resource = cb_desc.resource
         cb_offset = getattr(cb_desc, "byteOffset", 0)
         cb_size = getattr(cb_desc, "byteSize", 0)

--- a/tests/mocks/mock_renderdoc.py
+++ b/tests/mocks/mock_renderdoc.py
@@ -1286,6 +1286,7 @@ class MockPipeState:
         self.rasterizer: RasterizerState | None = None
         self.depthStencil: DepthStencilState | None = None
         self.multisample: MultisampleState = MultisampleState()
+        self.pushconsts: bytes = b""
 
     def GetShader(self, stage: ShaderStage) -> ResourceId:
         return self._shaders.get(stage, ResourceId.Null())
@@ -1340,9 +1341,10 @@ class MockPipeState:
         stage: int,
         slot: int,
         array_idx: int,
-    ) -> Descriptor:
-        """Mock GetConstantBlock — returns descriptor with cbuffer resource."""
-        return self._cbuffer_descriptors.get((stage, slot), Descriptor())
+    ) -> UsedDescriptor:
+        """Mock GetConstantBlock — returns UsedDescriptor with cbuffer resource."""
+        desc = self._cbuffer_descriptors.get((stage, slot), Descriptor())
+        return UsedDescriptor(descriptor=desc)
 
     def GetAllUsedDescriptors(self, only_used: bool = True) -> list[UsedDescriptor]:
         """Mock GetAllUsedDescriptors — returns configured used descriptors."""


### PR DESCRIPTION
## Summary

- **B29 (P1):** `pipe_push_constants` rewrote to iterate `constantBlocks` with `bufferBacked=False` instead of non-existent `pushConstantRangeByteOffset/Size` properties
- **B30 (P1):** `GetConstantBlock` returns `UsedDescriptor` — unwrap via `.descriptor` in `shader_constants`, `cbuffer_decode`, and `pipe_push_constants` handlers
- **B31 (P2):** Expose raw push constant bytes as hex-encoded `raw_bytes` field
- Move `_flatten_shader_var` to `_helpers.py` for reuse across `shader.py` and `pipe_state.py`

## Test plan

- [x] 8 new tests in `TestPipePushConstants` (empty, buffer-backed, single stage, multi-stage, raw bytes, mixed)
- [x] Existing `shader_constants` and `cbuffer_decode` tests pass with `UsedDescriptor` unwrap
- [x] `pixi run lint && pixi run test` — 2055 passed, 95.21% coverage
- [x] E2e tests — 26/26 passed
- [ ] GPU probe on `conditional_rendering.rdc` (manual)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal shader variable inspection and constant block descriptor handling.
  * Enhanced push constants processing with more granular per-block and per-variable data extraction.

* **Tests**
  * Expanded test coverage for shader constant block scenarios, including buffered and non-buffered configurations.
  * Added validation for raw bytes and detailed variable contents in push constants results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->