### PR TITLE
fix(platform,daemon,doctor): macOS test, remote replay GPU init, brew PATH, renderdoccmd paths (B38-B42)

### DIFF
--- a/src/rdc/_platform.py
+++ b/src/rdc/_platform.py
@@ -177,5 +177,10 @@ def renderdoccmd_search_paths() -> list[Path]:
             Path("/opt/homebrew/bin/renderdoccmd"),
             Path("/opt/renderdoc/bin/renderdoccmd"),
             Path("/usr/local/bin/renderdoccmd"),
+            Path.home() / ".local" / "renderdoc" / "renderdoccmd",
         ]
-    return [Path("/opt/renderdoc/bin/renderdoccmd"), Path("/usr/local/bin/renderdoccmd")]
+    return [
+        Path("/opt/renderdoc/bin/renderdoccmd"),
+        Path("/usr/local/bin/renderdoccmd"),
+        Path.home() / ".local" / "renderdoc" / "renderdoccmd",
+    ]

--- a/src/rdc/commands/doctor.py
+++ b/src/rdc/commands/doctor.py
@@ -238,14 +238,20 @@ def _check_mac_homebrew() -> CheckResult:
     """Check if Homebrew is available."""
     if sys.platform != "darwin":
         return CheckResult("mac-homebrew", True, "n/a")
-    if not shutil.which("brew"):
+    brew_path = shutil.which("brew")
+    if not brew_path:
+        for candidate in ("/opt/homebrew/bin/brew", "/usr/local/bin/brew"):
+            if Path(candidate).is_file():
+                brew_path = candidate
+                break
+    if not brew_path:
         return CheckResult(
             "mac-homebrew",
             False,
             "brew not found — install from https://brew.sh",
         )
     try:
-        proc = subprocess.run(["brew", "--version"], capture_output=True, text=True, timeout=5)
+        proc = subprocess.run([brew_path, "--version"], capture_output=True, text=True, timeout=5)
         if proc.returncode != 0:
             detail = proc.stderr.strip() or "brew --version failed"
             return CheckResult("mac-homebrew", False, detail)

--- a/src/rdc/daemon_server.py
+++ b/src/rdc/daemon_server.py
@@ -267,8 +267,8 @@ def _load_remote_replay(state: DaemonState, remote_url: str) -> str | None:
 
     try:
         rd.InitialiseReplay(rd.GlobalEnvironment(), [])
-    except Exception as exc:  # noqa: BLE001
-        return f"InitialiseReplay failed: {exc}"
+    except Exception:  # noqa: BLE001
+        _log.warning("InitialiseReplay skipped for remote replay (no local GPU)")
 
     result, remote = rd.CreateRemoteServerConnection(remote_url)
     if result != rd.ResultCode.Succeeded:

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -336,6 +336,38 @@ class TestRenderdoccmdSearchPathsDarwin:
         result = renderdoccmd_search_paths()
         assert Path("/usr/local/bin/renderdoccmd") in result
 
+    def test_includes_local_renderdoc_darwin(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """B42: darwin includes ~/.local/renderdoc/renderdoccmd."""
+        monkeypatch.setattr("rdc._platform._MAC", True)
+        monkeypatch.setattr("rdc._platform._WIN", False)
+        monkeypatch.setattr("rdc._platform.Path.home", staticmethod(lambda: tmp_path))
+        result = renderdoccmd_search_paths()
+        assert tmp_path / ".local" / "renderdoc" / "renderdoccmd" in result
+
+
+class TestRenderdoccmdSearchPathsLinuxB42:
+    """B42: Linux renderdoccmd search paths include ~/.local/renderdoc/renderdoccmd."""
+
+    def test_includes_local_renderdoc_linux(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """B42: linux includes ~/.local/renderdoc/renderdoccmd."""
+        monkeypatch.setattr("rdc._platform._MAC", False)
+        monkeypatch.setattr("rdc._platform._WIN", False)
+        monkeypatch.setattr("rdc._platform.Path.home", staticmethod(lambda: tmp_path))
+        result = renderdoccmd_search_paths()
+        assert tmp_path / ".local" / "renderdoc" / "renderdoccmd" in result
+
+    def test_existing_linux_paths_still_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """B42: existing linux paths not removed."""
+        monkeypatch.setattr("rdc._platform._MAC", False)
+        monkeypatch.setattr("rdc._platform._WIN", False)
+        result = renderdoccmd_search_paths()
+        assert Path("/opt/renderdoc/bin/renderdoccmd") in result
+        assert Path("/usr/local/bin/renderdoccmd") in result
+
 
 # ── Group C-mac: is_pid_alive() on darwin ─────────────────────────────
 


### PR DESCRIPTION
## Summary

- **B38**: Split `is_pid_alive` tests into Linux/macOS variants with proper monkeypatching — macOS uses `subprocess.run(["ps", ...])`, not `/proc`
- **B39 (P1)**: `_load_remote_replay()` now logs warning and continues when `InitialiseReplay()` fails — remote replay doesn't need local GPU
- **B40**: `_check_mac_homebrew()` falls back to `/opt/homebrew/bin/brew` and `/usr/local/bin/brew` when `shutil.which("brew")` fails in non-login shells
- **B42**: `renderdoccmd_search_paths()` now includes `~/.local/renderdoc/renderdoccmd` on macOS and Linux

B41 (error messages output twice) is deferred — cannot reproduce; likely environment artifact from pixi→uv→python wrapper or SSH buffering.

## Test plan

- [x] `pixi run lint` clean
- [x] `pixi run test` — 2154 passed, 3 skipped (darwin-only on linux), 95.05% coverage
- [x] E2E tests pass (pre-push hook)
- [ ] Verify on macOS: B38 darwin tests run, B39 `rdc open --remote` succeeds, B40 `rdc doctor` finds brew in non-login SSH, B42 `rdc capture --list-apis` finds self-compiled renderdoccmd