### PR TITLE
test(e2e): accept click typed completion output

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -154,7 +154,7 @@ else
 fi
 COMP_OUTPUT=$(env _RDC_COMPLETE=bash_complete COMP_WORDS="rdc ls /d" COMP_CWORD=2 $RDC 2>&1 || true)
 if [ "$REPLAY_READY" -eq 1 ] && echo "$COMP_OUTPUT" | grep -Eq "(/draws/|dir,/draws)"; then
-  echo -e "  ${GREEN}✓${NC} click shell_complete /d → /draws/"
+  echo -e "  ${GREEN}✓${NC} click shell_complete /d"
   PASS=$((PASS + 1))
 elif [ "$REPLAY_READY" -eq 0 ] && echo "$COMP_OUTPUT" | grep -q "no replay loaded"; then
   echo -e "  ${GREEN}✓${NC} click shell_complete /d (no replay)"


### PR DESCRIPTION
## Summary
- update e2e VFS completion assertion to accept Click typed completion output (`dir,/draws`) in addition to legacy slash-form output
- keep completion regression check stable across shell completion output formats
- verified with `pixi run e2e` locally and in pre-push hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated shell completion message in end-to-end testing script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->