### PR TITLE
fix(completion): remove extra slash spacing in open path suggestions

### DIFF
--- a/src/rdc/commands/session.py
+++ b/src/rdc/commands/session.py
@@ -52,9 +52,9 @@ def _complete_capture_path(
         if not child.name.startswith(prefix):
             continue
         if child.is_dir():
-            items.append(CompletionItem(f"{base}{child.name}/"))
+            items.append(CompletionItem(f"{base}{child.name}", type="dir"))
         elif child.suffix.lower() == ".rdc":
-            items.append(CompletionItem(f"{base}{child.name}"))
+            items.append(CompletionItem(f"{base}{child.name}", type="file"))
     return items
 
 

--- a/tests/unit/test_session_completion.py
+++ b/tests/unit/test_session_completion.py
@@ -22,7 +22,7 @@ def test_complete_capture_suggests_dirs_and_rdc(monkeypatch, tmp_path: Path) -> 
     (tmp_path / "notes.txt").touch()
 
     values = [item.value for item in _complete_capture_path(None, None, "")]
-    assert "captures/" in values
+    assert "captures" in values
     assert "frame.rdc" in values
     assert "notes.txt" not in values
 
@@ -44,7 +44,7 @@ def test_complete_capture_nested_path(monkeypatch, tmp_path: Path) -> None:
 
     values = [item.value for item in _complete_capture_path(None, None, "captures/")]
     assert "captures/a.rdc" in values
-    assert "captures/nested/" in values
+    assert "captures/nested" in values
     assert "captures/ignore.bin" not in values
 
 
@@ -58,4 +58,15 @@ def test_complete_capture_nested_path_with_backslashes(monkeypatch, tmp_path: Pa
     values = [item.value for item in _complete_capture_path(None, None, "captures\\a")]
     assert "captures/a.rdc" in values
     assert "captures/b.rdc" not in values
-    assert "captures/nested/" not in values
+    assert "captures/nested" not in values
+
+
+def test_complete_capture_marks_dirs_and_files(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "captures").mkdir()
+    (tmp_path / "frame.rdc").touch()
+
+    items = _complete_capture_path(None, None, "")
+    by_value = {item.value: item for item in items}
+    assert by_value["captures"].type == "dir"
+    assert by_value["frame.rdc"].type == "file"


### PR DESCRIPTION
## Summary
- Update `rdc open` capture completion to emit typed completion items (`dir`/`file`) instead of hardcoding trailing `/` in directory values.
- Keep candidate values clean (no forced trailing slash), which avoids shell-side extra space/slash artifacts during interactive completion.
- Extend session completion tests to assert new value expectations and completion item types.

## Validation
- `pixi run check`
- `pixi run e2e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Shell completion for local capture paths now explicitly identifies directories and files with proper type information
  * Directory names in completion results no longer display with trailing slashes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->