### PR TITLE
refactor(tests): consolidate test boilerplate into shared helpers (Phase R2)

### DIFF
--- a/openspec/changes/2026-02-24-phase-r2-test-infrastructure/proposal.md
+++ b/openspec/changes/2026-02-24-phase-r2-test-infrastructure/proposal.md
@@ -1,0 +1,88 @@
+# Phase R2: Test Infrastructure Consolidation
+
+## Motivation
+
+Phase R1 eliminated the most widespread copy-paste patterns in source and test files.
+R2 targets the next layer of duplication that R1 left in scope: daemon state
+construction, CLI monkeypatching, and output format assertions.
+
+All changes are pure refactors — zero behavioral change, zero modification to
+production code.
+
+## Changes
+
+### R2.1 Shared `make_daemon_state()` builder
+
+23 definitions of `_make_state()` exist across the test suite. Signatures diverge:
+
+- Minimal: `_make_state() -> DaemonState` (no args, hardcoded defaults)
+- With controller: `_make_state(ctrl: MockReplayController) -> DaemonState`
+- With actions: `_make_state(actions: list | None) -> DaemonState`
+- With pipe: `_make_state(tmp_path, pipe: MockPipeState) -> DaemonState`
+- With remote flag: `_make_state(*, is_remote: bool) -> DaemonState`
+- Miscellaneous overrides: `_make_state_with_ps()`, `_make_state_with_cbuffer()`, etc.
+
+A single `make_daemon_state()` factory in `tests/unit/conftest.py` accepting
+keyword-only arguments covers all variants. Fields not provided default to
+sensible values (`capture="test.rdc"`, `current_eid=0`, `token="tok"`,
+`max_eid=100`, `rd=mock_renderdoc`, etc.).
+
+Files affected: `test_draws_daemon.py`, `test_vfs_daemon.py`,
+`test_capturefile_handlers.py`, `test_daemon_output_quality.py`,
+`test_tex_stats_handler.py`, `test_draws_events_daemon.py`,
+`test_pipeline_section_routing.py`, `test_script_handler.py`,
+`test_handlers_remote.py`, `test_descriptors_daemon.py`,
+`test_fix1_draws_pass_name.py`, `test_pipeline_daemon.py`,
+`test_debug_handlers.py`, `test_pick_pixel_daemon.py`,
+`test_binary_daemon.py`, `test_pixel_history_daemon.py`,
+`test_shader_edit_handlers.py`, `test_daemon_shader_api_fix.py`,
+`test_daemon_pipeline_extended.py`.
+
+### R2.2 CLI monkeypatch fixture
+
+15 test files import `rdc.commands._helpers as mod` and repeat:
+
+```python
+session = type("S", (), {"host": "127.0.0.1", "port": 1, "token": "tok"})()
+monkeypatch.setattr(mod, "load_session", lambda: session)
+monkeypatch.setattr(mod, "send_request", lambda _h, _p, _payload: {"result": response})
+```
+
+A `patch_helpers` fixture (or helper function) in `conftest.py` encapsulates
+this pattern. It accepts a `response` dict and an optional `session` override,
+and handles the import and both `setattr` calls.
+
+Inconsistent import paths (`import rdc.commands._helpers` at function scope vs
+module scope) are normalized to module-scope imports where safe.
+
+### R2.3 Output assertion helpers
+
+CLI tests assert on JSON, JSONL, and TSV outputs with inline boilerplate:
+
+- JSON: `data = json.loads(result.output); assert data[key] == value`
+- JSONL: `lines = [json.loads(ln) for ln in result.output.strip().splitlines()]`
+- TSV: `assert "COL1\tCOL2" in result.output`
+
+Three helpers in `conftest.py`:
+
+- `assert_json_output(result, **checks)` — parses and asserts dict keys
+- `assert_jsonl_output(result) -> list[dict]` — returns parsed lines
+- `assert_tsv_output(result, header=None)` — asserts header row and returns rows
+
+## Risks
+
+- **R2.1**: Some `_make_state` variants set uncommon fields (`disasm_cache`,
+  `replay_output`, `built_shaders`). The factory must expose these via `**kwargs`
+  forwarded to `DaemonState`, or tests that need them keep a local wrapper. Audit
+  required before removal.
+- **R2.2**: `send_request` lambda signatures differ subtly across files
+  (`_h, _p, _payload` vs `*a`). The fixture must choose the most permissive form
+  or expose a `send_fn` override parameter.
+- **R2.3**: Helpers are pure convenience — no risk of hiding assertion intent.
+  Must not swallow `result.exit_code` checks (callers remain responsible).
+
+## Out of Scope
+
+- Command layer unification (R3)
+- Handler consolidation (R4)
+- Any modification to production source code

--- a/openspec/changes/2026-02-24-phase-r2-test-infrastructure/tasks.md
+++ b/openspec/changes/2026-02-24-phase-r2-test-infrastructure/tasks.md
@@ -1,0 +1,64 @@
+# Phase R2: Tasks
+
+## R2.1 Shared `make_daemon_state()` builder [1.5h]
+
+- [ ] Add `make_daemon_state()` to `tests/unit/conftest.py` with signature:
+  `make_daemon_state(ctrl=None, *, capture="test.rdc", eid=0, token="tok", api_name=None, max_eid=None, rd_mod=None, **kwargs) -> DaemonState`
+  `**kwargs` forwards to DaemonState for uncommon fields (structured_file, vfs_tree, disasm_cache, built_shaders, is_remote, etc.)
+- [ ] Replace `_make_state()` in `tests/unit/test_capturefile_handlers.py` — note: uses `SimpleNamespace`, not `DaemonState`; skip or adapt separately
+- [ ] Replace `_make_state()` in `tests/unit/test_vfs_daemon.py`
+- [ ] Replace `_make_state()` in `tests/unit/test_draws_daemon.py`
+- [ ] Replace `_make_state()` in `tests/unit/test_fix1_draws_pass_name.py`
+- [ ] Replace `_make_state()` in `tests/unit/test_daemon_pipeline_extended.py`
+- [ ] Replace `_make_state()` in `tests/unit/test_tex_stats_handler.py`
+- [ ] Replace `_make_state()` in `tests/unit/test_handlers_remote.py`
+- [ ] Replace `_make_state()` in `tests/unit/test_script_handler.py`
+- [ ] Replace `_make_state()` in `tests/unit/test_pipeline_section_routing.py`
+- [ ] Replace `_make_state()` in `tests/unit/test_draws_events_daemon.py`
+- [ ] Replace `_make_state()` in `tests/unit/test_daemon_output_quality.py`
+- [ ] Replace `_make_state()` in `tests/unit/test_pixel_history_daemon.py`
+- [ ] Replace `_make_state()` in `tests/unit/test_pipeline_daemon.py`
+- [ ] Replace `_make_state()` in `tests/unit/test_pick_pixel_daemon.py`
+- [ ] Replace `_make_state()` in `tests/unit/test_debug_handlers.py`
+- [ ] Replace `_make_state()` in `tests/unit/test_shader_edit_handlers.py`
+- [ ] Replace `_make_state_with_temp()` in `tests/unit/test_binary_daemon.py`
+- [ ] Replace `_make_state_with_pipe()` in `tests/unit/test_descriptors_daemon.py`
+- [ ] Replace `_make_state_with_*()` variants in `tests/unit/test_daemon_shader_api_fix.py` (3 variants: _ps, _cbuffer, _vfs)
+- [ ] Verify `test_daemon_handlers_real.py` is untouched (different pattern — real adapter)
+
+## R2.2 CLI monkeypatch helper [1h]
+
+- [ ] Add `mock_cli_session()` fixture to `tests/unit/conftest.py` that patches
+  `rdc.commands._helpers.load_session` and `rdc.commands._helpers.send_request`
+  and accepts a `response` dict; returns a `CliRunner` instance
+- [ ] Replace local `_patch()` helpers in:
+  - `tests/unit/test_capturefile_commands.py`
+  - `tests/unit/test_info_commands.py`
+  - `tests/unit/test_pipeline_commands.py`
+  - `tests/unit/test_pipeline_cli_phase27.py`
+  - `tests/unit/test_resources_commands.py`
+  - `tests/unit/test_resources_filter.py`
+  - `tests/unit/test_search.py`
+  - `tests/unit/test_unix_helpers_commands.py`
+- [ ] Update string-based monkeypatches in:
+  - `tests/unit/test_draws_events_cli.py`
+  - `tests/unit/test_pixel_history_commands.py`
+  - `tests/unit/test_snapshot_command.py`
+
+## R2.3 Output assertion helpers [0.5h]
+
+- [ ] Add `assert_json_output(result, *, exit_code=0)` to `tests/unit/conftest.py`:
+  parses result.output as JSON, asserts exit_code, returns parsed dict
+- [ ] Add `assert_jsonl_output(result, *, exit_code=0)` to `tests/unit/conftest.py`:
+  splits lines, parses each as JSON, asserts exit_code, returns list of dicts
+- [ ] Add `assert_tsv_output(result, *, exit_code=0, has_header=True)` to `tests/unit/conftest.py`:
+  splits lines, validates tab-separated structure, returns list of rows
+- [ ] Add `assert_quiet_output(result, *, exit_code=0)` to `tests/unit/conftest.py`:
+  asserts exit_code and output is empty or whitespace-only
+- [ ] Replace ad-hoc inline JSON parse + exit_code assertions in at least 5 test files
+  to validate the helpers work; no requirement to replace all instances
+
+## Validation [0.25h]
+
+- [ ] `pixi run lint` — zero new warnings
+- [ ] `pixi run test` — no regressions, coverage unchanged

--- a/openspec/changes/2026-02-24-phase-r2-test-infrastructure/test-plan.md
+++ b/openspec/changes/2026-02-24-phase-r2-test-infrastructure/test-plan.md
@@ -1,0 +1,191 @@
+# Phase R2 — Test Infrastructure Refactoring: Test Plan
+
+## Scope
+
+Pure regression validation. R2 introduces no new behavior — only consolidates existing boilerplate
+into shared helpers in `tests/unit/conftest.py`. All 2135 tests must continue to pass at ≥94%
+coverage. No new test cases are added; no test logic changes semantically.
+
+---
+
+## Acceptance Criteria
+
+| Criterion | Verification |
+|-----------|-------------|
+| All 2135 tests pass | `pixi run test` exits 0 |
+| Coverage stays ≥ 94% | Coverage report shows ≥ 94% total |
+| No local `_make_state()` definitions remain in daemon handler tests | `grep` count = 0 (see TC-1) |
+| No inline `import rdc.commands._helpers as mod` inside test functions | `grep` count = 0 (see TC-2) |
+| No repeated session stub construction (`type("S", ...)`) | `grep` count = 0 (see TC-3) |
+| Output assertion boilerplate replaced with shared helpers | Spot-check selected files (see TC-4) |
+| `conftest.py` exports remain backward-compatible | `rpc_request()` still callable from all importing tests |
+
+---
+
+## TC-1: `make_daemon_state()` consolidation
+
+**Objective**: Verify that all local `_make_state*()` definitions in daemon handler test files
+have been replaced by imports of `make_daemon_state()` from `conftest`.
+
+**Verification command**:
+```bash
+grep -rn "^def _make_state" tests/unit/ --include="*.py"
+```
+**Expected**: zero matches (pattern without `\b` catches `_make_state_with_*` variants too).
+
+**Files that must be migrated** (19 files, baseline from pre-R2):
+- `test_daemon_pipeline_extended.py`
+- `test_draws_daemon.py`
+- `test_vfs_daemon.py`
+- `test_capturefile_handlers.py`
+- `test_daemon_output_quality.py`
+- `test_tex_stats_handler.py`
+- `test_draws_events_daemon.py`
+- `test_pipeline_section_routing.py`
+- `test_script_handler.py`
+- `test_handlers_remote.py`
+- `test_fix1_draws_pass_name.py`
+- `test_pipeline_daemon.py`
+- `test_debug_handlers.py`
+- `test_pick_pixel_daemon.py`
+- `test_pixel_history_daemon.py`
+- `test_shader_edit_handlers.py`
+- `test_binary_daemon.py` (`_make_state_with_temp`)
+- `test_descriptors_daemon.py` (`_make_state_with_pipe`)
+- `test_daemon_shader_api_fix.py` (`_make_state_with_ps`, `_make_state_with_cbuffer`, `_make_state_with_vfs`)
+
+**Spot-check**: import in each migrated file:
+```bash
+grep "from conftest import.*make_daemon_state" tests/unit/test_draws_daemon.py
+grep "from conftest import.*make_daemon_state" tests/unit/test_vfs_daemon.py
+grep "from conftest import.*make_daemon_state" tests/unit/test_debug_handlers.py
+```
+Each must return exactly one match.
+
+---
+
+## TC-2: CLI monkeypatch helper consolidation
+
+**Objective**: Verify that inline `import rdc.commands._helpers as mod` inside test functions or
+local `_patch()` wrappers have been replaced by a shared `patch_cli()` fixture or helper from
+`conftest`.
+
+**Verification command** (inline import inside functions):
+```bash
+grep -rn "import rdc.commands._helpers as" tests/unit/ --include="*.py"
+```
+**Expected**: zero matches (all imports moved to `conftest.py`).
+
+**Verification command** (session stub duplication):
+```bash
+grep -rn 'type("S", (), {"host"' tests/unit/ --include="*.py"
+```
+**Expected**: zero matches in test files (only in `conftest.py`).
+
+**Verification command** (string-based monkeypatches):
+```bash
+grep -rn 'setattr("rdc.commands._helpers' tests/unit/ --include="*.py" | grep -v conftest.py
+```
+**Expected**: zero matches (all migrated to shared helper).
+
+---
+
+## TC-3: Session stub deduplication
+
+**Objective**: The session stub `type("S", (), {"host": "127.0.0.1", "port": 1, "token": "tok"})()`
+must appear only inside `conftest.py`, not in individual test files.
+
+**Verification command**:
+```bash
+grep -rn '"host": "127.0.0.1"' tests/unit/ --include="*.py" | grep -v conftest.py
+```
+**Expected**: zero matches.
+
+---
+
+## TC-4: Output assertion helpers
+
+**Objective**: Spot-check that `assert_json_output()`, `assert_jsonl_output()` (or equivalent
+helpers) are used in the five highest-boilerplate CLI test files.
+
+**Verification command**:
+```bash
+grep -rn "assert_json_output\|assert_jsonl_output" tests/unit/ --include="*.py"
+```
+**Expected**: matches in at least:
+- `test_resources_commands.py`
+- `test_pipeline_commands.py`
+- `test_capturefile_commands.py`
+- `test_debug_commands.py`
+- `test_tex_stats_commands.py`
+
+**Anti-pattern check** — inline `json.loads(result.output)` in CLI test files should be eliminated
+or reduced significantly:
+```bash
+grep -rn "json\.loads(result\.output)" tests/unit/ --include="*.py" | grep -v conftest.py | wc -l
+```
+**Expected**: count reduced from 37 (pre-R2 baseline) toward 0; must not exceed 10.
+
+---
+
+## TC-5: `rpc_request()` backward compatibility
+
+**Objective**: The existing `rpc_request()` helper (present since R1) must remain callable with the
+same signature and produce identical output.
+
+**Verification**: All tests that import `rpc_request` from `conftest` must pass without
+modification.
+
+**Verification command**:
+```bash
+grep -rn "from conftest import rpc_request" tests/unit/ --include="*.py" | wc -l
+```
+**Expected**: same count as pre-R2 (no imports removed).
+
+**Functional check**: Run `pixi run test -k "vfs_daemon or draws_daemon"` — must pass with zero
+failures.
+
+---
+
+## TC-6: Full test suite regression
+
+**Objective**: Zero regressions across all test files after refactoring.
+
+**Verification command**:
+```bash
+pixi run test
+```
+**Expected output** (last lines):
+```
+2135 passed in ...
+Required test coverage of 80% reached. Total coverage: 94.xx%
+```
+
+Exact pass count must equal pre-R2 baseline (2135). Coverage must not drop below 94.0%.
+
+---
+
+## TC-7: Lint and type check
+
+**Objective**: No new lint or type errors introduced in `conftest.py` or migrated test files.
+
+**Verification command**:
+```bash
+pixi run lint
+```
+**Expected**: exits 0, zero ruff errors.
+
+```bash
+pixi run typecheck
+```
+**Expected**: exits 0, zero mypy errors.
+
+---
+
+## Non-Goals
+
+- This test plan does NOT validate new behaviors or new test cases.
+- Tests for the helper functions themselves (e.g., unit-testing `make_daemon_state()`) are out of
+  scope — helpers are validated indirectly by the full suite passing.
+- GPU integration tests (`test_daemon_handlers_real.py`) are not affected by R2 and are excluded
+  from scope.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
+
+import pytest
+
+from rdc.adapter import RenderDocAdapter
+from rdc.daemon_server import DaemonState
 
 
 def rpc_request(
@@ -18,3 +26,131 @@ def rpc_request(
         "method": method,
         "params": {"_token": token, **(params or {})},
     }
+
+
+def make_daemon_state(
+    *,
+    capture: str = "test.rdc",
+    current_eid: int = 0,
+    token: str = "tok",
+    ctrl: Any | None = None,
+    version: tuple[int, int] = (1, 41),
+    api_name: str = "Vulkan",
+    max_eid: int = 100,
+    structured_file: Any | None = None,
+    rd: Any | None = None,
+    tmp_path: Path | None = None,
+    pipe_state: Any | None = None,
+    actions: list[Any] | None = None,
+    is_remote: bool = False,
+    **kwargs: Any,
+) -> DaemonState:
+    """Build a DaemonState for daemon handler tests.
+
+    Args:
+        capture: Capture filename.
+        current_eid: Current event ID.
+        token: Auth token.
+        ctrl: Replay controller (SimpleNamespace or MockReplayController).
+            If None, a minimal SimpleNamespace controller is created.
+        version: RenderDoc version tuple for the adapter.
+        api_name: Graphics API name.
+        max_eid: Maximum event ID.
+        structured_file: Structured file object. Defaults to empty SimpleNamespace.
+        rd: Mock renderdoc module.
+        tmp_path: Temp directory path.
+        pipe_state: Pipeline state for the controller's GetPipelineState.
+        actions: Action list for the controller's GetRootActions.
+        is_remote: Whether this is a remote-mode state.
+        **kwargs: Additional DaemonState attributes to set directly.
+    """
+    if ctrl is None:
+        sf = structured_file or SimpleNamespace(chunks=[])
+        ctrl = SimpleNamespace(
+            GetRootActions=lambda: actions or [],
+            GetResources=lambda: [],
+            GetAPIProperties=lambda: SimpleNamespace(pipelineType=api_name),
+            GetPipelineState=lambda: pipe_state or SimpleNamespace(),
+            SetFrameEvent=lambda eid, force: None,
+            GetStructuredFile=lambda: sf,
+            GetDebugMessages=lambda: [],
+            Shutdown=lambda: None,
+        )
+
+    state = DaemonState(capture=capture, current_eid=current_eid, token=token)
+    state.adapter = RenderDocAdapter(controller=ctrl, version=version)
+    state.api_name = api_name
+    state.max_eid = max_eid
+    if structured_file is not None:
+        state.structured_file = structured_file
+    if rd is not None:
+        state.rd = rd
+    if tmp_path is not None:
+        state.temp_dir = tmp_path
+    state.is_remote = is_remote
+    for key, val in kwargs.items():
+        setattr(state, key, val)
+    return state
+
+
+def patch_cli_session(
+    monkeypatch: pytest.MonkeyPatch,
+    response: dict[str, Any] | None = None,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 1,
+    token: str = "tok",
+) -> None:
+    """Patch load_session and send_request for CLI command tests.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture.
+        response: Dict to wrap as ``{"result": response}`` and return from
+            ``send_request``.  Pass ``None`` to simulate "no active session".
+        host: Fake session host.
+        port: Fake session port.
+        token: Fake session token.
+    """
+    import rdc.commands._helpers as mod
+
+    if response is None:
+        monkeypatch.setattr(mod, "load_session", lambda: None)
+        return
+
+    session = type("S", (), {"host": host, "port": port, "token": token})()
+    monkeypatch.setattr(mod, "load_session", lambda: session)
+    monkeypatch.setattr(mod, "send_request", lambda _h, _p, _payload: {"result": response})
+
+
+def assert_json_output(result: Any) -> dict[str, Any]:
+    """Assert CLI result succeeded with valid JSON and return parsed dict.
+
+    Args:
+        result: ``click.testing.Result`` from ``CliRunner().invoke()``.
+
+    Returns:
+        Parsed JSON dict.
+    """
+    assert result.exit_code == 0
+    data: dict[str, Any] = json.loads(result.output)
+    return data
+
+
+def assert_jsonl_output(
+    result: Any,
+    expected_count: int | None = None,
+) -> list[dict[str, Any]]:
+    """Assert CLI result succeeded with valid JSONL and return parsed list.
+
+    Args:
+        result: ``click.testing.Result`` from ``CliRunner().invoke()``.
+        expected_count: If given, assert the number of JSONL lines matches.
+
+    Returns:
+        List of parsed JSON dicts, one per line.
+    """
+    assert result.exit_code == 0
+    lines = [json.loads(ln) for ln in result.output.strip().splitlines()]
+    if expected_count is not None:
+        assert len(lines) == expected_count
+    return lines

--- a/tests/unit/test_capturefile_commands.py
+++ b/tests/unit/test_capturefile_commands.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import json
-
 from click.testing import CliRunner
+from conftest import assert_json_output, patch_cli_session
 
 from rdc.commands.capturefile import (
     gpus_cmd,
@@ -13,30 +12,20 @@ from rdc.commands.capturefile import (
     thumbnail_cmd,
 )
 
-
-def _patch(monkeypatch, response):
-    """Patch load_session and send_request for CLI command tests."""
-    import rdc.commands._helpers as mod
-
-    session = type("S", (), {"host": "127.0.0.1", "port": 1, "token": "tok"})()
-    monkeypatch.setattr(mod, "load_session", lambda: session)
-    monkeypatch.setattr(mod, "send_request", lambda _h, _p, _payload: {"result": response})
-
-
 # ---------------------------------------------------------------------------
 # thumbnail
 # ---------------------------------------------------------------------------
 
 
 def test_thumbnail_cmd(monkeypatch) -> None:
-    _patch(monkeypatch, {"data": "AQID", "width": 4, "height": 4})
+    patch_cli_session(monkeypatch, {"data": "AQID", "width": 4, "height": 4})
     result = CliRunner().invoke(thumbnail_cmd, [])
     assert result.exit_code == 0
     assert "4x4" in result.output
 
 
 def test_thumbnail_cmd_output(monkeypatch, tmp_path) -> None:
-    _patch(monkeypatch, {"data": "AQID", "width": 4, "height": 4})
+    patch_cli_session(monkeypatch, {"data": "AQID", "width": 4, "height": 4})
     out = tmp_path / "thumb.png"
     result = CliRunner().invoke(thumbnail_cmd, ["-o", str(out)])
     assert result.exit_code == 0
@@ -45,11 +34,10 @@ def test_thumbnail_cmd_output(monkeypatch, tmp_path) -> None:
 
 
 def test_thumbnail_cmd_json(monkeypatch) -> None:
-    _patch(monkeypatch, {"data": "AQID", "width": 4, "height": 4})
+    patch_cli_session(monkeypatch, {"data": "AQID", "width": 4, "height": 4})
     result = CliRunner().invoke(thumbnail_cmd, ["--json"])
-    assert result.exit_code == 0
-    parsed = json.loads(result.output)
-    assert parsed["width"] == 4
+    data = assert_json_output(result)
+    assert data["width"] == 4
 
 
 # ---------------------------------------------------------------------------
@@ -62,22 +50,21 @@ def _gpu_entry() -> dict:
 
 
 def test_gpus_cmd(monkeypatch) -> None:
-    _patch(monkeypatch, {"gpus": [_gpu_entry()]})
+    patch_cli_session(monkeypatch, {"gpus": [_gpu_entry()]})
     result = CliRunner().invoke(gpus_cmd, [])
     assert result.exit_code == 0
     assert "RTX 4090" in result.output
 
 
 def test_gpus_cmd_json(monkeypatch) -> None:
-    _patch(monkeypatch, {"gpus": [_gpu_entry()]})
+    patch_cli_session(monkeypatch, {"gpus": [_gpu_entry()]})
     result = CliRunner().invoke(gpus_cmd, ["--json"])
-    assert result.exit_code == 0
-    parsed = json.loads(result.output)
-    assert len(parsed["gpus"]) == 1
+    data = assert_json_output(result)
+    assert len(data["gpus"]) == 1
 
 
 def test_gpus_cmd_empty(monkeypatch) -> None:
-    _patch(monkeypatch, {"gpus": []})
+    patch_cli_session(monkeypatch, {"gpus": []})
     result = CliRunner().invoke(gpus_cmd, [])
     assert result.exit_code == 0
     assert "no GPUs found" in result.output
@@ -97,14 +84,14 @@ def test_sections_cmd(monkeypatch) -> None:
         "compressedSize": 0,
         "uncompressedSize": 1024,
     }
-    _patch(monkeypatch, {"sections": [section]})
+    patch_cli_session(monkeypatch, {"sections": [section]})
     result = CliRunner().invoke(sections_cmd, [])
     assert result.exit_code == 0
     assert "FrameCapture" in result.output
 
 
 def test_sections_cmd_empty(monkeypatch) -> None:
-    _patch(monkeypatch, {"sections": []})
+    patch_cli_session(monkeypatch, {"sections": []})
     result = CliRunner().invoke(sections_cmd, [])
     assert result.exit_code == 0
     assert "no sections" in result.output
@@ -116,15 +103,16 @@ def test_sections_cmd_empty(monkeypatch) -> None:
 
 
 def test_section_cmd(monkeypatch) -> None:
-    _patch(monkeypatch, {"name": "Notes", "contents": "hello world", "encoding": "utf-8"})
+    resp = {"name": "Notes", "contents": "hello world", "encoding": "utf-8"}
+    patch_cli_session(monkeypatch, resp)
     result = CliRunner().invoke(section_cmd, ["Notes"])
     assert result.exit_code == 0
     assert "hello world" in result.output
 
 
 def test_section_cmd_json(monkeypatch) -> None:
-    _patch(monkeypatch, {"name": "Notes", "contents": "hello world", "encoding": "utf-8"})
+    resp = {"name": "Notes", "contents": "hello world", "encoding": "utf-8"}
+    patch_cli_session(monkeypatch, resp)
     result = CliRunner().invoke(section_cmd, ["Notes", "--json"])
-    assert result.exit_code == 0
-    parsed = json.loads(result.output)
-    assert parsed["encoding"] == "utf-8"
+    data = assert_json_output(result)
+    assert data["encoding"] == "utf-8"

--- a/tests/unit/test_capturefile_handlers.py
+++ b/tests/unit/test_capturefile_handlers.py
@@ -8,15 +8,13 @@ from typing import Any
 
 import mock_renderdoc as mock_rd
 import pytest
+from conftest import make_daemon_state
 
 
 def _make_state(tmp_path: Path) -> Any:
-    """Build a minimal DaemonState with MockCaptureFile."""
-    from types import SimpleNamespace
-
     cap = mock_rd.MockCaptureFile()
     cap.OpenFile(str(tmp_path / "test.rdc"), "", None)
-    return SimpleNamespace(cap=cap, rd=mock_rd, temp_dir=tmp_path)
+    return make_daemon_state(tmp_path=tmp_path, rd=mock_rd, cap=cap)
 
 
 def _handle(method: str, params: dict[str, Any], state: Any) -> dict[str, Any]:
@@ -72,9 +70,7 @@ def test_thumbnail_maxsize(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_thumbnail_no_cap(tmp_path: Path) -> None:
-    from types import SimpleNamespace
-
-    state = SimpleNamespace(cap=None, rd=mock_rd, temp_dir=tmp_path)
+    state = make_daemon_state(tmp_path=tmp_path, rd=mock_rd)
     resp = _handle("capture_thumbnail", {}, state)
     assert resp["error"]["code"] == -32002
 

--- a/tests/unit/test_counters_commands.py
+++ b/tests/unit/test_counters_commands.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from click.testing import CliRunner
+from conftest import assert_json_output, assert_jsonl_output
 
 from rdc.cli import main
 from rdc.commands import counters as counters_mod
@@ -60,8 +60,7 @@ def test_counters_list_tsv(monkeypatch: Any) -> None:
 def test_counters_list_json(monkeypatch: Any) -> None:
     _patch(monkeypatch, _LIST_RESPONSE)
     result = CliRunner().invoke(main, ["counters", "--list", "--json"])
-    assert result.exit_code == 0
-    data = json.loads(result.output)
+    data = assert_json_output(result)
     assert data["total"] == 2
     assert len(data["counters"]) == 2
 
@@ -113,8 +112,7 @@ def test_counters_name_filter_tsv(monkeypatch: Any) -> None:
 def test_counters_fetch_json(monkeypatch: Any) -> None:
     _patch(monkeypatch, _FETCH_RESPONSE)
     result = CliRunner().invoke(main, ["counters", "--json"])
-    assert result.exit_code == 0
-    data = json.loads(result.output)
+    data = assert_json_output(result)
     assert data["total"] == 3
     assert len(data["rows"]) == 3
 
@@ -140,9 +138,7 @@ def test_counters_list_no_header(monkeypatch: Any) -> None:
 def test_counters_list_jsonl(monkeypatch: Any) -> None:
     _patch(monkeypatch, _LIST_RESPONSE)
     result = CliRunner().invoke(main, ["counters", "--list", "--jsonl"])
-    assert result.exit_code == 0
-    lines = [json.loads(ln) for ln in result.output.strip().splitlines()]
-    assert len(lines) == 2
+    lines = assert_jsonl_output(result, 2)
     assert lines[0]["id"] == 1
     assert lines[0]["name"] == "EventGPUDuration"
 
@@ -176,9 +172,7 @@ def test_counters_fetch_no_header(monkeypatch: Any) -> None:
 def test_counters_fetch_jsonl(monkeypatch: Any) -> None:
     _patch(monkeypatch, _FETCH_RESPONSE)
     result = CliRunner().invoke(main, ["counters", "--jsonl"])
-    assert result.exit_code == 0
-    lines = [json.loads(ln) for ln in result.output.strip().splitlines()]
-    assert len(lines) == 3
+    lines = assert_jsonl_output(result, 3)
     assert lines[0]["eid"] == 10
     assert lines[0]["counter"] == "EventGPUDuration"
 

--- a/tests/unit/test_daemon_shader_api_fix.py
+++ b/tests/unit/test_daemon_shader_api_fix.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import mock_renderdoc as rd
-from conftest import rpc_request
+from conftest import make_daemon_state, rpc_request
 
 from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request
@@ -24,14 +24,8 @@ def _make_state_with_ps() -> DaemonState:
         entryPoint="main_ps",
     )
     ctrl._disasm_text[101] = "SPIR-V code here"
-    a = rd.ActionDescription(eventId=10, flags=rd.ActionFlags.Drawcall)
-    ctrl._actions = [a]
-
-    state = DaemonState(capture="x.rdc", current_eid=0, token="tok")
-    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
-    state.api_name = "Vulkan"
-    state.max_eid = 100
-    return state
+    ctrl._actions = [rd.ActionDescription(eventId=10, flags=rd.ActionFlags.Drawcall)]
+    return make_daemon_state(ctrl=ctrl, capture="x.rdc")
 
 
 # ---------------------------------------------------------------------------
@@ -223,12 +217,7 @@ def _make_state_with_cbuffer() -> DaemonState:
         ),
     ]
     ctrl._actions = [rd.ActionDescription(eventId=10, flags=rd.ActionFlags.Drawcall)]
-
-    state = DaemonState(capture="x.rdc", current_eid=0, token="tok")
-    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
-    state.api_name = "Vulkan"
-    state.max_eid = 100
-    return state
+    return make_daemon_state(ctrl=ctrl, capture="x.rdc")
 
 
 def test_shader_constants_returns_structured_variables() -> None:
@@ -400,13 +389,7 @@ def _make_state_with_vfs() -> DaemonState:
     ctrl._disasm_text[101] = "SPIR-V shader"
     draw = rd.ActionDescription(eventId=10, flags=rd.ActionFlags.Drawcall)
     ctrl._actions = [draw]
-
-    state = DaemonState(capture="x.rdc", current_eid=0, token="tok")
-    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
-    state.api_name = "Vulkan"
-    state.max_eid = 100
-    state.vfs_tree = build_vfs_skeleton([draw], [])
-    return state
+    return make_daemon_state(ctrl=ctrl, capture="x.rdc", vfs_tree=build_vfs_skeleton([draw], []))
 
 
 def test_vfs_ls_shaders_triggers_cache_build() -> None:

--- a/tests/unit/test_debug_commands.py
+++ b/tests/unit/test_debug_commands.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from click.testing import CliRunner
+from conftest import assert_json_output
 
 from rdc.cli import main
 from rdc.commands import debug as debug_mod
@@ -276,8 +276,7 @@ def test_debug_pixel_dump_at_no_match(monkeypatch: Any) -> None:
 def test_debug_pixel_json(monkeypatch: Any) -> None:
     _patch(monkeypatch, _PIXEL_HAPPY_RESPONSE)
     result = CliRunner().invoke(main, ["debug", "pixel", "120", "512", "384", "--json"])
-    assert result.exit_code == 0
-    data = json.loads(result.output)
+    data = assert_json_output(result)
     assert data["stage"] == "ps"
     assert data["total_steps"] == 3
     assert "trace" in data
@@ -374,8 +373,7 @@ def test_debug_vertex_instance_forwarded(monkeypatch: Any) -> None:
 def test_debug_vertex_json(monkeypatch: Any) -> None:
     _patch(monkeypatch, _VERTEX_HAPPY_RESPONSE)
     result = CliRunner().invoke(main, ["debug", "vertex", "120", "0", "--json"])
-    assert result.exit_code == 0
-    data = json.loads(result.output)
+    data = assert_json_output(result)
     assert data["stage"] == "vs"
     assert data["total_steps"] == 2
 
@@ -626,8 +624,7 @@ def test_debug_thread_dump_at_no_match(monkeypatch: Any) -> None:
 def test_debug_thread_json(monkeypatch: Any) -> None:
     _patch(monkeypatch, _THREAD_HAPPY_RESPONSE)
     result = CliRunner().invoke(main, [*_THREAD_ARGS, "--json"])
-    assert result.exit_code == 0
-    data = json.loads(result.output)
+    data = assert_json_output(result)
     assert data["stage"] == "cs"
     assert data["total_steps"] == 3
     assert "trace" in data

--- a/tests/unit/test_debug_handlers.py
+++ b/tests/unit/test_debug_handlers.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import mock_renderdoc as rd
-from conftest import rpc_request
+from conftest import make_daemon_state, rpc_request
 
-from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request
 
 
@@ -72,11 +71,7 @@ def _make_state(
     ctrl._actions = [
         rd.ActionDescription(eventId=100, flags=rd.ActionFlags.Drawcall, _name="vkCmdDraw"),
     ]
-    state = DaemonState(capture="test.rdc", current_eid=100, token="tok")
-    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
-    state.max_eid = 100
-    state.rd = rd
-    return state
+    return make_daemon_state(ctrl=ctrl, current_eid=100, rd=rd)
 
 
 # ---------------------------------------------------------------------------
@@ -407,11 +402,7 @@ def _make_dispatch_state(
     ctrl._actions = [
         rd.ActionDescription(eventId=150, flags=rd.ActionFlags.Dispatch, _name="vkCmdDispatch"),
     ]
-    state = DaemonState(capture="test.rdc", current_eid=150, token="tok")
-    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
-    state.max_eid = 150
-    state.rd = rd
-    return state
+    return make_daemon_state(ctrl=ctrl, current_eid=150, max_eid=150, rd=rd)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_descriptors_daemon.py
+++ b/tests/unit/test_descriptors_daemon.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import mock_renderdoc as rd
+from conftest import make_daemon_state
 from mock_renderdoc import (
     AddressMode,
     Descriptor,
@@ -17,7 +18,6 @@ from mock_renderdoc import (
     UsedDescriptor,
 )
 
-from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request
 
 
@@ -35,18 +35,7 @@ def _make_state_with_pipe(pipe: MockPipeState, **overrides: object) -> DaemonSta
         GetDebugMessages=lambda: [],
         Shutdown=lambda: None,
     )
-    adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
-    defaults: dict[str, object] = {
-        "capture": "test.rdc",
-        "current_eid": 0,
-        "token": "test-token",
-        "adapter": adapter,
-        "rd": rd,
-        "api_name": "Vulkan",
-        "max_eid": 100,
-    }
-    defaults.update(overrides)
-    return DaemonState(**defaults)  # type: ignore[arg-type]
+    return make_daemon_state(ctrl=ctrl, token="test-token", rd=rd, **overrides)  # type: ignore[arg-type]
 
 
 def _call(state: DaemonState, method: str, **params: object) -> dict:

--- a/tests/unit/test_draws_daemon.py
+++ b/tests/unit/test_draws_daemon.py
@@ -7,10 +7,9 @@ from typing import Any
 from unittest.mock import patch
 
 import mock_renderdoc as rd
-from conftest import rpc_request
+from conftest import make_daemon_state, rpc_request
 
-from rdc.adapter import RenderDocAdapter
-from rdc.daemon_server import DaemonState, _handle_request
+from rdc.daemon_server import _handle_request
 from rdc.services.query_service import FlatAction
 
 
@@ -37,15 +36,14 @@ def _build_actions(pass_name: str = "vkCmdBeginRenderPass(C=Load)") -> list:
     return [begin, *draws, end]
 
 
-def _make_state(actions: list | None = None) -> DaemonState:
+def _make_state(actions: list | None = None) -> Any:
     ctrl = rd.MockReplayController()
     ctrl._actions = actions or _build_actions()
-    state = DaemonState(capture="x.rdc", current_eid=0, token="tok")
-    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
-    state.api_name = "Vulkan"
-    state.max_eid = 100
-    state.structured_file = SimpleNamespace(chunks=[])
-    return state
+    return make_daemon_state(
+        capture="x.rdc",
+        ctrl=ctrl,
+        structured_file=SimpleNamespace(chunks=[]),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_draws_events_daemon.py
+++ b/tests/unit/test_draws_events_daemon.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from conftest import rpc_request
+from conftest import make_daemon_state, rpc_request
 from mock_renderdoc import (
     ActionDescription,
     ActionFlags,
@@ -16,7 +16,6 @@ from mock_renderdoc import (
     StructuredFile,
 )
 
-from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request
 
 
@@ -66,7 +65,7 @@ def _build_sf():
 def _make_state():
     actions = _build_actions()
     sf = _build_sf()
-    controller = SimpleNamespace(
+    ctrl = SimpleNamespace(
         GetRootActions=lambda: actions,
         GetResources=lambda: [],
         GetAPIProperties=lambda: SimpleNamespace(pipelineType="Vulkan"),
@@ -76,11 +75,7 @@ def _make_state():
         GetDebugMessages=lambda: [],
         Shutdown=lambda: None,
     )
-    state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
-    state.adapter = RenderDocAdapter(controller=controller, version=(1, 33))
-    state.structured_file = sf
-    state.api_name = "Vulkan"
-    state.max_eid = 300
+    state = make_daemon_state(ctrl=ctrl, version=(1, 33), max_eid=300, structured_file=sf)
     from rdc.vfs.tree_cache import build_vfs_skeleton
 
     state.vfs_tree = build_vfs_skeleton(actions, [], sf=sf)
@@ -244,7 +239,7 @@ def _make_pass_state():
         GetOutputTargets=lambda: [SimpleNamespace(resource=_IntLike(10))],
         GetDepthTarget=lambda: SimpleNamespace(resource=_IntLike(20)),
     )
-    controller = SimpleNamespace(
+    ctrl = SimpleNamespace(
         GetRootActions=lambda: actions,
         GetResources=lambda: [],
         GetAPIProperties=lambda: SimpleNamespace(pipelineType="Vulkan"),
@@ -253,12 +248,7 @@ def _make_pass_state():
         GetStructuredFile=lambda: sf,
         Shutdown=lambda: None,
     )
-    state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
-    state.adapter = RenderDocAdapter(controller=controller, version=(1, 33))
-    state.structured_file = sf
-    state.api_name = "Vulkan"
-    state.max_eid = 300
-    return state
+    return make_daemon_state(ctrl=ctrl, version=(1, 33), max_eid=300, structured_file=sf)
 
 
 def _make_log_state(messages=None):
@@ -266,7 +256,7 @@ def _make_log_state(messages=None):
     actions = _build_actions()
     sf = _build_sf()
     msgs = messages or []
-    controller = SimpleNamespace(
+    ctrl = SimpleNamespace(
         GetRootActions=lambda: actions,
         GetResources=lambda: [],
         GetAPIProperties=lambda: SimpleNamespace(pipelineType="Vulkan"),
@@ -276,12 +266,7 @@ def _make_log_state(messages=None):
         GetDebugMessages=lambda: msgs,
         Shutdown=lambda: None,
     )
-    state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
-    state.adapter = RenderDocAdapter(controller=controller, version=(1, 33))
-    state.structured_file = sf
-    state.api_name = "Vulkan"
-    state.max_eid = 300
-    return state
+    return make_daemon_state(ctrl=ctrl, version=(1, 33), max_eid=300, structured_file=sf)
 
 
 class TestPassHandler:
@@ -422,7 +407,7 @@ class TestEventMultiChunk:
                 APIEvent(eventId=42, chunkIndex=1),
             ],
         )
-        controller = SimpleNamespace(
+        ctrl = SimpleNamespace(
             GetRootActions=lambda: [action],
             GetResources=lambda: [],
             GetAPIProperties=lambda: SimpleNamespace(pipelineType="Vulkan"),
@@ -432,11 +417,7 @@ class TestEventMultiChunk:
             GetDebugMessages=lambda: [],
             Shutdown=lambda: None,
         )
-        state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
-        state.adapter = RenderDocAdapter(controller=controller, version=(1, 33))
-        state.structured_file = sf
-        state.api_name = "Vulkan"
-        state.max_eid = 42
+        state = make_daemon_state(ctrl=ctrl, version=(1, 33), max_eid=42, structured_file=sf)
         from rdc.vfs.tree_cache import build_vfs_skeleton
 
         state.vfs_tree = build_vfs_skeleton([action], [], sf=sf)
@@ -474,7 +455,7 @@ def _build_mesh_actions():
 def _make_mesh_state():
     actions = _build_mesh_actions()
     sf = StructuredFile()
-    controller = SimpleNamespace(
+    ctrl = SimpleNamespace(
         GetRootActions=lambda: actions,
         GetResources=lambda: [],
         GetAPIProperties=lambda: SimpleNamespace(pipelineType="Vulkan"),
@@ -484,11 +465,7 @@ def _make_mesh_state():
         GetDebugMessages=lambda: [],
         Shutdown=lambda: None,
     )
-    state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
-    state.adapter = RenderDocAdapter(controller=controller, version=(1, 33))
-    state.structured_file = sf
-    state.api_name = "Vulkan"
-    state.max_eid = 10
+    state = make_daemon_state(ctrl=ctrl, version=(1, 33), max_eid=10, structured_file=sf)
     from rdc.vfs.tree_cache import build_vfs_skeleton
 
     state.vfs_tree = build_vfs_skeleton(actions, [], sf=sf)

--- a/tests/unit/test_handlers_remote.py
+++ b/tests/unit/test_handlers_remote.py
@@ -5,20 +5,20 @@ from __future__ import annotations
 import threading
 from unittest.mock import MagicMock
 
-from rdc.daemon_server import DaemonState
+from conftest import make_daemon_state
+
 from rdc.handlers.core import _handle_shutdown, _handle_status
 from rdc.handlers.texture import _handle_rt_overlay
 
 
-def _make_state(*, is_remote: bool = False) -> DaemonState:
-    """Build a DaemonState with mock adapter for handler tests."""
+def _make_state(*, is_remote: bool = False):
     controller = MagicMock()
-    state = DaemonState(capture="frame.rdc", current_eid=0, token="tok")
-    from rdc.adapter import RenderDocAdapter
-
-    state.adapter = RenderDocAdapter(controller=controller, version=(1, 41))
-    state.rd = MagicMock()
-    state.is_remote = is_remote
+    state = make_daemon_state(
+        capture="frame.rdc",
+        ctrl=controller,
+        rd=MagicMock(),
+        is_remote=is_remote,
+    )
     if is_remote:
         state.remote = MagicMock()
         state.remote_url = "host:39920"

--- a/tests/unit/test_pick_pixel_commands.py
+++ b/tests/unit/test_pick_pixel_commands.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import json
-
 from click.testing import CliRunner
+from conftest import assert_json_output
 
 import rdc.commands.pick_pixel as mod
 from rdc.cli import main
@@ -41,8 +40,7 @@ def test_pick_pixel_default_output(monkeypatch):
 def test_pick_pixel_json(monkeypatch):
     _patch(monkeypatch)
     r = CliRunner().invoke(pick_pixel_cmd, ["512", "384", "--json"])
-    assert r.exit_code == 0
-    data = json.loads(r.output)
+    data = assert_json_output(r)
     assert "color" in data
     assert data["color"]["r"] == 0.5
     assert data["color"]["g"] == 0.3

--- a/tests/unit/test_pick_pixel_daemon.py
+++ b/tests/unit/test_pick_pixel_daemon.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import mock_renderdoc as rd
-from conftest import rpc_request
+from conftest import make_daemon_state, rpc_request
 
-from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request
 
 
@@ -28,12 +27,13 @@ def _make_state(
         rd.ActionDescription(eventId=120, flags=rd.ActionFlags.Drawcall, _name="vkCmdDraw"),
     ]
 
-    state = DaemonState(capture="test.rdc", current_eid=120, token="tok")
-    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
-    state.max_eid = 120
-    state.rd = rd
-    state.tex_map = {int(t.resourceId): t for t in ctrl._textures}
-    return state
+    return make_daemon_state(
+        ctrl=ctrl,
+        current_eid=120,
+        max_eid=120,
+        rd=rd,
+        tex_map={int(t.resourceId): t for t in ctrl._textures},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pipeline_commands.py
+++ b/tests/unit/test_pipeline_commands.py
@@ -2,23 +2,14 @@
 
 from __future__ import annotations
 
-import json
-
 from click.testing import CliRunner
+from conftest import assert_jsonl_output, patch_cli_session
 
 from rdc.cli import main
 
 
-def _patch_pipeline(monkeypatch, response):
-    import rdc.commands._helpers as mod
-
-    session = type("S", (), {"host": "127.0.0.1", "port": 1, "token": "tok"})()
-    monkeypatch.setattr(mod, "load_session", lambda: session)
-    monkeypatch.setattr(mod, "send_request", lambda _h, _p, _payload: {"result": response})
-
-
 def test_pipeline_tsv(monkeypatch) -> None:
-    _patch_pipeline(
+    patch_cli_session(
         monkeypatch,
         {
             "row": {
@@ -37,7 +28,7 @@ def test_pipeline_tsv(monkeypatch) -> None:
 
 
 def test_pipeline_with_section(monkeypatch) -> None:
-    _patch_pipeline(
+    patch_cli_session(
         monkeypatch,
         {
             "row": {
@@ -64,7 +55,7 @@ def test_pipeline_with_section(monkeypatch) -> None:
 
 
 def test_bindings_tsv(monkeypatch) -> None:
-    _patch_pipeline(
+    patch_cli_session(
         monkeypatch,
         {
             "rows": [
@@ -79,7 +70,7 @@ def test_bindings_tsv(monkeypatch) -> None:
 
 
 def test_bindings_json(monkeypatch) -> None:
-    _patch_pipeline(
+    patch_cli_session(
         monkeypatch,
         {"rows": [{"eid": 10, "stage": "ps", "kind": "RO", "slot": 0, "name": "albedo"}]},
     )
@@ -105,21 +96,21 @@ def test_bindings_with_filters(monkeypatch) -> None:
 
 
 def test_shader_targets(monkeypatch) -> None:
-    _patch_pipeline(monkeypatch, {"targets": ["SPIR-V", "GLSL"]})
+    patch_cli_session(monkeypatch, {"targets": ["SPIR-V", "GLSL"]})
     result = CliRunner().invoke(main, ["shader", "--targets"])
     assert result.exit_code == 0
     assert "SPIR-V" in result.output
 
 
 def test_shader_targets_json(monkeypatch) -> None:
-    _patch_pipeline(monkeypatch, {"targets": ["SPIR-V", "GLSL"]})
+    patch_cli_session(monkeypatch, {"targets": ["SPIR-V", "GLSL"]})
     result = CliRunner().invoke(main, ["shader", "--targets", "--json"])
     assert result.exit_code == 0
     assert "SPIR-V" in result.output
 
 
 def test_shader_all(monkeypatch) -> None:
-    _patch_pipeline(
+    patch_cli_session(
         monkeypatch,
         {
             "eid": 10,
@@ -142,7 +133,7 @@ def test_shader_all(monkeypatch) -> None:
 
 
 def test_shader_all_json(monkeypatch) -> None:
-    _patch_pipeline(
+    patch_cli_session(
         monkeypatch,
         {
             "eid": 10,
@@ -165,7 +156,7 @@ def test_shader_all_json(monkeypatch) -> None:
 
 
 def test_shader_single_tsv(monkeypatch) -> None:
-    _patch_pipeline(
+    patch_cli_session(
         monkeypatch,
         {
             "row": {
@@ -185,7 +176,7 @@ def test_shader_single_tsv(monkeypatch) -> None:
 
 
 def test_shader_single_json(monkeypatch) -> None:
-    _patch_pipeline(
+    patch_cli_session(
         monkeypatch,
         {
             "row": {
@@ -205,7 +196,7 @@ def test_shader_single_json(monkeypatch) -> None:
 
 
 def test_shader_with_source_output(monkeypatch, tmp_path) -> None:
-    _patch_pipeline(
+    patch_cli_session(
         monkeypatch,
         {
             "row": {
@@ -227,7 +218,7 @@ def test_shader_with_source_output(monkeypatch, tmp_path) -> None:
 
 
 def test_shader_with_reflect(monkeypatch) -> None:
-    _patch_pipeline(
+    patch_cli_session(
         monkeypatch,
         {
             "row": {
@@ -255,7 +246,7 @@ def test_shader_with_reflect(monkeypatch) -> None:
 
 
 def test_shader_with_constants(monkeypatch) -> None:
-    _patch_pipeline(
+    patch_cli_session(
         monkeypatch,
         {
             "row": {
@@ -287,7 +278,7 @@ def test_shader_with_constants(monkeypatch) -> None:
 
 
 def test_shaders_list(monkeypatch) -> None:
-    _patch_pipeline(
+    patch_cli_session(
         monkeypatch,
         {
             "rows": [
@@ -303,7 +294,7 @@ def test_shaders_list(monkeypatch) -> None:
 
 
 def test_shaders_json(monkeypatch) -> None:
-    _patch_pipeline(monkeypatch, {"rows": [{"shader": 101, "stages": "ps", "uses": 5}]})
+    patch_cli_session(monkeypatch, {"rows": [{"shader": 101, "stages": "ps", "uses": 5}]})
     result = CliRunner().invoke(main, ["shaders", "--json"])
     assert result.exit_code == 0
     assert '"shader": 101' in result.output
@@ -337,14 +328,14 @@ _BINDINGS_ROWS = {
 
 
 def test_bindings_default_has_header(monkeypatch) -> None:
-    _patch_pipeline(monkeypatch, _BINDINGS_ROWS)
+    patch_cli_session(monkeypatch, _BINDINGS_ROWS)
     result = CliRunner().invoke(main, ["bindings"])
     assert result.exit_code == 0
     assert "EID\tSTAGE\tKIND" in result.output
 
 
 def test_bindings_no_header(monkeypatch) -> None:
-    _patch_pipeline(monkeypatch, _BINDINGS_ROWS)
+    patch_cli_session(monkeypatch, _BINDINGS_ROWS)
     result = CliRunner().invoke(main, ["bindings", "--no-header"])
     assert result.exit_code == 0
     assert "EID\tSTAGE\tKIND" not in result.output
@@ -352,16 +343,14 @@ def test_bindings_no_header(monkeypatch) -> None:
 
 
 def test_bindings_jsonl(monkeypatch) -> None:
-    _patch_pipeline(monkeypatch, _BINDINGS_ROWS)
+    patch_cli_session(monkeypatch, _BINDINGS_ROWS)
     result = CliRunner().invoke(main, ["bindings", "--jsonl"])
-    assert result.exit_code == 0
-    lines = [json.loads(ln) for ln in result.output.strip().splitlines()]
-    assert len(lines) == 2
+    lines = assert_jsonl_output(result, 2)
     assert lines[0]["eid"] == 10
 
 
 def test_bindings_quiet(monkeypatch) -> None:
-    _patch_pipeline(monkeypatch, _BINDINGS_ROWS)
+    patch_cli_session(monkeypatch, _BINDINGS_ROWS)
     result = CliRunner().invoke(main, ["bindings", "-q"])
     assert result.exit_code == 0
     lines = result.output.strip().splitlines()
@@ -379,14 +368,14 @@ _SHADERS_ROWS = {
 
 
 def test_shaders_default_has_header(monkeypatch) -> None:
-    _patch_pipeline(monkeypatch, _SHADERS_ROWS)
+    patch_cli_session(monkeypatch, _SHADERS_ROWS)
     result = CliRunner().invoke(main, ["shaders"])
     assert result.exit_code == 0
     assert "SHADER\tSTAGES\tUSES" in result.output
 
 
 def test_shaders_no_header(monkeypatch) -> None:
-    _patch_pipeline(monkeypatch, _SHADERS_ROWS)
+    patch_cli_session(monkeypatch, _SHADERS_ROWS)
     result = CliRunner().invoke(main, ["shaders", "--no-header"])
     assert result.exit_code == 0
     assert "SHADER\tSTAGES\tUSES" not in result.output
@@ -394,16 +383,14 @@ def test_shaders_no_header(monkeypatch) -> None:
 
 
 def test_shaders_jsonl(monkeypatch) -> None:
-    _patch_pipeline(monkeypatch, _SHADERS_ROWS)
+    patch_cli_session(monkeypatch, _SHADERS_ROWS)
     result = CliRunner().invoke(main, ["shaders", "--jsonl"])
-    assert result.exit_code == 0
-    lines = [json.loads(ln) for ln in result.output.strip().splitlines()]
-    assert len(lines) == 2
+    lines = assert_jsonl_output(result, 2)
     assert lines[0]["shader"] == "abc123"
 
 
 def test_shaders_quiet(monkeypatch) -> None:
-    _patch_pipeline(monkeypatch, _SHADERS_ROWS)
+    patch_cli_session(monkeypatch, _SHADERS_ROWS)
     result = CliRunner().invoke(main, ["shaders", "-q"])
     assert result.exit_code == 0
     lines = result.output.strip().splitlines()

--- a/tests/unit/test_pipeline_daemon.py
+++ b/tests/unit/test_pipeline_daemon.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import mock_renderdoc as rd
-from conftest import rpc_request
+from conftest import make_daemon_state, rpc_request
 
-from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request
 
 
@@ -13,15 +12,9 @@ def _make_state() -> DaemonState:
     ctrl = rd.MockReplayController()
     a = rd.ActionDescription(eventId=10, flags=rd.ActionFlags.Drawcall)
     ctrl._actions = [a]
-    vs_id = rd.ResourceId(1)
-    ps_id = rd.ResourceId(2)
-    ctrl._pipe_state._shaders[rd.ShaderStage.Vertex] = vs_id
-    ctrl._pipe_state._shaders[rd.ShaderStage.Pixel] = ps_id
-    state = DaemonState(capture="x.rdc", current_eid=0, token="tok")
-    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
-    state.api_name = "Vulkan"
-    state.max_eid = 100
-    return state
+    ctrl._pipe_state._shaders[rd.ShaderStage.Vertex] = rd.ResourceId(1)
+    ctrl._pipe_state._shaders[rd.ShaderStage.Pixel] = rd.ResourceId(2)
+    return make_daemon_state(capture="x.rdc", ctrl=ctrl)
 
 
 def _make_state_with_shader_meta() -> DaemonState:

--- a/tests/unit/test_pipeline_section_routing.py
+++ b/tests/unit/test_pipeline_section_routing.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 
 import mock_renderdoc as mock_rd
 import pytest
-from conftest import rpc_request
+from conftest import make_daemon_state, rpc_request
 from mock_renderdoc import (
     ActionDescription,
     ActionFlags,
@@ -19,7 +19,6 @@ from mock_renderdoc import (
     ShaderStage,
 )
 
-from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request
 from rdc.vfs.tree_cache import build_vfs_skeleton
 
@@ -35,7 +34,7 @@ def _build_resources() -> list[ResourceDescription]:
 def _make_state(tmp_path: Path, pipe: MockPipeState) -> DaemonState:
     actions = _build_actions()
     resources = _build_resources()
-    controller = SimpleNamespace(
+    ctrl = SimpleNamespace(
         GetRootActions=lambda: actions,
         GetResources=lambda: resources,
         GetAPIProperties=lambda: SimpleNamespace(pipelineType="Vulkan"),
@@ -47,11 +46,13 @@ def _make_state(tmp_path: Path, pipe: MockPipeState) -> DaemonState:
         GetDebugMessages=lambda: [],
         Shutdown=lambda: None,
     )
-    s = DaemonState(capture="test.rdc", current_eid=0, token="abcdef1234567890")
-    s.adapter = RenderDocAdapter(controller=controller, version=(1, 41))
-    s.max_eid = 10
-    s.rd = mock_rd
-    s.temp_dir = tmp_path
+    s = make_daemon_state(
+        ctrl=ctrl,
+        token="abcdef1234567890",
+        max_eid=10,
+        rd=mock_rd,
+        tmp_path=tmp_path,
+    )
     s.vfs_tree = build_vfs_skeleton(actions, resources)
     return s
 

--- a/tests/unit/test_pixel_history_commands.py
+++ b/tests/unit/test_pixel_history_commands.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from click.testing import CliRunner
+from conftest import assert_json_output, assert_jsonl_output
 
 from rdc.cli import main
 from rdc.commands import pixel as pixel_mod
@@ -142,8 +142,7 @@ def test_sample_forwarded(monkeypatch: Any) -> None:
 def test_json_output(monkeypatch: Any) -> None:
     _patch(monkeypatch, _HAPPY_RESPONSE)
     result = CliRunner().invoke(main, ["pixel", "512", "384", "--json"])
-    assert result.exit_code == 0
-    data = json.loads(result.output)
+    data = assert_json_output(result)
     assert data["x"] == 512
     assert "modifications" in data
 
@@ -226,9 +225,7 @@ def test_pixel_no_header_regression(monkeypatch: Any) -> None:
 def test_pixel_jsonl(monkeypatch: Any) -> None:
     _patch(monkeypatch, _HAPPY_RESPONSE)
     result = CliRunner().invoke(main, ["pixel", "512", "384", "--jsonl"])
-    assert result.exit_code == 0
-    lines = [json.loads(ln) for ln in result.output.strip().splitlines()]
-    assert len(lines) == 2
+    lines = assert_jsonl_output(result, 2)
     assert lines[0]["eid"] == 88
 
 

--- a/tests/unit/test_pixel_history_daemon.py
+++ b/tests/unit/test_pixel_history_daemon.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import math
 
 import mock_renderdoc as rd
-from conftest import rpc_request
+from conftest import make_daemon_state, rpc_request
 
-from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request
 
 
@@ -40,12 +39,13 @@ def _make_state(
         rd.ActionDescription(eventId=120, flags=rd.ActionFlags.Drawcall, _name="vkCmdDraw"),
     ]
 
-    state = DaemonState(capture="test.rdc", current_eid=120, token="tok")
-    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
-    state.max_eid = 120
-    state.rd = rd
-    state.tex_map = {int(t.resourceId): t for t in ctrl._textures}
-    return state
+    return make_daemon_state(
+        ctrl=ctrl,
+        current_eid=120,
+        max_eid=120,
+        rd=rd,
+        tex_map={int(t.resourceId): t for t in ctrl._textures},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_script_handler.py
+++ b/tests/unit/test_script_handler.py
@@ -4,30 +4,14 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from types import SimpleNamespace
 
-from conftest import rpc_request
+from conftest import make_daemon_state, rpc_request
 
-from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request
 
 
 def _make_state() -> DaemonState:
-    controller = SimpleNamespace(
-        GetRootActions=lambda: [],
-        GetResources=lambda: [],
-        GetAPIProperties=lambda: SimpleNamespace(pipelineType="Vulkan"),
-        GetPipelineState=lambda: SimpleNamespace(),
-        SetFrameEvent=lambda eid, force: None,
-        GetStructuredFile=lambda: SimpleNamespace(chunks=[]),
-        GetDebugMessages=lambda: [],
-        Shutdown=lambda: None,
-    )
-    state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
-    state.adapter = RenderDocAdapter(controller=controller, version=(1, 41))
-    state.api_name = "Vulkan"
-    state.max_eid = 10
-    return state
+    return make_daemon_state(max_eid=10)
 
 
 def _write_script(tmp_path: Path, content: str, name: str = "script.py") -> Path:

--- a/tests/unit/test_shader_edit_commands.py
+++ b/tests/unit/test_shader_edit_commands.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from click.testing import CliRunner
+from conftest import assert_json_output
 
 from rdc.cli import main
 from rdc.commands import shader_edit as shader_edit_mod
@@ -51,8 +51,7 @@ def test_shader_encodings_default(monkeypatch: Any) -> None:
 def test_shader_encodings_json(monkeypatch: Any) -> None:
     _patch(monkeypatch, _ENCODINGS_RESPONSE)
     result = CliRunner().invoke(main, ["shader-encodings", "--json"])
-    assert result.exit_code == 0
-    data = json.loads(result.output)
+    data = assert_json_output(result)
     assert len(data["encodings"]) == 2
     assert data["encodings"][0]["name"] == "GLSL"
 
@@ -92,8 +91,7 @@ def test_shader_build_json(monkeypatch: Any, tmp_path: Any) -> None:
     src = tmp_path / "test.frag"
     src.write_text("#version 450\nvoid main(){}\n")
     result = CliRunner().invoke(main, ["shader-build", str(src), "--stage", "ps", "--json"])
-    assert result.exit_code == 0
-    data = json.loads(result.output)
+    data = assert_json_output(result)
     assert data["shader_id"] == 42
 
 

--- a/tests/unit/test_shader_edit_handlers.py
+++ b/tests/unit/test_shader_edit_handlers.py
@@ -5,19 +5,13 @@ from __future__ import annotations
 from typing import Any
 
 import mock_renderdoc as rd
-from conftest import rpc_request
+from conftest import make_daemon_state, rpc_request
 
-from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request
 
 
 def _make_state(ctrl: rd.MockReplayController) -> DaemonState:
-    adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
-    state = DaemonState(capture="test.rdc", current_eid=0, token="tok")
-    state.adapter = adapter
-    state.max_eid = 1000
-    state.rd = rd
-    return state
+    return make_daemon_state(ctrl=ctrl, max_eid=1000, rd=rd)
 
 
 # ── shader_encodings ──────────────────────────────────────────────────

--- a/tests/unit/test_tex_stats_commands.py
+++ b/tests/unit/test_tex_stats_commands.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from click.testing import CliRunner
+from conftest import assert_json_output
 
 from rdc.cli import main
 from rdc.commands import tex_stats as tex_stats_mod
@@ -71,8 +71,7 @@ def test_tex_stats_float_format(monkeypatch: Any) -> None:
 def test_tex_stats_json(monkeypatch: Any) -> None:
     _patch(monkeypatch, _HAPPY_RESPONSE)
     result = CliRunner().invoke(main, ["tex-stats", "42", "--json"])
-    assert result.exit_code == 0
-    data = json.loads(result.output)
+    data = assert_json_output(result)
     assert "min" in data
     assert "max" in data
     assert data["min"]["r"] == 0.0
@@ -96,8 +95,7 @@ def test_tex_stats_histogram_table(monkeypatch: Any) -> None:
 def test_tex_stats_histogram_json(monkeypatch: Any) -> None:
     _patch(monkeypatch, _HISTOGRAM_RESPONSE)
     result = CliRunner().invoke(main, ["tex-stats", "42", "--histogram", "--json"])
-    assert result.exit_code == 0
-    data = json.loads(result.output)
+    data = assert_json_output(result)
     assert "histogram" in data
     assert len(data["histogram"]) == 256
 

--- a/tests/unit/test_tex_stats_handler.py
+++ b/tests/unit/test_tex_stats_handler.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import mock_renderdoc as rd
-from conftest import rpc_request
+from conftest import make_daemon_state, rpc_request
 
-from rdc.adapter import RenderDocAdapter
 from rdc.daemon_server import DaemonState, _handle_request
 
 
@@ -28,11 +27,12 @@ def _make_state(
     if histogram is not None:
         ctrl._histogram_map.update(histogram)
 
-    state = DaemonState(capture="test.rdc", current_eid=100, token="tok")
-    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
-    state.max_eid = 100
-    state.rd = rd
-    state.tex_map = {int(t.resourceId): t for t in ctrl._textures}
+    state = make_daemon_state(
+        ctrl=ctrl,
+        current_eid=100,
+        rd=rd,
+        tex_map={int(t.resourceId): t for t in ctrl._textures},
+    )
     return state
 
 
@@ -100,11 +100,12 @@ def test_tex_stats_mip_slice_forwarded() -> None:
     ctrl._actions = [
         rd.ActionDescription(eventId=100, flags=rd.ActionFlags.Drawcall, _name="vkCmdDraw"),
     ]
-    state = DaemonState(capture="test.rdc", current_eid=100, token="tok")
-    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
-    state.max_eid = 100
-    state.rd = rd
-    state.tex_map = {int(t.resourceId): t for t in ctrl._textures}
+    state = make_daemon_state(
+        ctrl=ctrl,
+        current_eid=100,
+        rd=rd,
+        tex_map={int(t.resourceId): t for t in ctrl._textures},
+    )
     resp, _ = _handle_request(rpc_request("tex_stats", {"id": 42, "mip": 2, "slice": 3}), state)
     r = resp["result"]
     assert r["mip"] == 2
@@ -229,11 +230,12 @@ def test_tex_stats_mip_upper_boundary() -> None:
     ctrl._actions = [
         rd.ActionDescription(eventId=100, flags=rd.ActionFlags.Drawcall, _name="vkCmdDraw"),
     ]
-    state = DaemonState(capture="test.rdc", current_eid=100, token="tok")
-    state.adapter = RenderDocAdapter(controller=ctrl, version=(1, 41))
-    state.max_eid = 100
-    state.rd = rd
-    state.tex_map = {int(t.resourceId): t for t in ctrl._textures}
+    state = make_daemon_state(
+        ctrl=ctrl,
+        current_eid=100,
+        rd=rd,
+        tex_map={int(t.resourceId): t for t in ctrl._textures},
+    )
     resp, _ = _handle_request(rpc_request("tex_stats", {"id": 42, "mip": 3}), state)
     assert "result" in resp
     assert resp["result"]["mip"] == 3

--- a/tests/unit/test_usage_commands.py
+++ b/tests/unit/test_usage_commands.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from click.testing import CliRunner
+from conftest import assert_json_output, assert_jsonl_output
 
 from rdc.cli import main
 from rdc.commands import usage as usage_mod
@@ -49,8 +49,7 @@ def test_usage_single_tsv(monkeypatch: Any) -> None:
 def test_usage_single_json(monkeypatch: Any) -> None:
     _patch(monkeypatch, _SINGLE_RESPONSE)
     result = CliRunner().invoke(main, ["usage", "97", "--json"])
-    assert result.exit_code == 0
-    data = json.loads(result.output)
+    data = assert_json_output(result)
     assert data["id"] == 97
     assert len(data["entries"]) == 3
 
@@ -135,9 +134,7 @@ def test_usage_single_no_header(monkeypatch: Any) -> None:
 def test_usage_single_jsonl(monkeypatch: Any) -> None:
     _patch(monkeypatch, _SINGLE_RESPONSE)
     result = CliRunner().invoke(main, ["usage", "97", "--jsonl"])
-    assert result.exit_code == 0
-    lines = [json.loads(ln) for ln in result.output.strip().splitlines()]
-    assert len(lines) == 3
+    lines = assert_jsonl_output(result, 3)
     assert lines[0]["eid"] == 6
     assert lines[0]["usage"] == "Clear"
 
@@ -171,9 +168,7 @@ def test_usage_all_no_header(monkeypatch: Any) -> None:
 def test_usage_all_jsonl(monkeypatch: Any) -> None:
     _patch(monkeypatch, _ALL_RESPONSE)
     result = CliRunner().invoke(main, ["usage", "--all", "--jsonl"])
-    assert result.exit_code == 0
-    lines = [json.loads(ln) for ln in result.output.strip().splitlines()]
-    assert len(lines) == 4
+    lines = assert_jsonl_output(result, 4)
     assert lines[0]["id"] == 97
     assert lines[0]["name"] == "2D Image 97"
     assert lines[0]["eid"] == 6


### PR DESCRIPTION
## Summary
- Add `make_daemon_state()`, `patch_cli_session()`, `assert_json_output()`, and `assert_jsonl_output()` to `tests/unit/conftest.py`
- Migrate 19 daemon handler test files to delegate DaemonState construction to the shared builder
- Replace local `_patch_*()` CLI test helpers in 5 files with `patch_cli_session()`
- Apply output assertion helpers across 12 CLI test files, removing unused `import json` from 9 files
- Net result: -632 lines of duplicated test boilerplate across 35 files

## Test plan
- [x] `pixi run lint` — zero warnings
- [x] `pixi run typecheck` — zero mypy errors
- [x] `pixi run test` — 2135 passed, 94.95% coverage
- [x] `pixi run e2e` — 26 passed (pre-push hook)
- [x] No remaining `_make_state()` definitions that construct DaemonState directly
- [x] `type("S", ...)` session stubs consolidated into `conftest.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

## Tests
* Refactored test infrastructure to consolidate state creation, session mocking, and output assertion utilities, reducing duplication across test suite without affecting application functionality.

---

**Note:** This release contains no user-facing changes. All modifications are internal test infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->