### PR TITLE
feat(cli): add semantic EID completions across commands

### DIFF
--- a/src/rdc/commands/assert_ci.py
+++ b/src/rdc/commands/assert_ci.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import click
 
-from rdc.commands._helpers import _json_mode
+from rdc.commands._helpers import _json_mode, complete_eid
 from rdc.commands.unix_helpers import _COUNT_TARGETS
 from rdc.daemon_client import send_request
 from rdc.protocol import _request
@@ -132,7 +132,7 @@ def _normalize_value(v: Any) -> str:
 
 
 @click.command("assert-pixel")
-@click.argument("eid", type=int)
+@click.argument("eid", type=int, shell_complete=complete_eid)
 @click.argument("x", type=int)
 @click.argument("y", type=int)
 @click.option("--expect", required=True, help="Expected RGBA as 4 space-separated floats.")
@@ -292,7 +292,7 @@ def assert_count_cmd(
 
 
 @click.command("assert-state")
-@click.argument("eid", type=int)
+@click.argument("eid", type=int, shell_complete=complete_eid)
 @click.argument("key_path", metavar="KEY_PATH")
 @click.option("--expect", required=True, help="Expected value.")
 @click.option("--json", "use_json", is_flag=True, help="JSON output.")

--- a/src/rdc/commands/counters.py
+++ b/src/rdc/commands/counters.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import click
 
-from rdc.commands._helpers import call
+from rdc.commands._helpers import call, complete_eid
 from rdc.formatters.json_fmt import write_json, write_jsonl
 from rdc.formatters.options import list_output_options
 from rdc.formatters.tsv import write_tsv
@@ -15,7 +15,13 @@ from rdc.formatters.tsv import write_tsv
 
 @click.command("counters")
 @click.option("--list", "show_list", is_flag=True, help="List available counters.")
-@click.option("--eid", type=int, default=None, help="Filter to specific event ID.")
+@click.option(
+    "--eid",
+    type=int,
+    default=None,
+    shell_complete=complete_eid,
+    help="Filter to specific event ID.",
+)
 @click.option("--name", "name_filter", default=None, help="Filter counters by name substring.")
 @click.option("--json", "use_json", is_flag=True, help="JSON output.")
 @list_output_options

--- a/src/rdc/commands/debug.py
+++ b/src/rdc/commands/debug.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import click
 
-from rdc.commands._helpers import call
+from rdc.commands._helpers import call, complete_eid
 from rdc.formatters.json_fmt import write_json
 
 
@@ -70,7 +70,7 @@ def _print_dump_at(result: dict[str, Any], target_line: int, no_header: bool) ->
 
 
 @debug_group.command("pixel")
-@click.argument("eid", type=int)
+@click.argument("eid", type=int, shell_complete=complete_eid)
 @click.argument("x", type=int)
 @click.argument("y", type=int)
 @click.option("--trace", "show_trace", is_flag=True, help="Full execution trace (TSV)")
@@ -116,7 +116,7 @@ def pixel_cmd(
 
 
 @debug_group.command("thread")
-@click.argument("eid", type=int)
+@click.argument("eid", type=int, shell_complete=complete_eid)
 @click.argument("gx", type=int)
 @click.argument("gy", type=int)
 @click.argument("gz", type=int)
@@ -169,7 +169,7 @@ def thread_cmd(
 
 
 @debug_group.command("vertex")
-@click.argument("eid", type=int)
+@click.argument("eid", type=int, shell_complete=complete_eid)
 @click.argument("vtx_id", type=int)
 @click.option("--trace", "show_trace", is_flag=True, help="Full execution trace (TSV)")
 @click.option("--dump-at", "dump_at", type=int, default=None, help="Var snapshot at LINE")

--- a/src/rdc/commands/diff.py
+++ b/src/rdc/commands/diff.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import click
 
+from rdc.commands._helpers import complete_eid
 from rdc.diff import stats as diff_stats_mod
 from rdc.diff.alignment import align_draws
 from rdc.diff.draws import DiffStatus
@@ -195,7 +196,13 @@ def _handle_summary(ctx: DiffContext, *, use_json: bool) -> None:
     type=float,
     help="Max diff ratio %% to count as identical",
 )
-@click.option("--eid", default=None, type=int, help="Compare at specific EID (default: last draw)")
+@click.option(
+    "--eid",
+    default=None,
+    type=int,
+    shell_complete=complete_eid,
+    help="Compare at specific EID (default: last draw)",
+)
 @click.option(
     "--diff-output",
     default=None,

--- a/src/rdc/commands/events.py
+++ b/src/rdc/commands/events.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import click
 
-from rdc.commands._helpers import call
+from rdc.commands._helpers import call, complete_eid
 from rdc.formatters.json_fmt import write_json, write_jsonl
 from rdc.formatters.kv import write_kv
 from rdc.formatters.tsv import write_footer, write_tsv
@@ -115,7 +115,7 @@ def draws_cmd(
 
 
 @click.command("event")
-@click.argument("eid", type=int)
+@click.argument("eid", type=int, shell_complete=complete_eid)
 @click.option("--json", "use_json", is_flag=True, help="JSON output")
 def event_cmd(eid: int, use_json: bool) -> None:
     """Show single API call detail."""
@@ -127,7 +127,7 @@ def event_cmd(eid: int, use_json: bool) -> None:
 
 
 @click.command("draw")
-@click.argument("eid", type=int, required=False, default=None)
+@click.argument("eid", type=int, required=False, default=None, shell_complete=complete_eid)
 @click.option("--json", "use_json", is_flag=True, help="JSON output")
 def draw_cmd(eid: int | None, use_json: bool) -> None:
     """Show draw call detail."""

--- a/src/rdc/commands/export.py
+++ b/src/rdc/commands/export.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import click
 
-from rdc.commands._helpers import call, fetch_remote_file
+from rdc.commands._helpers import call, complete_eid, fetch_remote_file
 from rdc.commands.vfs import _deliver_binary
 from rdc.session_state import load_session
 from rdc.vfs.router import resolve_path
@@ -42,7 +42,7 @@ def texture_cmd(id: int, output: str | None, mip: int, raw: bool) -> None:
 
 
 @click.command("rt")
-@click.argument("eid", type=int, required=False, default=None)
+@click.argument("eid", type=int, required=False, default=None, shell_complete=complete_eid)
 @click.option("-o", "--output", type=click.Path(), default=None, help="Write to file")
 @click.option("--target", default=0, type=int, help="Color target index (default 0)")
 @click.option("--raw", is_flag=True, help="Force raw output even on TTY")

--- a/src/rdc/commands/info.py
+++ b/src/rdc/commands/info.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import click
 
-from rdc.commands._helpers import call
+from rdc.commands._helpers import call, complete_eid
 from rdc.formatters.json_fmt import write_json, write_jsonl
 from rdc.formatters.kv import write_kv
 from rdc.formatters.options import list_output_options
@@ -82,7 +82,13 @@ def stats_cmd(use_json: bool, no_header: bool, use_jsonl: bool, quiet: bool) -> 
     type=click.Choice(["HIGH", "MEDIUM", "LOW", "INFO", "UNKNOWN"], case_sensitive=False),
     help="Filter by severity.",
 )
-@click.option("--eid", default=None, type=int, help="Filter by event ID.")
+@click.option(
+    "--eid",
+    default=None,
+    type=int,
+    shell_complete=complete_eid,
+    help="Filter by event ID.",
+)
 @click.option("--json", "use_json", is_flag=True, help="JSON output")
 @list_output_options
 def log_cmd(

--- a/src/rdc/commands/mesh.py
+++ b/src/rdc/commands/mesh.py
@@ -7,12 +7,12 @@ from typing import Any
 
 import click
 
-from rdc.commands._helpers import call
+from rdc.commands._helpers import call, complete_eid
 from rdc.formatters.json_fmt import write_json
 
 
 @click.command("mesh")
-@click.argument("eid", type=int, required=False, default=None)
+@click.argument("eid", type=int, required=False, default=None, shell_complete=complete_eid)
 @click.option(
     "--stage",
     type=click.Choice(["vs-out", "gs-out"]),

--- a/src/rdc/commands/pick_pixel.py
+++ b/src/rdc/commands/pick_pixel.py
@@ -6,14 +6,14 @@ from typing import Any
 
 import click
 
-from rdc.commands._helpers import call
+from rdc.commands._helpers import call, complete_eid
 from rdc.formatters.json_fmt import write_json
 
 
 @click.command("pick-pixel")
 @click.argument("x", type=int)
 @click.argument("y", type=int)
-@click.argument("eid", required=False, type=int)
+@click.argument("eid", required=False, type=int, shell_complete=complete_eid)
 @click.option("--target", default=0, type=int, help="Color target index (default 0)")
 @click.option("--json", "use_json", is_flag=True, help="JSON output")
 def pick_pixel_cmd(x: int, y: int, eid: int | None, target: int, use_json: bool) -> None:

--- a/src/rdc/commands/pipeline.py
+++ b/src/rdc/commands/pipeline.py
@@ -9,7 +9,7 @@ from typing import Any
 import click
 from click.shell_completion import CompletionItem
 
-from rdc.commands._helpers import call
+from rdc.commands._helpers import call, complete_eid
 from rdc.formatters.json_fmt import write_json, write_jsonl
 from rdc.formatters.options import list_output_options
 from rdc.formatters.tsv import format_row, write_tsv
@@ -20,8 +20,19 @@ _SORT_CHOICES = ["name", "stage", "uses"]
 _SHADER_STAGES_CLI: frozenset[str] = frozenset(STAGE_MAP)
 
 
+def _complete_shader_first(
+    ctx: click.Context | None,
+    param: click.Parameter | None,
+    incomplete: str,
+) -> list[CompletionItem]:
+    stage_items = [
+        CompletionItem(stage) for stage in _STAGE_CHOICES if stage.startswith(incomplete.lower())
+    ]
+    return [*complete_eid(ctx, param, incomplete), *stage_items]
+
+
 @click.command("pipeline")
-@click.argument("eid", required=False, type=int)
+@click.argument("eid", required=False, type=int, shell_complete=complete_eid)
 @click.argument("section", required=False)
 @click.option("--json", "use_json", is_flag=True, default=False, help="Output JSON.")
 def pipeline_cmd(eid: int | None, section: str | None, use_json: bool) -> None:
@@ -86,7 +97,7 @@ def pipeline_cmd(eid: int | None, section: str | None, use_json: bool) -> None:
 
 
 @click.command("bindings")
-@click.argument("eid", required=False, type=int)
+@click.argument("eid", required=False, type=int, shell_complete=complete_eid)
 @click.option("--binding", "binding_index", type=int, help="Filter by binding index.")
 @click.option("--set", "set_index", type=int, help="Filter by descriptor set index.")
 @click.option("--json", "use_json", is_flag=True, default=False, help="Output JSON.")
@@ -142,9 +153,7 @@ def bindings_cmd(
     "first",
     required=False,
     metavar="[EID|STAGE]",
-    shell_complete=lambda _ctx, _param, incomplete: [
-        CompletionItem(stage) for stage in _STAGE_CHOICES if stage.startswith(incomplete.lower())
-    ],
+    shell_complete=_complete_shader_first,
 )
 @click.argument(
     "second",

--- a/src/rdc/commands/pixel.py
+++ b/src/rdc/commands/pixel.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import click
 
-from rdc.commands._helpers import call
+from rdc.commands._helpers import call, complete_eid
 from rdc.commands.vfs import _fmt_pixel_mod
 from rdc.formatters.json_fmt import write_json, write_jsonl
 from rdc.formatters.options import list_output_options
@@ -16,7 +16,7 @@ from rdc.formatters.options import list_output_options
 @click.command("pixel")
 @click.argument("x", type=int)
 @click.argument("y", type=int)
-@click.argument("eid", required=False, type=int)
+@click.argument("eid", required=False, type=int, shell_complete=complete_eid)
 @click.option("--target", default=0, type=int, help="Color target index (default 0)")
 @click.option("--sample", default=0, type=int, help="MSAA sample index (default 0)")
 @click.option("--json", "use_json", is_flag=True, help="JSON output")

--- a/src/rdc/commands/session.py
+++ b/src/rdc/commands/session.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import click
 from click.shell_completion import CompletionItem
 
+from rdc.commands._helpers import complete_eid
 from rdc.services.session_service import (
     close_session,
     connect_session,
@@ -226,7 +227,7 @@ def status_cmd() -> None:
 
 
 @click.command("goto")
-@click.argument("eid", type=int)
+@click.argument("eid", type=int, shell_complete=complete_eid)
 def goto_cmd(eid: int) -> None:
     """Update current event id via daemon."""
     ok, message = goto_session(eid)

--- a/src/rdc/commands/shader_edit.py
+++ b/src/rdc/commands/shader_edit.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import click
 
-from rdc.commands._helpers import call
+from rdc.commands._helpers import call, complete_eid
 from rdc.formatters.json_fmt import write_json
 
 
@@ -54,7 +54,7 @@ def shader_build_cmd(
 
 
 @click.command("shader-replace")
-@click.argument("eid", type=int)
+@click.argument("eid", type=int, shell_complete=complete_eid)
 @click.argument("stage", type=click.Choice(["vs", "hs", "ds", "gs", "ps", "cs"]))
 @click.option(
     "--with", "shader_id", required=True, type=int, help="Built shader ID from shader-build"
@@ -71,7 +71,7 @@ def shader_replace_cmd(eid: int, stage: str, shader_id: int, use_json: bool) -> 
 
 
 @click.command("shader-restore")
-@click.argument("eid", type=int)
+@click.argument("eid", type=int, shell_complete=complete_eid)
 @click.argument("stage", type=click.Choice(["vs", "hs", "ds", "gs", "ps", "cs"]))
 @click.option("--json", "use_json", is_flag=True, help="JSON output")
 def shader_restore_cmd(eid: int, stage: str, use_json: bool) -> None:

--- a/src/rdc/commands/snapshot.py
+++ b/src/rdc/commands/snapshot.py
@@ -8,12 +8,12 @@ from pathlib import Path
 
 import click
 
-from rdc.commands._helpers import call, fetch_remote_file, try_call
+from rdc.commands._helpers import call, complete_eid, fetch_remote_file, try_call
 from rdc.formatters.json_fmt import write_json
 
 
 @click.command("snapshot")
-@click.argument("eid", type=int)
+@click.argument("eid", type=int, shell_complete=complete_eid)
 @click.option("-o", "--output", required=True, type=click.Path(), help="Output directory")
 @click.option("--json", "use_json", is_flag=True, help="JSON output")
 def snapshot_cmd(eid: int, output: str, use_json: bool) -> None:

--- a/src/rdc/commands/tex_stats.py
+++ b/src/rdc/commands/tex_stats.py
@@ -6,14 +6,14 @@ from typing import Any
 
 import click
 
-from rdc.commands._helpers import call
+from rdc.commands._helpers import call, complete_eid
 from rdc.formatters.json_fmt import write_json
 from rdc.formatters.tsv import write_tsv
 
 
 @click.command("tex-stats")
 @click.argument("resource_id", type=int)
-@click.argument("eid", required=False, type=int)
+@click.argument("eid", required=False, type=int, shell_complete=complete_eid)
 @click.option("--mip", default=0, type=int, help="Mip level (default 0)")
 @click.option("--slice", "array_slice", default=0, type=int, help="Array slice (default 0)")
 @click.option("--histogram", is_flag=True, help="Show 256-bucket histogram")

--- a/tests/unit/test_eid_completion.py
+++ b/tests/unit/test_eid_completion.py
@@ -1,0 +1,108 @@
+"""Tests for semantic EID shell completion callbacks."""
+
+from __future__ import annotations
+
+import sys
+
+from rdc.commands._helpers import complete_eid
+from rdc.commands.assert_ci import assert_pixel_cmd, assert_state_cmd
+from rdc.commands.counters import counters_cmd
+from rdc.commands.debug import pixel_cmd as debug_pixel_cmd
+from rdc.commands.debug import thread_cmd, vertex_cmd
+from rdc.commands.diff import diff_cmd
+from rdc.commands.events import draw_cmd, event_cmd
+from rdc.commands.export import rt_cmd
+from rdc.commands.info import log_cmd
+from rdc.commands.mesh import mesh_cmd
+from rdc.commands.pick_pixel import pick_pixel_cmd
+from rdc.commands.pipeline import bindings_cmd, pipeline_cmd, shader_cmd
+from rdc.commands.pixel import pixel_cmd
+from rdc.commands.session import goto_cmd
+from rdc.commands.shader_edit import shader_replace_cmd, shader_restore_cmd
+from rdc.commands.snapshot import snapshot_cmd
+from rdc.commands.tex_stats import tex_stats_cmd
+
+
+def _param(cmd, name: str):
+    return next(p for p in cmd.params if p.name == name)
+
+
+def test_complete_eid_suggests_events(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "rdc.commands._helpers.try_call",
+        lambda _m, _p: {
+            "events": [
+                {"eid": 12, "name": "vkCmdDrawIndexed"},
+                {"eid": 34, "name": "vkCmdDispatch"},
+            ]
+        },
+    )
+
+    items = complete_eid(None, None, "")
+    assert [item.value for item in items] == ["12", "34"]
+    assert [item.help for item in items] == ["vkCmdDrawIndexed", "vkCmdDispatch"]
+
+
+def test_complete_eid_applies_prefix_filter(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "rdc.commands._helpers.try_call",
+        lambda _m, _p: {"events": [{"eid": 12, "name": "a"}, {"eid": 34, "name": "b"}]},
+    )
+
+    items = complete_eid(None, None, "3")
+    assert [item.value for item in items] == ["34"]
+
+
+def test_complete_eid_daemon_failure_returns_empty(monkeypatch) -> None:
+    monkeypatch.setattr("rdc.commands._helpers.try_call", lambda _m, _p: None)
+
+    assert complete_eid(None, None, "") == []
+
+
+def test_complete_eid_does_not_force_limit(monkeypatch) -> None:
+    seen_params: dict[str, object] = {}
+
+    def _try_call(_method: str, params: dict[str, object]) -> dict[str, object]:
+        seen_params.update(params)
+        return {"events": []}
+
+    monkeypatch.setattr("rdc.commands._helpers.try_call", _try_call)
+
+    assert complete_eid(None, None, "") == []
+    assert "limit" not in seen_params
+
+
+def test_complete_eid_failure_keeps_stderr_empty(monkeypatch, capsys) -> None:
+    def _failing_try_call(_method: str, _params: dict[str, object]) -> None:
+        sys.stderr.write("error: no active session\n")
+        return None
+
+    monkeypatch.setattr("rdc.commands._helpers.try_call", _failing_try_call)
+
+    assert complete_eid(None, None, "") == []
+    assert capsys.readouterr().err == ""
+
+
+def test_eid_arguments_are_wired_for_completion() -> None:
+    assert _param(event_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(draw_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(pipeline_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(bindings_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(goto_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(rt_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(mesh_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(pixel_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(pick_pixel_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(tex_stats_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(shader_replace_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(shader_restore_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(snapshot_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(assert_pixel_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(assert_state_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(debug_pixel_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(thread_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(vertex_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(shader_cmd, "first").shell_complete is not None
+    assert _param(counters_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(log_cmd, "eid")._custom_shell_complete is complete_eid
+    assert _param(diff_cmd, "eid")._custom_shell_complete is complete_eid


### PR DESCRIPTION
## Summary
- add daemon-backed `complete_eid` completion callback and wire it to EID arguments across session, events, debug, pipeline/bindings, export, mesh, pixel, pick-pixel, snapshot, shader-edit, tex-stats, counters, info, diff, and assert-ci commands
- make completion failures silent and fail-safe (no stderr noise, no crash) when session/daemon state is unavailable
- expand unit coverage in `tests/unit/test_eid_completion.py` for wiring, prefix filtering, error fallback, and uncapped events request behavior

## Validation
- `pixi run lint`
- `pixi run test`
- pre-push hook `pixi run e2e` (26 passed, 0 failed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled shell completion for event ID (eid) arguments across multiple commands (assert-pixel, assert-state, debug, diff, events, export, info, mesh, pick-pixel, pipeline, pixel, session, shader-edit, and snapshot), improving CLI usability.
  * Added --json output option to tex-stats command for JSON-formatted results.

* **Tests**
  * Added unit tests for event ID completion functionality covering filtering and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->