### PR TITLE
refactor(tests): deduplicate helpers and remove sys.path hacks (Phase R1)

### DIFF
--- a/openspec/changes/2026-02-24-phase-r1-quick-wins/proposal.md
+++ b/openspec/changes/2026-02-24-phase-r1-quick-wins/proposal.md
@@ -1,0 +1,34 @@
+# Phase R1: Quick Wins — Deduplicate Source & Test Helpers
+
+## Motivation
+
+The codebase has accumulated mechanical duplication across 43+ test files and 2 source files.
+This PR eliminates the most widespread copy-paste patterns with zero behavioral change.
+
+## Changes
+
+### R1.1 Deduplicate `_require_renderdoc()`
+- Move identical function from `commands/remote.py` and `commands/capture_control.py` to `commands/_helpers.py`
+- Replace both call-sites with import
+
+### R1.2 Remove `sys.path.insert` from tests
+- Add `pythonpath = ["src"]` to `[tool.pytest.ini_options]` in `pyproject.toml`
+- Delete all `sys.path.insert(0, ...)` lines from 43+ test files
+- Remove now-unused `import sys` / `from pathlib import Path` where they become orphaned
+
+### R1.3 Unify `_req()` test helper
+- Create `tests/unit/conftest.py` with shared `rpc_request()` function
+- Replace 25+ local `_req()` definitions across daemon test files
+- Adapt call-sites: `_req(m, **kw)` → `rpc_request(m, kw)` (kwargs→dict)
+
+## Risks
+
+- **R1.2**: If any test relied on `sys.path` ordering, it would break. Mitigated: `pythonpath` does the same thing.
+- **R1.3**: Two `_req()` signatures exist (`**params` vs `params: dict`). Must handle both during migration.
+
+## Out of Scope
+
+- `_make_state()` consolidation (R2)
+- CLI monkeypatch helpers (R2)
+- Command layer unification (R3)
+- Handler consolidation (R4)

--- a/openspec/changes/2026-02-24-phase-r1-quick-wins/tasks.md
+++ b/openspec/changes/2026-02-24-phase-r1-quick-wins/tasks.md
@@ -1,0 +1,15 @@
+# Phase R1: Tasks
+
+## R1.1 Deduplicate `_require_renderdoc()` [0.25h]
+- [ ] Add `require_renderdoc()` to `src/rdc/commands/_helpers.py`
+- [ ] Replace in `commands/remote.py` — import from `_helpers`
+- [ ] Replace in `commands/capture_control.py` — import from `_helpers`
+
+## R1.2 Remove `sys.path.insert` from tests [0.5h]
+- [ ] Add `pythonpath = ["src"]` to `pyproject.toml [tool.pytest.ini_options]`
+- [ ] Remove `sys.path.insert` + orphaned imports from all 43+ test files
+
+## R1.3 Unify `_req()` test helper [1h]
+- [ ] Create `tests/unit/conftest.py` with `rpc_request(method, params=None)`
+- [ ] Replace all `_req()` definitions in daemon test files
+- [ ] Adapt call-sites from `_req(m, key=val)` to `rpc_request(m, {"key": val})`

--- a/openspec/changes/2026-02-24-phase-r1-quick-wins/test-plan.md
+++ b/openspec/changes/2026-02-24-phase-r1-quick-wins/test-plan.md
@@ -1,0 +1,20 @@
+# Phase R1: Test Plan
+
+## Validation Strategy
+
+Pure refactoring — no new tests needed. All 2135 existing tests must pass unchanged.
+
+## Acceptance Criteria
+
+1. `pixi run lint` passes (ruff + mypy)
+2. `pixi run test` passes — all 2135 tests green
+3. Coverage does not decrease from 94.92%
+4. No `sys.path.insert` remains in any test file
+5. No local `_req()` definition remains in daemon test files
+6. No duplicate `_require_renderdoc()` outside `_helpers.py`
+
+## Regression Checks
+
+- `grep -r "sys.path.insert" tests/` returns 0 matches
+- `grep -rn "def _req(" tests/unit/` returns 0 matches (only conftest.py has `rpc_request`)
+- `grep -rn "_require_renderdoc" src/rdc/commands/` shows only `_helpers.py` definition + imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ where = ["src"]
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["tests"]
+pythonpath = ["src", "tests/mocks", "scripts"]
 markers = ["gpu: requires real renderdoc module and GPU"]
 
 [tool.setuptools_scm]

--- a/src/rdc/commands/_helpers.py
+++ b/src/rdc/commands/_helpers.py
@@ -8,10 +8,11 @@ from typing import Any, cast
 import click
 
 from rdc.daemon_client import send_request
+from rdc.discover import find_renderdoc
 from rdc.protocol import _request
 from rdc.session_state import load_session
 
-__all__ = ["require_session", "call", "_json_mode"]
+__all__ = ["require_session", "require_renderdoc", "call", "_json_mode"]
 
 
 def _json_mode() -> bool:
@@ -21,6 +22,15 @@ def _json_mode() -> bool:
         return False
     params = ctx.params
     return bool(params.get("use_json") or params.get("output_json") or params.get("as_json"))
+
+
+def require_renderdoc() -> Any:
+    """Find and return the renderdoc module, or exit with error."""
+    rd = find_renderdoc()
+    if rd is None:
+        click.echo("error: renderdoc module not found", err=True)
+        raise SystemExit(1)
+    return rd
 
 
 def require_session() -> tuple[str, int, str]:

--- a/src/rdc/commands/capture_control.py
+++ b/src/rdc/commands/capture_control.py
@@ -10,21 +10,12 @@ from typing import Any
 
 import click
 
-from rdc.discover import find_renderdoc
+from rdc.commands._helpers import require_renderdoc
 from rdc.target_state import (
     TargetControlState,
     load_latest_target_state,
     save_target_state,
 )
-
-
-def _require_renderdoc() -> Any:
-    """Find and return the renderdoc module, or exit with error."""
-    rd = find_renderdoc()
-    if rd is None:
-        click.echo("error: renderdoc module not found", err=True)
-        raise SystemExit(1)
-    return rd
 
 
 def _resolve_ident(ident: int | None) -> int:
@@ -56,7 +47,7 @@ def _connect(rd: Any, host: str, ident: int) -> Any:
 @click.option("--host", default="localhost", help="Target host.")
 def attach_cmd(ident: int, host: str) -> None:
     """Attach to a running RenderDoc target by ident."""
-    rd = _require_renderdoc()
+    rd = require_renderdoc()
     tc = _connect(rd, host, ident)
     try:
         target = tc.GetTarget()
@@ -83,7 +74,7 @@ def attach_cmd(ident: int, host: str) -> None:
 def capture_trigger_cmd(ident: int | None, host: str, num_frames: int) -> None:
     """Trigger a capture on the attached target."""
     resolved = _resolve_ident(ident)
-    rd = _require_renderdoc()
+    rd = require_renderdoc()
     tc = _connect(rd, host, resolved)
     try:
         tc.TriggerCapture(num_frames)
@@ -102,7 +93,7 @@ def capture_list_cmd(ident: int | None, host: str, timeout: float, use_json: boo
     import json as json_mod
 
     resolved = _resolve_ident(ident)
-    rd = _require_renderdoc()
+    rd = require_renderdoc()
     tc = _connect(rd, host, resolved)
     captures: list[dict[str, Any]] = []
     try:
@@ -152,7 +143,7 @@ def capture_copy_cmd(
 ) -> None:
     """Copy a capture from the target to a local path."""
     resolved = _resolve_ident(ident)
-    rd = _require_renderdoc()
+    rd = require_renderdoc()
     tc = _connect(rd, host, resolved)
     try:
         tc.CopyCapture(capture_id, dest)

--- a/src/rdc/commands/remote.py
+++ b/src/rdc/commands/remote.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import click
 
-from rdc.discover import find_renderdoc
+from rdc.commands._helpers import require_renderdoc
 from rdc.remote_core import (
     build_conn_url,
     connect_remote_server,
@@ -24,15 +24,6 @@ from rdc.remote_state import (
     load_latest_remote_state,
     save_remote_state,
 )
-
-
-def _require_renderdoc() -> Any:
-    """Find and return the renderdoc module, or exit with error."""
-    rd = find_renderdoc()
-    if rd is None:
-        click.echo("error: renderdoc module not found", err=True)
-        raise SystemExit(1)
-    return rd
 
 
 def _resolve_url(url: str | None) -> tuple[str, int]:
@@ -73,7 +64,7 @@ def remote_connect_cmd(url: str, as_json: bool) -> None:
         click.echo(f"error: {exc}", err=True)
         raise SystemExit(1) from None
     _check_public_ip(host)
-    rd = _require_renderdoc()
+    rd = require_renderdoc()
 
     conn_url = build_conn_url(host, port)
     try:
@@ -101,7 +92,7 @@ def remote_list_cmd(url: str | None, as_json: bool) -> None:
     """List capturable applications on a remote host."""
     host, port = _resolve_url(url)
     _check_public_ip(host)
-    rd = _require_renderdoc()
+    rd = require_renderdoc()
 
     conn_url = build_conn_url(host, port)
     idents = enumerate_remote_targets(rd, conn_url)
@@ -173,7 +164,7 @@ def remote_capture_cmd(
     """Capture on a remote host and transfer to local."""
     host, port = _resolve_url(url)
     _check_public_ip(host)
-    rd = _require_renderdoc()
+    rd = require_renderdoc()
 
     opts: dict[str, Any] = {}
     if api_validation:

--- a/tests/integration/test_mock_api_sync.py
+++ b/tests/integration/test_mock_api_sync.py
@@ -6,16 +6,12 @@ Runs only when real renderdoc is available (GPU marker).
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from typing import Any
 
+import mock_renderdoc as mock
 import pytest
 
 pytestmark = pytest.mark.gpu
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-import mock_renderdoc as mock  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,20 @@
+"""Shared helpers for unit tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def rpc_request(
+    method: str,
+    params: dict[str, Any] | None = None,
+    *,
+    token: str = "tok",
+) -> dict[str, Any]:
+    """Build a JSON-RPC 2.0 request dict for daemon handler tests."""
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": {"_token": token, **(params or {})},
+    }

--- a/tests/unit/test_build_renderdoc.py
+++ b/tests/unit/test_build_renderdoc.py
@@ -12,13 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Add scripts/ to sys.path so build_renderdoc can be imported as a module
-_scripts = str(Path(__file__).parents[2] / "scripts")
-if _scripts not in sys.path:
-    sys.path.insert(0, _scripts)
-
 br = importlib.import_module("build_renderdoc")
-
 
 # ---------------------------------------------------------------------------
 # Platform detection

--- a/tests/unit/test_capture_control.py
+++ b/tests/unit/test_capture_control.py
@@ -74,7 +74,7 @@ def _save_state(ident: int = 12345) -> None:
 def test_attach_success(monkeypatch: pytest.MonkeyPatch) -> None:
     tc = _make_mock_tc()
     rd = _make_mock_rd(tc)
-    monkeypatch.setattr("rdc.commands.capture_control.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
 
     result = CliRunner().invoke(attach_cmd, ["12345"])
     assert result.exit_code == 0
@@ -88,7 +88,7 @@ def test_attach_success(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_attach_connection_failed(monkeypatch: pytest.MonkeyPatch) -> None:
     tc = _make_mock_tc(connected=False)
     rd = _make_mock_rd(tc)
-    monkeypatch.setattr("rdc.commands.capture_control.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
 
     result = CliRunner().invoke(attach_cmd, ["12345"])
     assert result.exit_code != 0
@@ -102,7 +102,7 @@ def test_capture_trigger_success(monkeypatch: pytest.MonkeyPatch) -> None:
     _save_state()
     tc = _make_mock_tc()
     rd = _make_mock_rd(tc)
-    monkeypatch.setattr("rdc.commands.capture_control.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
 
     result = CliRunner().invoke(capture_trigger_cmd, [])
     assert result.exit_code == 0
@@ -113,7 +113,7 @@ def test_capture_trigger_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_capture_trigger_no_state(monkeypatch: pytest.MonkeyPatch) -> None:
     rd = MagicMock()
-    monkeypatch.setattr("rdc.commands.capture_control.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
 
     result = CliRunner().invoke(capture_trigger_cmd, [])
     assert result.exit_code != 0
@@ -147,7 +147,7 @@ def test_capture_list_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
     tc = _make_mock_tc(messages=[new_cap_msg, noop_msg, disconnect_msg])
     rd = _make_mock_rd(tc)
-    monkeypatch.setattr("rdc.commands.capture_control.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
 
     result = CliRunner().invoke(capture_list_cmd, ["--timeout", "0.1"])
     assert result.exit_code == 0
@@ -167,7 +167,7 @@ def test_capture_copy_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
     tc = _make_mock_tc(messages=[copied_msg])
     rd = _make_mock_rd(tc)
-    monkeypatch.setattr("rdc.commands.capture_control.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
 
     result = CliRunner().invoke(capture_copy_cmd, ["0", "/tmp/out.rdc", "--timeout", "1"])
     assert result.exit_code == 0
@@ -180,7 +180,7 @@ def test_capture_copy_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     _save_state()
     tc = _make_mock_tc()  # default Noop messages -> will timeout
     rd = _make_mock_rd(tc)
-    monkeypatch.setattr("rdc.commands.capture_control.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
 
     result = CliRunner().invoke(capture_copy_cmd, ["0", "/tmp/out.rdc", "--timeout", "0.05"])
     assert result.exit_code != 0
@@ -194,7 +194,7 @@ def test_capture_copy_disconnected(monkeypatch: pytest.MonkeyPatch) -> None:
 
     tc = _make_mock_tc(messages=[disconnect_msg])
     rd = _make_mock_rd(tc)
-    monkeypatch.setattr("rdc.commands.capture_control.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
 
     result = CliRunner().invoke(capture_copy_cmd, ["0", "/tmp/out.rdc", "--timeout", "1"])
     assert result.exit_code != 0
@@ -202,7 +202,7 @@ def test_capture_copy_disconnected(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_capture_copy_no_state(monkeypatch: pytest.MonkeyPatch) -> None:
     rd = MagicMock()
-    monkeypatch.setattr("rdc.commands.capture_control.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
 
     result = CliRunner().invoke(capture_copy_cmd, ["0", "/tmp/out.rdc"])
     assert result.exit_code != 0
@@ -216,7 +216,7 @@ def test_capture_copy_no_state(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_connect_not_connected_calls_shutdown(monkeypatch: pytest.MonkeyPatch) -> None:
     tc = _make_mock_tc(connected=False)
     rd = _make_mock_rd(tc)
-    monkeypatch.setattr("rdc.commands.capture_control.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
 
     result = CliRunner().invoke(attach_cmd, ["12345"])
     assert result.exit_code != 0
@@ -226,7 +226,7 @@ def test_connect_not_connected_calls_shutdown(monkeypatch: pytest.MonkeyPatch) -
 def test_connect_none_tc_does_not_call_shutdown(monkeypatch: pytest.MonkeyPatch) -> None:
     rd = MagicMock()
     rd.CreateTargetControl.return_value = None
-    monkeypatch.setattr("rdc.commands.capture_control.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
 
     result = CliRunner().invoke(attach_cmd, ["12345"])
     assert result.exit_code != 0
@@ -235,7 +235,7 @@ def test_connect_none_tc_does_not_call_shutdown(monkeypatch: pytest.MonkeyPatch)
 def test_capture_trigger_not_connected_calls_shutdown(monkeypatch: pytest.MonkeyPatch) -> None:
     tc = _make_mock_tc(connected=False)
     rd = _make_mock_rd(tc)
-    monkeypatch.setattr("rdc.commands.capture_control.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
 
     result = CliRunner().invoke(capture_trigger_cmd, ["--ident", "12345"])
     assert result.exit_code != 0
@@ -245,7 +245,7 @@ def test_capture_trigger_not_connected_calls_shutdown(monkeypatch: pytest.Monkey
 def test_capture_list_not_connected_calls_shutdown(monkeypatch: pytest.MonkeyPatch) -> None:
     tc = _make_mock_tc(connected=False)
     rd = _make_mock_rd(tc)
-    monkeypatch.setattr("rdc.commands.capture_control.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
 
     result = CliRunner().invoke(capture_list_cmd, ["--ident", "12345", "--timeout", "0.1"])
     assert result.exit_code != 0

--- a/tests/unit/test_capture_core.py
+++ b/tests/unit/test_capture_core.py
@@ -4,15 +4,11 @@ from __future__ import annotations
 
 import signal
 import sys
-from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
-import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-
 import mock_renderdoc as mock_rd
+import pytest
 
 
 def _make_mock_rd(

--- a/tests/unit/test_capturefile_handlers.py
+++ b/tests/unit/test_capturefile_handlers.py
@@ -3,15 +3,11 @@
 from __future__ import annotations
 
 import base64
-import sys
 from pathlib import Path
 from typing import Any
 
+import mock_renderdoc as mock_rd
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-
-import mock_renderdoc as mock_rd  # noqa: E402
 
 
 def _make_state(tmp_path: Path) -> Any:

--- a/tests/unit/test_count_shadermap.py
+++ b/tests/unit/test_count_shadermap.py
@@ -2,16 +2,11 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import mock_renderdoc as mrd
 import pytest
 from click.testing import CliRunner
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-
-import mock_renderdoc as mrd  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers: build mock action trees

--- a/tests/unit/test_daemon_crash_regression.py
+++ b/tests/unit/test_daemon_crash_regression.py
@@ -8,14 +8,10 @@ Tests that the daemon survives previously-crashing scenarios:
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from types import SimpleNamespace
 
 from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
 
 
 def _state_with_mock() -> DaemonState:

--- a/tests/unit/test_daemon_server_unit.py
+++ b/tests/unit/test_daemon_server_unit.py
@@ -13,10 +13,8 @@ import pytest
 from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request, _load_replay, _set_frame_event
 
+
 # Make mock module importable
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-
-
 class TestHandleRequest:
     def _state(self) -> DaemonState:
         return DaemonState(capture="capture.rdc", current_eid=0, token="tok")

--- a/tests/unit/test_descriptors_daemon.py
+++ b/tests/unit/test_descriptors_daemon.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from types import SimpleNamespace
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-
-import mock_renderdoc as rd  # noqa: E402
-from mock_renderdoc import (  # noqa: E402
+import mock_renderdoc as rd
+from mock_renderdoc import (
     AddressMode,
     Descriptor,
     DescriptorAccess,

--- a/tests/unit/test_draws_events_daemon.py
+++ b/tests/unit/test_draws_events_daemon.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from types import SimpleNamespace
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-
+from conftest import rpc_request
 from mock_renderdoc import (
     ActionDescription,
     ActionFlags,
@@ -90,116 +87,110 @@ def _make_state():
     return state
 
 
-def _req(method, **params):
-    p = {"_token": "tok"}
-    p.update(params)
-    return {"id": 1, "method": method, "params": p}
-
-
 class TestInfoHandler:
     def test_info_metadata(self):
-        resp, _ = _handle_request(_req("info"), _make_state())
+        resp, _ = _handle_request(rpc_request("info"), _make_state())
         assert resp["result"]["Capture"] == "test.rdc"
         assert resp["result"]["API"] == "Vulkan"
 
     def test_info_no_adapter(self):
         state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
-        resp, _ = _handle_request(_req("info"), state)
+        resp, _ = _handle_request(rpc_request("info"), state)
         assert resp["error"]["code"] == -32002
 
 
 class TestStatsHandler:
     def test_stats_per_pass(self):
-        resp, _ = _handle_request(_req("stats"), _make_state())
+        resp, _ = _handle_request(rpc_request("stats"), _make_state())
         assert len(resp["result"]["per_pass"]) > 0
 
     def test_stats_top_draws(self):
-        resp, _ = _handle_request(_req("stats"), _make_state())
+        resp, _ = _handle_request(rpc_request("stats"), _make_state())
         assert len(resp["result"]["top_draws"]) >= 1
 
     def test_stats_no_adapter(self):
         state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
-        resp, _ = _handle_request(_req("stats"), state)
+        resp, _ = _handle_request(rpc_request("stats"), state)
         assert resp["error"]["code"] == -32002
 
 
 class TestEventsHandler:
     def test_events_list(self):
-        resp, _ = _handle_request(_req("events"), _make_state())
+        resp, _ = _handle_request(rpc_request("events"), _make_state())
         assert len(resp["result"]["events"]) > 0
 
     def test_events_filter_type(self):
-        resp, _ = _handle_request(_req("events", type="draw"), _make_state())
+        resp, _ = _handle_request(rpc_request("events", {"type": "draw"}), _make_state())
         assert all(e["type"] in ("Draw", "DrawIndexed") for e in resp["result"]["events"])
 
     def test_events_filter_name(self):
-        resp, _ = _handle_request(_req("events", filter="Shadow*"), _make_state())
+        resp, _ = _handle_request(rpc_request("events", {"filter": "Shadow*"}), _make_state())
         assert any("Shadow" in e["name"] for e in resp["result"]["events"])
 
     def test_events_limit(self):
-        resp, _ = _handle_request(_req("events", limit=2), _make_state())
+        resp, _ = _handle_request(rpc_request("events", {"limit": 2}), _make_state())
         assert len(resp["result"]["events"]) <= 2
 
     def test_events_range(self):
-        resp, _ = _handle_request(_req("events", range="40:50"), _make_state())
+        resp, _ = _handle_request(rpc_request("events", {"range": "40:50"}), _make_state())
         assert all(40 <= e["eid"] <= 50 for e in resp["result"]["events"])
 
     def test_events_no_adapter(self):
         state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
-        resp, _ = _handle_request(_req("events"), state)
+        resp, _ = _handle_request(rpc_request("events"), state)
         assert resp["error"]["code"] == -32002
 
 
 class TestDrawsHandler:
     def test_draws_list(self):
-        resp, _ = _handle_request(_req("draws"), _make_state())
+        resp, _ = _handle_request(rpc_request("draws"), _make_state())
         assert len(resp["result"]["draws"]) >= 1
         assert "summary" in resp["result"]
 
     def test_draws_filter_pass(self):
         state = _make_state()
-        passes_resp, _ = _handle_request(_req("passes"), state)
+        passes_resp, _ = _handle_request(rpc_request("passes"), state)
         friendly = passes_resp["result"]["tree"]["passes"][0]["name"]
-        resp, _ = _handle_request(_req("draws", **{"pass": friendly}), state)
+        resp, _ = _handle_request(rpc_request("draws", {"pass": friendly}), state)
         assert len(resp["result"]["draws"]) > 0
         assert all(d["pass"] == friendly for d in resp["result"]["draws"])
 
     def test_draws_sort_triangles(self):
-        resp, _ = _handle_request(_req("draws", sort="triangles"), _make_state())
+        resp, _ = _handle_request(rpc_request("draws", {"sort": "triangles"}), _make_state())
         tris = [d["triangles"] for d in resp["result"]["draws"]]
         assert tris == sorted(tris, reverse=True)
 
     def test_draws_limit(self):
-        resp, _ = _handle_request(_req("draws", limit=1), _make_state())
+        resp, _ = _handle_request(rpc_request("draws", {"limit": 1}), _make_state())
         assert len(resp["result"]["draws"]) <= 1
 
     def test_draws_empty_pass(self):
-        resp, _ = _handle_request(_req("draws", **{"pass": "NonExistent"}), _make_state())
+        resp, _ = _handle_request(rpc_request("draws", {"pass": "NonExistent"}), _make_state())
         assert len(resp["result"]["draws"]) == 0
 
 
 class TestEventHandler:
     def test_event_detail(self):
-        resp, _ = _handle_request(_req("event", eid=42), _make_state())
+        resp, _ = _handle_request(rpc_request("event", {"eid": 42}), _make_state())
         assert resp["result"]["EID"] == 42
         assert resp["result"]["API Call"] == "vkCmdDrawIndexed"
 
     def test_event_params(self):
-        resp, _ = _handle_request(_req("event", eid=42), _make_state())
+        resp, _ = _handle_request(rpc_request("event", {"eid": 42}), _make_state())
         assert "indexCount" in str(resp["result"]["Parameters"])
 
     def test_event_not_found(self):
-        resp, _ = _handle_request(_req("event", eid=99999), _make_state())
+        resp, _ = _handle_request(rpc_request("event", {"eid": 99999}), _make_state())
         assert resp["error"]["code"] == -32002
 
     def test_event_missing_eid(self):
-        resp, _ = _handle_request(_req("event"), _make_state())
+        resp, _ = _handle_request(rpc_request("event"), _make_state())
         assert resp["error"]["code"] == -32602
 
 
 class TestDrawHandler:
     def test_draw_detail(self):
-        resp, _ = _handle_request(_req("draw", eid=42), _make_state())
+        resp, _ = _handle_request(rpc_request("draw", {"eid": 42}), _make_state())
         assert resp["result"]["Event"] == 42
         assert resp["result"]["Triangles"] == 1200
         assert resp["result"]["Instances"] == 1
@@ -207,11 +198,11 @@ class TestDrawHandler:
     def test_draw_current_eid(self):
         state = _make_state()
         state.current_eid = 42
-        resp, _ = _handle_request(_req("draw"), state)
+        resp, _ = _handle_request(rpc_request("draw"), state)
         assert resp["result"]["Event"] == 42
 
     def test_draw_not_found(self):
-        resp, _ = _handle_request(_req("draw", eid=99999), _make_state())
+        resp, _ = _handle_request(rpc_request("draw", {"eid": 99999}), _make_state())
         assert resp["error"]["code"] == -32002
 
 
@@ -295,7 +286,7 @@ def _make_log_state(messages=None):
 
 class TestPassHandler:
     def test_pass_by_index(self):
-        resp, _ = _handle_request(_req("pass", index=0), _make_pass_state())
+        resp, _ = _handle_request(rpc_request("pass", {"index": 0}), _make_pass_state())
         result = resp["result"]
         assert result["name"] == "Shadow"
         assert result["begin_eid"] == 10
@@ -303,36 +294,36 @@ class TestPassHandler:
         assert result["triangles"] == 1200
 
     def test_pass_by_name(self):
-        resp, _ = _handle_request(_req("pass", name="Shadow"), _make_pass_state())
+        resp, _ = _handle_request(rpc_request("pass", {"name": "Shadow"}), _make_pass_state())
         assert resp["result"]["name"] == "Shadow"
 
     def test_pass_by_name_case_insensitive(self):
-        resp, _ = _handle_request(_req("pass", name="shadow"), _make_pass_state())
+        resp, _ = _handle_request(rpc_request("pass", {"name": "shadow"}), _make_pass_state())
         assert resp["result"]["name"] == "Shadow"
 
     def test_pass_not_found_index(self):
-        resp, _ = _handle_request(_req("pass", index=999), _make_pass_state())
+        resp, _ = _handle_request(rpc_request("pass", {"index": 999}), _make_pass_state())
         assert resp["error"]["code"] == -32001
 
     def test_pass_not_found_name(self):
-        resp, _ = _handle_request(_req("pass", name="NoSuch"), _make_pass_state())
+        resp, _ = _handle_request(rpc_request("pass", {"name": "NoSuch"}), _make_pass_state())
         assert resp["error"]["code"] == -32001
 
     def test_pass_no_adapter(self):
         state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
-        resp, _ = _handle_request(_req("pass", index=0), state)
+        resp, _ = _handle_request(rpc_request("pass", {"index": 0}), state)
         assert resp["error"]["code"] == -32002
 
     def test_pass_missing_params(self):
-        resp, _ = _handle_request(_req("pass"), _make_pass_state())
+        resp, _ = _handle_request(rpc_request("pass"), _make_pass_state())
         assert resp["error"]["code"] == -32602
 
     def test_pass_invalid_index(self):
-        resp, _ = _handle_request(_req("pass", index="abc"), _make_pass_state())
+        resp, _ = _handle_request(rpc_request("pass", {"index": "abc"}), _make_pass_state())
         assert resp["error"]["code"] == -32602
 
     def test_pass_color_targets(self):
-        resp, _ = _handle_request(_req("pass", index=0), _make_pass_state())
+        resp, _ = _handle_request(rpc_request("pass", {"index": 0}), _make_pass_state())
         result = resp["result"]
         assert len(result["color_targets"]) == 1
         assert result["color_targets"][0]["id"] == 10
@@ -345,7 +336,7 @@ class TestLogHandler:
             SimpleNamespace(severity=0, eventId=0, description="validation error"),
             SimpleNamespace(severity=3, eventId=42, description="info message"),
         ]
-        resp, _ = _handle_request(_req("log"), _make_log_state(msgs))
+        resp, _ = _handle_request(rpc_request("log"), _make_log_state(msgs))
         result = resp["result"]["messages"]
         assert len(result) == 2
         assert result[0]["level"] == "HIGH"
@@ -358,7 +349,7 @@ class TestLogHandler:
             SimpleNamespace(severity=0, eventId=0, description="error"),
             SimpleNamespace(severity=3, eventId=10, description="info"),
         ]
-        resp, _ = _handle_request(_req("log", level="HIGH"), _make_log_state(msgs))
+        resp, _ = _handle_request(rpc_request("log", {"level": "HIGH"}), _make_log_state(msgs))
         result = resp["result"]["messages"]
         assert len(result) == 1
         assert result[0]["level"] == "HIGH"
@@ -368,7 +359,7 @@ class TestLogHandler:
             SimpleNamespace(severity=0, eventId=0, description="global"),
             SimpleNamespace(severity=1, eventId=42, description="at eid 42"),
         ]
-        resp, _ = _handle_request(_req("log", eid=42), _make_log_state(msgs))
+        resp, _ = _handle_request(rpc_request("log", {"eid": 42}), _make_log_state(msgs))
         result = resp["result"]["messages"]
         assert len(result) == 1
         assert result[0]["eid"] == 42
@@ -378,26 +369,26 @@ class TestLogHandler:
             SimpleNamespace(severity=0, eventId=0, description="global"),
             SimpleNamespace(severity=1, eventId=42, description="at eid 42"),
         ]
-        resp, _ = _handle_request(_req("log", eid=0), _make_log_state(msgs))
+        resp, _ = _handle_request(rpc_request("log", {"eid": 0}), _make_log_state(msgs))
         result = resp["result"]["messages"]
         assert len(result) == 1
         assert result[0]["message"] == "global"
 
     def test_log_empty(self):
-        resp, _ = _handle_request(_req("log"), _make_log_state([]))
+        resp, _ = _handle_request(rpc_request("log"), _make_log_state([]))
         assert resp["result"]["messages"] == []
 
     def test_log_no_adapter(self):
         state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
-        resp, _ = _handle_request(_req("log"), state)
+        resp, _ = _handle_request(rpc_request("log"), state)
         assert resp["error"]["code"] == -32002
 
     def test_log_invalid_level(self):
-        resp, _ = _handle_request(_req("log", level="HIHG"), _make_log_state([]))
+        resp, _ = _handle_request(rpc_request("log", {"level": "HIHG"}), _make_log_state([]))
         assert resp["error"]["code"] == -32602
 
     def test_log_invalid_eid(self):
-        resp, _ = _handle_request(_req("log", eid="abc"), _make_log_state([]))
+        resp, _ = _handle_request(rpc_request("log", {"eid": "abc"}), _make_log_state([]))
         assert resp["error"]["code"] == -32602
 
 
@@ -452,14 +443,14 @@ class TestEventMultiChunk:
         return state
 
     def test_all_chunk_params_present(self):
-        resp, _ = _handle_request(_req("event", eid=42), self._make_multi_chunk_state())
+        resp, _ = _handle_request(rpc_request("event", {"eid": 42}), self._make_multi_chunk_state())
         params_str = resp["result"]["Parameters"]
         assert "viewportCount" in params_str
         assert "indexCount" in params_str
         assert "instanceCount" in params_str
 
     def test_last_chunk_wins_api_call(self):
-        resp, _ = _handle_request(_req("event", eid=42), self._make_multi_chunk_state())
+        resp, _ = _handle_request(rpc_request("event", {"eid": 42}), self._make_multi_chunk_state())
         assert resp["result"]["API Call"] == "vkCmdDrawIndexed"
 
 
@@ -512,7 +503,7 @@ class TestMeshDispatchClassification:
         assert _action_type_str(0x0008) != "Other"
 
     def test_mesh_dispatch_classified_as_draw_in_events(self):
-        resp, _ = _handle_request(_req("events"), _make_mesh_state())
+        resp, _ = _handle_request(rpc_request("events"), _make_mesh_state())
         events = resp["result"]["events"]
         mesh_ev = [e for e in events if e["eid"] == 10]
         assert len(mesh_ev) == 1
@@ -520,20 +511,20 @@ class TestMeshDispatchClassification:
         assert mesh_ev[0]["type"] == "Draw"
 
     def test_mesh_dispatch_included_in_draws_list(self):
-        resp, _ = _handle_request(_req("draws"), _make_mesh_state())
+        resp, _ = _handle_request(rpc_request("draws"), _make_mesh_state())
         draws = resp["result"]["draws"]
         mesh_draws = [d for d in draws if d["eid"] == 10]
         assert len(mesh_draws) == 1
 
     def test_mesh_dispatch_counted_as_draw(self):
-        resp, _ = _handle_request(_req("count", what="draws"), _make_mesh_state())
+        resp, _ = _handle_request(rpc_request("count", {"what": "draws"}), _make_mesh_state())
         assert resp["result"]["value"] == 1
 
     def test_mesh_dispatch_in_info_draw_calls(self):
-        resp, _ = _handle_request(_req("info"), _make_mesh_state())
+        resp, _ = _handle_request(rpc_request("info"), _make_mesh_state())
         draw_calls = resp["result"]["Draw Calls"]
         assert "1 " in draw_calls
 
     def test_mesh_dispatch_not_classified_as_dispatch(self):
-        resp, _ = _handle_request(_req("count", what="dispatches"), _make_mesh_state())
+        resp, _ = _handle_request(rpc_request("count", {"what": "dispatches"}), _make_mesh_state())
         assert resp["result"]["value"] == 0

--- a/tests/unit/test_fix2_vfs_intermediate_dirs.py
+++ b/tests/unit/test_fix2_vfs_intermediate_dirs.py
@@ -2,11 +2,6 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-
 from mock_renderdoc import (
     ActionDescription,
     ActionFlags,

--- a/tests/unit/test_info_commands.py
+++ b/tests/unit/test_info_commands.py
@@ -246,11 +246,7 @@ def test_log_quiet(monkeypatch) -> None:
 
 def test_log_handler_caches_messages(monkeypatch) -> None:
     """Second _handle_log call returns same data without re-calling GetDebugMessages."""
-    import sys
-    from pathlib import Path
-
-    sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-    import mock_renderdoc as rd  # noqa: E402
+    import mock_renderdoc as rd
 
     from rdc.adapter import RenderDocAdapter
     from rdc.daemon_server import DaemonState, _handle_request

--- a/tests/unit/test_keep_remote.py
+++ b/tests/unit/test_keep_remote.py
@@ -25,7 +25,7 @@ def _save_state() -> None:
 
 def _mock_rd(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     rd = MagicMock()
-    monkeypatch.setattr("rdc.commands.remote.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
     return rd
 
 

--- a/tests/unit/test_mock_capture_types.py
+++ b/tests/unit/test_mock_capture_types.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-
-import mock_renderdoc as rd  # noqa: E402
+import mock_renderdoc as rd
 
 
 class TestCaptureOptions:

--- a/tests/unit/test_mock_renderdoc.py
+++ b/tests/unit/test_mock_renderdoc.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import pytest
-
 # Make mock module importable
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-
-import mock_renderdoc as rd  # noqa: E402
+import mock_renderdoc as rd
+import pytest
 
 
 @pytest.fixture

--- a/tests/unit/test_pick_pixel_daemon.py
+++ b/tests/unit/test_pick_pixel_daemon.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
+import mock_renderdoc as rd
+from conftest import rpc_request
 
 from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-
-import mock_renderdoc as rd  # noqa: E402
 
 
 def _make_state(
@@ -40,13 +36,6 @@ def _make_state(
     return state
 
 
-def _req(method: str, params: dict | None = None) -> dict:
-    p = {"_token": "tok"}
-    if params:
-        p.update(params)
-    return {"jsonrpc": "2.0", "id": 1, "method": method, "params": p}
-
-
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------
@@ -55,7 +44,7 @@ def _req(method: str, params: dict | None = None) -> dict:
 def test_pick_pixel_happy() -> None:
     pv = rd.PixelValue(floatValue=[0.5, 0.3, 0.1, 1.0])
     state = _make_state(pick_pixel={(512, 384): pv})
-    resp, running = _handle_request(_req("pick_pixel", {"x": 512, "y": 384}), state)
+    resp, running = _handle_request(rpc_request("pick_pixel", {"x": 512, "y": 384}), state)
     assert running
     r = resp["result"]
     assert r["color"] == {"r": 0.5, "g": 0.3, "b": 0.1, "a": 1.0}
@@ -64,7 +53,7 @@ def test_pick_pixel_happy() -> None:
 def test_pick_pixel_result_schema() -> None:
     pv = rd.PixelValue(floatValue=[0.5, 0.3, 0.1, 1.0])
     state = _make_state(pick_pixel={(512, 384): pv})
-    resp, _ = _handle_request(_req("pick_pixel", {"x": 512, "y": 384}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": 512, "y": 384}), state)
     r = resp["result"]
     assert r["x"] == 512
     assert r["y"] == 384
@@ -77,7 +66,7 @@ def test_pick_pixel_target_index_1() -> None:
     rt1 = rd.Descriptor(resource=rd.ResourceId(43))
     pv = rd.PixelValue(floatValue=[1.0, 0.0, 0.0, 1.0])
     state = _make_state(pick_pixel={(100, 200): pv}, output_targets=[rt0, rt1])
-    resp, _ = _handle_request(_req("pick_pixel", {"x": 100, "y": 200, "target": 1}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": 100, "y": 200, "target": 1}), state)
     r = resp["result"]
     assert r["target"]["index"] == 1
     assert r["target"]["id"] == 43
@@ -86,28 +75,28 @@ def test_pick_pixel_target_index_1() -> None:
 def test_pick_pixel_eid_defaults_to_current() -> None:
     state = _make_state(pick_pixel={(10, 20): rd.PixelValue()})
     state.current_eid = 120
-    resp, _ = _handle_request(_req("pick_pixel", {"x": 10, "y": 20}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": 10, "y": 20}), state)
     assert resp["result"]["eid"] == 120
 
 
 def test_pick_pixel_eid_override() -> None:
     state = _make_state(pick_pixel={(10, 20): rd.PixelValue()})
     state._eid_cache = -1
-    resp, _ = _handle_request(_req("pick_pixel", {"x": 10, "y": 20, "eid": 120}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": 10, "y": 20, "eid": 120}), state)
     ctrl = state.adapter.controller  # type: ignore[union-attr]
     assert (120, True) in ctrl._set_frame_event_calls
 
 
 def test_pick_pixel_unknown_pixel_returns_zero() -> None:
     state = _make_state()
-    resp, _ = _handle_request(_req("pick_pixel", {"x": 999, "y": 999}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": 999, "y": 999}), state)
     assert resp["error"]["code"] == -32001
     assert "out of bounds" in resp["error"]["message"]
 
 
 def test_pick_pixel_keep_running_true() -> None:
     state = _make_state()
-    _, running = _handle_request(_req("pick_pixel", {"x": 0, "y": 0}), state)
+    _, running = _handle_request(rpc_request("pick_pixel", {"x": 0, "y": 0}), state)
     assert running is True
 
 
@@ -118,46 +107,46 @@ def test_pick_pixel_keep_running_true() -> None:
 
 def test_pick_pixel_no_adapter() -> None:
     state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
-    resp, _ = _handle_request(_req("pick_pixel", {"x": 0, "y": 0}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": 0, "y": 0}), state)
     assert resp["error"]["code"] == -32002
 
 
 def test_pick_pixel_missing_x() -> None:
     state = _make_state()
-    resp, _ = _handle_request(_req("pick_pixel", {"y": 0}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"y": 0}), state)
     assert resp["error"]["code"] == -32602
     assert "x" in resp["error"]["message"]
 
 
 def test_pick_pixel_missing_y() -> None:
     state = _make_state()
-    resp, _ = _handle_request(_req("pick_pixel", {"x": 0}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": 0}), state)
     assert resp["error"]["code"] == -32602
     assert "y" in resp["error"]["message"]
 
 
 def test_pick_pixel_no_targets() -> None:
     state = _make_state(output_targets=[rd.Descriptor(resource=rd.ResourceId(0))])
-    resp, _ = _handle_request(_req("pick_pixel", {"x": 0, "y": 0}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": 0, "y": 0}), state)
     assert resp["error"]["code"] == -32001
     assert "no color targets" in resp["error"]["message"]
 
 
 def test_pick_pixel_target_out_of_range() -> None:
     state = _make_state()
-    resp, _ = _handle_request(_req("pick_pixel", {"x": 0, "y": 0, "target": 5}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": 0, "y": 0, "target": 5}), state)
     assert resp["error"]["code"] == -32001
 
 
 def test_pick_pixel_eid_out_of_range() -> None:
     state = _make_state()
-    resp, _ = _handle_request(_req("pick_pixel", {"x": 0, "y": 0, "eid": 9999}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": 0, "y": 0, "eid": 9999}), state)
     assert resp["error"]["code"] == -32002
 
 
 def test_pick_pixel_msaa_rejected() -> None:
     state = _make_state(ms_samp=4)
-    resp, _ = _handle_request(_req("pick_pixel", {"x": 0, "y": 0}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": 0, "y": 0}), state)
     assert resp["error"]["code"] == -32001
     assert "MSAA" in resp["error"]["message"]
 
@@ -169,14 +158,14 @@ def test_pick_pixel_msaa_rejected() -> None:
 
 def test_pick_pixel_out_of_bounds_x() -> None:
     state = _make_state()
-    resp, _ = _handle_request(_req("pick_pixel", {"x": 1024, "y": 0}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": 1024, "y": 0}), state)
     assert resp["error"]["code"] == -32001
     assert "out of bounds" in resp["error"]["message"]
 
 
 def test_pick_pixel_out_of_bounds_y() -> None:
     state = _make_state()
-    resp, _ = _handle_request(_req("pick_pixel", {"x": 0, "y": 768}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": 0, "y": 768}), state)
     assert resp["error"]["code"] == -32001
     assert "out of bounds" in resp["error"]["message"]
 
@@ -184,21 +173,21 @@ def test_pick_pixel_out_of_bounds_y() -> None:
 def test_pick_pixel_at_boundary() -> None:
     pv = rd.PixelValue(floatValue=[0.1, 0.2, 0.3, 1.0])
     state = _make_state(pick_pixel={(1023, 767): pv})
-    resp, _ = _handle_request(_req("pick_pixel", {"x": 1023, "y": 767}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": 1023, "y": 767}), state)
     assert "result" in resp
     assert resp["result"]["color"] == {"r": 0.1, "g": 0.2, "b": 0.3, "a": 1.0}
 
 
 def test_pixel_history_out_of_bounds() -> None:
     state = _make_state()
-    resp, _ = _handle_request(_req("pixel_history", {"x": 1024, "y": 0}), state)
+    resp, _ = _handle_request(rpc_request("pixel_history", {"x": 1024, "y": 0}), state)
     assert resp["error"]["code"] == -32001
     assert "out of bounds" in resp["error"]["message"]
 
 
 def test_pick_pixel_negative_coords() -> None:
     state = _make_state()
-    resp, _ = _handle_request(_req("pick_pixel", {"x": -1, "y": 0}), state)
+    resp, _ = _handle_request(rpc_request("pick_pixel", {"x": -1, "y": 0}), state)
     assert resp["error"]["code"] == -32001
     assert "out of bounds" in resp["error"]["message"]
 

--- a/tests/unit/test_pipeline_section_routing.py
+++ b/tests/unit/test_pipeline_section_routing.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
-
-import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
 
 import mock_renderdoc as mock_rd
+import pytest
+from conftest import rpc_request
 from mock_renderdoc import (
     ActionDescription,
     ActionFlags,
@@ -34,12 +30,6 @@ def _build_actions() -> list[ActionDescription]:
 
 def _build_resources() -> list[ResourceDescription]:
     return [ResourceDescription(resourceId=ResourceId(1), name="res0")]
-
-
-def _req(method: str, **params: Any) -> dict[str, Any]:
-    p: dict[str, Any] = {"_token": "abcdef1234567890"}
-    p.update(params)
-    return {"id": 1, "method": method, "params": p}
 
 
 def _make_state(tmp_path: Path, pipe: MockPipeState) -> DaemonState:
@@ -73,14 +63,18 @@ class TestPipelineSectionRouting:
     def test_topology_section_delegates(self, tmp_path: Path) -> None:
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="topology"), s)
+        resp, _ = _handle_request(
+            rpc_request("pipeline", {"eid": 10, "section": "topology"}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         assert "topology" in resp["result"]
 
     def test_viewport_section_delegates(self, tmp_path: Path) -> None:
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="viewport"), s)
+        resp, _ = _handle_request(
+            rpc_request("pipeline", {"eid": 10, "section": "viewport"}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         r = resp["result"]
         assert "x" in r and "y" in r and "width" in r and "height" in r
@@ -88,84 +82,115 @@ class TestPipelineSectionRouting:
     def test_blend_section_delegates(self, tmp_path: Path) -> None:
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="blend"), s)
+        resp, _ = _handle_request(
+            rpc_request("pipeline", {"eid": 10, "section": "blend"}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         assert "blends" in resp["result"]
 
     def test_vinputs_section_delegates(self, tmp_path: Path) -> None:
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="vinputs"), s)
+        resp, _ = _handle_request(
+            rpc_request("pipeline", {"eid": 10, "section": "vinputs"}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         assert "inputs" in resp["result"]
 
     def test_rasterizer_section_delegates(self, tmp_path: Path) -> None:
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="rasterizer"), s)
+        resp, _ = _handle_request(
+            rpc_request("pipeline", {"eid": 10, "section": "rasterizer"}, token="abcdef1234567890"),
+            s,
+        )
         assert "error" not in resp
         assert "eid" in resp["result"]
 
     def test_depth_stencil_section_delegates(self, tmp_path: Path) -> None:
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="depth-stencil"), s)
+        resp, _ = _handle_request(
+            rpc_request(
+                "pipeline", {"eid": 10, "section": "depth-stencil"}, token="abcdef1234567890"
+            ),
+            s,
+        )
         assert "error" not in resp
         assert "eid" in resp["result"]
 
     def test_msaa_section_delegates(self, tmp_path: Path) -> None:
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="msaa"), s)
+        resp, _ = _handle_request(
+            rpc_request("pipeline", {"eid": 10, "section": "msaa"}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         assert "eid" in resp["result"]
 
     def test_scissor_section_delegates(self, tmp_path: Path) -> None:
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="scissor"), s)
+        resp, _ = _handle_request(
+            rpc_request("pipeline", {"eid": 10, "section": "scissor"}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         assert "eid" in resp["result"]
 
     def test_stencil_section_delegates(self, tmp_path: Path) -> None:
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="stencil"), s)
+        resp, _ = _handle_request(
+            rpc_request("pipeline", {"eid": 10, "section": "stencil"}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         assert "eid" in resp["result"]
 
     def test_vbuffers_section_delegates(self, tmp_path: Path) -> None:
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="vbuffers"), s)
+        resp, _ = _handle_request(
+            rpc_request("pipeline", {"eid": 10, "section": "vbuffers"}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         assert "vbuffers" in resp["result"]
 
     def test_ibuffer_section_delegates(self, tmp_path: Path) -> None:
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="ibuffer"), s)
+        resp, _ = _handle_request(
+            rpc_request("pipeline", {"eid": 10, "section": "ibuffer"}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         assert "eid" in resp["result"]
 
     def test_samplers_section_delegates(self, tmp_path: Path) -> None:
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="samplers"), s)
+        resp, _ = _handle_request(
+            rpc_request("pipeline", {"eid": 10, "section": "samplers"}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         assert "samplers" in resp["result"]
 
     def test_push_constants_section_delegates(self, tmp_path: Path) -> None:
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="push-constants"), s)
+        resp, _ = _handle_request(
+            rpc_request(
+                "pipeline", {"eid": 10, "section": "push-constants"}, token="abcdef1234567890"
+            ),
+            s,
+        )
         assert "error" not in resp
         assert "push_constants" in resp["result"]
 
     def test_invalid_section_returns_error(self, tmp_path: Path) -> None:
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="xyz"), s)
+        resp, _ = _handle_request(
+            rpc_request("pipeline", {"eid": 10, "section": "xyz"}, token="abcdef1234567890"), s
+        )
         assert "error" in resp
         assert resp["error"]["code"] == -32602
 
@@ -175,7 +200,9 @@ class TestPipelineSectionRouting:
         pipe._shaders[ShaderStage.Pixel] = ResourceId(5)
         pipe._reflections[ShaderStage.Pixel] = refl
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="ps"), s)
+        resp, _ = _handle_request(
+            rpc_request("pipeline", {"eid": 10, "section": "ps"}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         row = resp["result"]["row"]
         assert row.get("section") == "ps"
@@ -184,7 +211,9 @@ class TestPipelineSectionRouting:
         """Section name is lowercased before routing."""
         pipe = MockPipeState()
         s = _make_state(tmp_path, pipe)
-        resp, _ = _handle_request(_req("pipeline", eid=10, section="TOPOLOGY"), s)
+        resp, _ = _handle_request(
+            rpc_request("pipeline", {"eid": 10, "section": "TOPOLOGY"}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         assert "topology" in resp["result"]
 
@@ -209,7 +238,9 @@ class TestBindingsSetFiltering:
         import rdc.services.query_service as qs
 
         monkeypatch.setattr(qs, "bindings_rows", lambda eid, pipe_state: rows)
-        resp, _ = _handle_request(_req("bindings", eid=1, set=1), s)
+        resp, _ = _handle_request(
+            rpc_request("bindings", {"eid": 1, "set": 1}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         result_rows = resp["result"]["rows"]
         assert len(result_rows) == 1
@@ -223,7 +254,9 @@ class TestBindingsSetFiltering:
         import rdc.services.query_service as qs
 
         monkeypatch.setattr(qs, "bindings_rows", lambda eid, pipe_state: rows)
-        resp, _ = _handle_request(_req("bindings", eid=1, set=0), s)
+        resp, _ = _handle_request(
+            rpc_request("bindings", {"eid": 1, "set": 0}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         result_rows = resp["result"]["rows"]
         assert len(result_rows) == 2
@@ -238,7 +271,9 @@ class TestBindingsSetFiltering:
         import rdc.services.query_service as qs
 
         monkeypatch.setattr(qs, "bindings_rows", lambda eid, pipe_state: rows)
-        resp, _ = _handle_request(_req("bindings", eid=1, set=0, binding=3), s)
+        resp, _ = _handle_request(
+            rpc_request("bindings", {"eid": 1, "set": 0, "binding": 3}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         result_rows = resp["result"]["rows"]
         assert len(result_rows) == 1
@@ -253,7 +288,9 @@ class TestBindingsSetFiltering:
         import rdc.services.query_service as qs
 
         monkeypatch.setattr(qs, "bindings_rows", lambda eid, pipe_state: rows)
-        resp, _ = _handle_request(_req("bindings", eid=1, binding=0), s)
+        resp, _ = _handle_request(
+            rpc_request("bindings", {"eid": 1, "binding": 0}, token="abcdef1234567890"), s
+        )
         assert "error" not in resp
         result_rows = resp["result"]["rows"]
         assert len(result_rows) == 1

--- a/tests/unit/test_pipeline_shader.py
+++ b/tests/unit/test_pipeline_shader.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
+# Make mock module importable
+import mock_renderdoc as rd
 from click.testing import CliRunner
 
 from rdc.cli import main
 from rdc.daemon_server import DaemonState, _handle_request
 from rdc.services.query_service import bindings_rows, pipeline_row, shader_row
-
-# Make mock module importable
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-
-import mock_renderdoc as rd  # noqa: E402
 
 
 def _state_with_adapter() -> DaemonState:

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -2,11 +2,6 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-
 from mock_renderdoc import (
     ActionDescription,
     ActionFlags,

--- a/tests/unit/test_remote_commands.py
+++ b/tests/unit/test_remote_commands.py
@@ -29,7 +29,7 @@ def _isolate_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 def _mock_rd(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     """Provide a mock renderdoc module and patch find_renderdoc."""
     rd = MagicMock()
-    monkeypatch.setattr("rdc.commands.remote.find_renderdoc", lambda: rd)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
     return rd
 
 
@@ -79,7 +79,7 @@ class TestRemoteConnect:
         assert result.exit_code == 1
 
     def test_no_renderdoc_exits_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr("rdc.commands.remote.find_renderdoc", lambda: None)
+        monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: None)
         result = CliRunner().invoke(remote_connect_cmd, ["192.168.1.10"])
         assert result.exit_code == 1
 
@@ -220,7 +220,7 @@ class TestRemoteList:
 
     def test_no_renderdoc_exits_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _save_state()
-        monkeypatch.setattr("rdc.commands.remote.find_renderdoc", lambda: None)
+        monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: None)
         result = CliRunner().invoke(remote_list_cmd, [])
         assert result.exit_code == 1
 
@@ -373,7 +373,7 @@ class TestRemoteCapture:
 
     def test_no_renderdoc_exits_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _save_state()
-        monkeypatch.setattr("rdc.commands.remote.find_renderdoc", lambda: None)
+        monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: None)
         result = CliRunner().invoke(remote_capture_cmd, ["myapp", "-o", "/tmp/out.rdc"])
         assert result.exit_code == 1
 

--- a/tests/unit/test_script_handler.py
+++ b/tests/unit/test_script_handler.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
+from conftest import rpc_request
 
 from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request
@@ -31,12 +30,6 @@ def _make_state() -> DaemonState:
     return state
 
 
-def _req(method: str, **params: Any) -> dict[str, Any]:
-    p: dict[str, Any] = {"_token": "tok"}
-    p.update(params)
-    return {"id": 1, "method": method, "params": p}
-
-
 def _write_script(tmp_path: Path, content: str, name: str = "script.py") -> Path:
     p = tmp_path / name
     p.write_text(content, encoding="utf-8")
@@ -46,7 +39,7 @@ def _write_script(tmp_path: Path, content: str, name: str = "script.py") -> Path
 class TestScriptHappyPaths:
     def test_print_and_result(self, tmp_path: Path) -> None:
         script = _write_script(tmp_path, 'print("hello")\nresult = 42')
-        resp, keep = _handle_request(_req("script", path=str(script)), _make_state())
+        resp, keep = _handle_request(rpc_request("script", {"path": str(script)}), _make_state())
         assert keep is True
         r = resp["result"]
         assert r["stdout"] == "hello\n"
@@ -56,31 +49,31 @@ class TestScriptHappyPaths:
 
     def test_stderr_capture(self, tmp_path: Path) -> None:
         script = _write_script(tmp_path, 'import sys; sys.stderr.write("warn\\n")')
-        resp, _ = _handle_request(_req("script", path=str(script)), _make_state())
+        resp, _ = _handle_request(rpc_request("script", {"path": str(script)}), _make_state())
         r = resp["result"]
         assert r["stderr"] == "warn\n"
         assert r["stdout"] == ""
 
     def test_no_result_variable(self, tmp_path: Path) -> None:
         script = _write_script(tmp_path, 'print("only stdout")')
-        resp, _ = _handle_request(_req("script", path=str(script)), _make_state())
+        resp, _ = _handle_request(rpc_request("script", {"path": str(script)}), _make_state())
         assert resp["result"]["return_value"] is None
 
     def test_non_serializable_result(self, tmp_path: Path) -> None:
         script = _write_script(tmp_path, "result = object()")
-        resp, _ = _handle_request(_req("script", path=str(script)), _make_state())
+        resp, _ = _handle_request(rpc_request("script", {"path": str(script)}), _make_state())
         rv = resp["result"]["return_value"]
         assert isinstance(rv, str)
         assert len(rv) > 0
 
     def test_dict_list_result(self, tmp_path: Path) -> None:
         script = _write_script(tmp_path, 'result = {"k": [1, 2]}')
-        resp, _ = _handle_request(_req("script", path=str(script)), _make_state())
+        resp, _ = _handle_request(rpc_request("script", {"path": str(script)}), _make_state())
         assert resp["result"]["return_value"] == {"k": [1, 2]}
 
     def test_empty_script(self, tmp_path: Path) -> None:
         script = _write_script(tmp_path, "")
-        resp, _ = _handle_request(_req("script", path=str(script)), _make_state())
+        resp, _ = _handle_request(rpc_request("script", {"path": str(script)}), _make_state())
         r = resp["result"]
         assert r["stdout"] == ""
         assert r["stderr"] == ""
@@ -89,7 +82,7 @@ class TestScriptHappyPaths:
     def test_args_forwarded(self, tmp_path: Path) -> None:
         script = _write_script(tmp_path, 'print(args["mode"])\nresult = args["mode"]')
         resp, _ = _handle_request(
-            _req("script", path=str(script), args={"mode": "fast"}),
+            rpc_request("script", {"path": str(script), "args": {"mode": "fast"}}),
             _make_state(),
         )
         assert resp["result"]["stdout"] == "fast\n"
@@ -98,7 +91,7 @@ class TestScriptHappyPaths:
 
 class TestScriptMissingParams:
     def test_script_missing_path(self) -> None:
-        resp, keep = _handle_request(_req("script"), _make_state())
+        resp, keep = _handle_request(rpc_request("script"), _make_state())
         assert keep is True
         assert resp["error"]["code"] == -32602
         assert "path" in resp["error"]["message"]
@@ -108,26 +101,28 @@ class TestScriptErrorPaths:
     def test_no_replay_loaded(self, tmp_path: Path) -> None:
         state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
         script = _write_script(tmp_path, "result = 1")
-        resp, keep = _handle_request(_req("script", path=str(script)), state)
+        resp, keep = _handle_request(rpc_request("script", {"path": str(script)}), state)
         assert keep is True
         assert resp["error"]["code"] == -32002
         assert resp["error"]["message"] == "no replay loaded"
 
     def test_file_not_found(self) -> None:
-        resp, keep = _handle_request(_req("script", path="/nonexistent/path.py"), _make_state())
+        resp, keep = _handle_request(
+            rpc_request("script", {"path": "/nonexistent/path.py"}), _make_state()
+        )
         assert keep is True
         assert resp["error"]["code"] == -32002
         assert "script not found" in resp["error"]["message"]
 
     def test_path_is_directory(self, tmp_path: Path) -> None:
-        resp, keep = _handle_request(_req("script", path=str(tmp_path)), _make_state())
+        resp, keep = _handle_request(rpc_request("script", {"path": str(tmp_path)}), _make_state())
         assert keep is True
         assert resp["error"]["code"] == -32002
         assert resp["error"]["message"] == "script path is a directory"
 
     def test_syntax_error(self, tmp_path: Path) -> None:
         script = _write_script(tmp_path, "def foo(:")
-        resp, keep = _handle_request(_req("script", path=str(script)), _make_state())
+        resp, keep = _handle_request(rpc_request("script", {"path": str(script)}), _make_state())
         assert keep is True
         assert resp["error"]["code"] == -32002
         assert resp["error"]["message"].startswith("syntax error:")
@@ -135,21 +130,21 @@ class TestScriptErrorPaths:
 
     def test_runtime_error(self, tmp_path: Path) -> None:
         script = _write_script(tmp_path, 'raise ValueError("bad input")')
-        resp, keep = _handle_request(_req("script", path=str(script)), _make_state())
+        resp, keep = _handle_request(rpc_request("script", {"path": str(script)}), _make_state())
         assert keep is True
         assert resp["error"]["code"] == -32002
         assert "script error: ValueError: bad input" in resp["error"]["message"]
 
     def test_system_exit(self, tmp_path: Path) -> None:
         script = _write_script(tmp_path, "import sys; sys.exit(0)")
-        resp, keep = _handle_request(_req("script", path=str(script)), _make_state())
+        resp, keep = _handle_request(rpc_request("script", {"path": str(script)}), _make_state())
         assert keep is True
         assert resp["error"]["code"] == -32002
         assert "script error: SystemExit: 0" in resp["error"]["message"]
 
     def test_keyboard_interrupt(self, tmp_path: Path) -> None:
         script = _write_script(tmp_path, "raise KeyboardInterrupt()")
-        resp, keep = _handle_request(_req("script", path=str(script)), _make_state())
+        resp, keep = _handle_request(rpc_request("script", {"path": str(script)}), _make_state())
         assert keep is True
         assert resp["error"]["code"] == -32002
         assert "KeyboardInterrupt" in resp["error"]["message"]
@@ -159,20 +154,20 @@ class TestScriptIsolation:
     def test_stdout_restored(self, tmp_path: Path) -> None:
         original_stdout = sys.stdout
         script = _write_script(tmp_path, 'print("captured")')
-        _handle_request(_req("script", path=str(script)), _make_state())
+        _handle_request(rpc_request("script", {"path": str(script)}), _make_state())
         assert sys.stdout is original_stdout
 
     def test_stdout_restored_on_error(self, tmp_path: Path) -> None:
         original_stdout = sys.stdout
         script = _write_script(tmp_path, 'raise RuntimeError("boom")')
-        _handle_request(_req("script", path=str(script)), _make_state())
+        _handle_request(rpc_request("script", {"path": str(script)}), _make_state())
         assert sys.stdout is original_stdout
 
     def test_independent_globals(self, tmp_path: Path) -> None:
         script1 = _write_script(tmp_path, "result = 111", "s1.py")
         script2 = _write_script(tmp_path, "result = 222", "s2.py")
         state = _make_state()
-        resp1, _ = _handle_request(_req("script", path=str(script1)), state)
-        resp2, _ = _handle_request(_req("script", path=str(script2)), state)
+        resp1, _ = _handle_request(rpc_request("script", {"path": str(script1)}), state)
+        resp2, _ = _handle_request(rpc_request("script", {"path": str(script2)}), state)
         assert resp1["result"]["return_value"] == 111
         assert resp2["result"]["return_value"] == 222

--- a/tests/unit/test_unix_helpers_commands.py
+++ b/tests/unit/test_unix_helpers_commands.py
@@ -148,10 +148,6 @@ def test_count_shaders(monkeypatch) -> None:
 
 
 def test_count_shaders_handler(monkeypatch) -> None:
-    import sys
-    from pathlib import Path
-
-    sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
     import mock_renderdoc as rd
 
     from rdc.adapter import RenderDocAdapter

--- a/tests/unit/test_vfs_tree_cache.py
+++ b/tests/unit/test_vfs_tree_cache.py
@@ -2,13 +2,7 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import pytest
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "mocks"))
-
 from mock_renderdoc import (
     ActionDescription,
     ActionFlags,


### PR DESCRIPTION
## Summary
- Consolidate `_require_renderdoc()` from `remote.py` / `capture_control.py` into `commands/_helpers.py`
- Add `pythonpath` to `pyproject.toml`, remove `sys.path.insert` from 42 test files
- Create shared `rpc_request()` in `tests/unit/conftest.py`, replace 26 local `_req()` definitions
- Net -499 lines of mechanical duplication, zero behavioral change

## Test plan
- [x] `pixi run lint` — all checks passed
- [x] `pixi run test` — 2135 passed, 94.95% coverage
- [x] Pre-push e2e — 26 passed
- [x] Regression: `grep -r "sys.path.insert" tests/` → 0 matches
- [x] Regression: `grep -rn "def _req(" tests/` → 0 matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to reduce duplication and streamline test infrastructure. These changes maintain all existing functionality with zero behavioral modifications to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->