### PR TITLE
fix(review): B53-B55 bug fixes, R1/R2/R5/R7-R9 quality, T1/T2 tests

### DIFF
--- a/src/rdc/commands/events.py
+++ b/src/rdc/commands/events.py
@@ -52,7 +52,7 @@ def events_cmd(
         return
     if quiet:
         for r in rows_data:
-            sys.stdout.write(str(r["eid"]) + chr(10))
+            sys.stdout.write(str(r["eid"]) + "\n")
         return
     header = ["EID", "TYPE", "NAME"]
     rows = [[r["eid"], r["type"], r["name"]] for r in rows_data]
@@ -101,7 +101,7 @@ def draws_cmd(
         return
     if quiet:
         for r in rows_data:
-            sys.stdout.write(str(r["eid"]) + chr(10))
+            sys.stdout.write(str(r["eid"]) + "\n")
         return
     header = ["EID", "TYPE", "TRIANGLES", "INSTANCES", "PASS", "MARKER"]
     rows = [

--- a/src/rdc/commands/export.py
+++ b/src/rdc/commands/export.py
@@ -8,14 +8,16 @@ from pathlib import Path
 import click
 from click.shell_completion import CompletionItem
 
-from rdc.commands._helpers import call, complete_eid, completion_call, fetch_remote_file
+from rdc.commands._helpers import (
+    _sort_numeric_like,
+    call,
+    complete_eid,
+    completion_call,
+    fetch_remote_file,
+)
 from rdc.commands.vfs import _deliver_binary
 from rdc.session_state import load_session
 from rdc.vfs.router import resolve_path
-
-
-def _sort_numeric_like(values: set[str] | list[str]) -> list[str]:
-    return sorted(values, key=lambda value: (0, int(value)) if value.isdigit() else (1, value))
 
 
 def _export_vfs_path(vfs_path: str, output: str | None, raw: bool) -> None:

--- a/src/rdc/commands/resources.py
+++ b/src/rdc/commands/resources.py
@@ -8,15 +8,16 @@ from typing import Any
 import click
 from click.shell_completion import CompletionItem
 
-from rdc.commands._helpers import call, complete_pass_identifier, completion_call
+from rdc.commands._helpers import (
+    _sort_numeric_like,
+    call,
+    complete_pass_identifier,
+    completion_call,
+)
 from rdc.formatters.json_fmt import write_json, write_jsonl
 from rdc.formatters.kv import format_kv
 from rdc.formatters.options import list_output_options
 from rdc.formatters.tsv import format_row, write_tsv
-
-
-def _sort_numeric_like(values: set[str] | list[str]) -> list[str]:
-    return sorted(values, key=lambda value: (0, int(value)) if value.isdigit() else (1, value))
 
 
 def _complete_resource_rows() -> list[dict[str, Any]]:
@@ -84,34 +85,6 @@ def _complete_resource_id(
                 continue
             values.append(rid)
         return [CompletionItem(value) for value in _sort_numeric_like(set(values))]
-    except Exception:
-        return []
-
-
-def _complete_pass_identifier(
-    ctx: click.Context, param: click.Parameter, incomplete: str
-) -> list[CompletionItem]:
-    try:
-        del ctx, param
-        result = completion_call("passes", {})
-        if not isinstance(result, dict):
-            return []
-        tree = result.get("tree", {})
-        passes = tree.get("passes", []) if isinstance(tree, dict) else []
-        if not isinstance(passes, list):
-            return []
-        prefix = incomplete.lower()
-        items: list[CompletionItem] = []
-        for idx, pass_row in enumerate(passes):
-            if not isinstance(pass_row, dict):
-                continue
-            index_text = str(idx)
-            name = str(pass_row.get("name", ""))
-            if index_text.startswith(incomplete):
-                items.append(CompletionItem(index_text))
-            if name and name.lower().startswith(prefix):
-                items.append(CompletionItem(name))
-        return items
     except Exception:
         return []
 

--- a/src/rdc/commands/session.py
+++ b/src/rdc/commands/session.py
@@ -25,7 +25,7 @@ def _complete_capture_path(
     del ctx, param
     if "/" in incomplete:
         dir_part, prefix = incomplete.rsplit("/", 1)
-        dir_path = Path(os.path.expanduser(dir_part or "/"))
+        dir_path = Path(dir_part or "/").expanduser()
         base = f"{dir_part}/"
     else:
         dir_path = Path(".")

--- a/src/rdc/commands/usage.py
+++ b/src/rdc/commands/usage.py
@@ -8,14 +8,10 @@ from typing import Any
 import click
 from click.shell_completion import CompletionItem
 
-from rdc.commands._helpers import call, completion_call
+from rdc.commands._helpers import _sort_numeric_like, call, completion_call
 from rdc.formatters.json_fmt import write_json, write_jsonl
 from rdc.formatters.options import list_output_options
 from rdc.formatters.tsv import write_tsv
-
-
-def _sort_numeric_like(values: set[str] | list[str]) -> list[str]:
-    return sorted(values, key=lambda value: (0, int(value)) if value.isdigit() else (1, value))
 
 
 def _completion_rows(result: Any, key: str) -> list[dict[str, Any]]:

--- a/src/rdc/handlers/__init__.py
+++ b/src/rdc/handlers/__init__.py
@@ -1,15 +1,1 @@
 """Handler modules for JSON-RPC daemon methods."""
-
-from __future__ import annotations
-
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from rdc.daemon_server import DaemonState
-
-    HandlerFunc = Callable[[int, dict[str, Any], DaemonState], tuple[dict[str, Any], bool]]
-else:
-    HandlerFunc = Any
-
-__all__ = ["HandlerFunc"]

--- a/src/rdc/handlers/core.py
+++ b/src/rdc/handlers/core.py
@@ -103,13 +103,12 @@ def _handle_shutdown(
         import shutil
 
         shutil.rmtree(state.temp_dir, ignore_errors=True)
-    if state.is_remote and state.local_capture_path:
+    if state.local_capture_is_temp and state.local_capture_path:
         import shutil
         from pathlib import Path
 
-        local_meta_dir = Path(state.local_capture_path).parent
-        if "rdc-remote-" in local_meta_dir.name:
-            shutil.rmtree(str(local_meta_dir), ignore_errors=True)
+        shutil.rmtree(str(Path(state.local_capture_path).parent), ignore_errors=True)
+        state.local_capture_is_temp = False
     if state.is_remote:
         if state._ping_stop is not None:
             state._ping_stop.set()

--- a/src/rdc/handlers/texture.py
+++ b/src/rdc/handlers/texture.py
@@ -310,7 +310,8 @@ def _handle_tex_stats(
                 if ch == 0:
                     histogram.append({"bucket": b_idx, "r": int(count), "g": 0, "b": 0, "a": 0})
                 else:
-                    histogram[b_idx][ch_name] = int(count)
+                    if b_idx < len(histogram):
+                        histogram[b_idx][ch_name] = int(count)
         result_data["histogram"] = histogram
 
     return _result_response(request_id, result_data), True

--- a/src/rdc/services/session_service.py
+++ b/src/rdc/services/session_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import secrets
 import socket
 import subprocess
@@ -19,6 +20,8 @@ from rdc.session_state import (
     load_session,
     save_session,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def pick_port() -> int:
@@ -262,6 +265,7 @@ def close_session(*, force_shutdown: bool = False) -> tuple[bool, str]:
     try:
         send_request(state.host, state.port, shutdown_request(state.token, request_id=4))
     except Exception:
+        logger.debug("shutdown request failed, terminating", exc_info=True)
         _platform.terminate_process(state.pid)
 
     removed = delete_session()

--- a/tests/unit/test_remote_replay.py
+++ b/tests/unit/test_remote_replay.py
@@ -129,6 +129,7 @@ class TestLoadRemoteReplay:
         mock_remote.CopyCaptureFromRemote.assert_called_once()
         assert state.local_capture_path != ""
         assert "rdc-remote-" in state.local_capture_path
+        assert state.local_capture_is_temp
 
     def test_copy_from_remote_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
         rd, mock_remote = _make_mock_rd()

--- a/tests/unit/test_resource_semantic_completion.py
+++ b/tests/unit/test_resource_semantic_completion.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from click.shell_completion import CompletionItem
 
+import rdc.commands._helpers as helpers_mod
 import rdc.commands.export as export_mod
 import rdc.commands.resources as resources_mod
 import rdc.commands.usage as usage_mod
@@ -63,11 +64,11 @@ def test_resources_completion_candidates(monkeypatch) -> None:
 
 def test_pass_identifier_completion_candidates(monkeypatch) -> None:
     monkeypatch.setattr(
-        resources_mod,
-        "completion_call",
+        helpers_mod,
+        "try_call",
         lambda method, params: {"tree": {"passes": [{"name": "Shadow"}, {"name": "Main"}]}},
     )
-    values = _values(resources_mod._complete_pass_identifier(None, None, ""))
+    values = _values(helpers_mod.complete_pass_identifier(None, None, ""))
     assert "0" in values
     assert "1" in values
     assert "Shadow" in values
@@ -128,7 +129,8 @@ def test_resource_completion_errors_return_empty(monkeypatch) -> None:
     monkeypatch.setattr(export_mod, "completion_call", lambda method, params: None)
 
     assert resources_mod._complete_resource_id(None, None, "") == []
-    assert resources_mod._complete_pass_identifier(None, None, "") == []
+    monkeypatch.setattr(helpers_mod, "try_call", lambda method, params: None)
+    assert helpers_mod.complete_pass_identifier(None, None, "") == []
     assert usage_mod._complete_usage_resource_id(None, None, "") == []
     assert usage_mod._complete_usage_kind(None, None, "") == []
     assert export_mod._complete_texture_id(None, None, "") == []
@@ -197,10 +199,11 @@ def test_completion_malformed_items_are_ignored(monkeypatch) -> None:
 
     monkeypatch.setattr(resources_mod, "completion_call", fake_call)
     monkeypatch.setattr(export_mod, "completion_call", fake_call)
+    monkeypatch.setattr(helpers_mod, "try_call", fake_call)
 
     class _Ctx:
         params = {"eid": 100}
 
     assert _values(resources_mod._complete_resource_id(None, None, "")) == ["9"]
-    assert _values(resources_mod._complete_pass_identifier(None, None, "")) == ["0", "Main"]
+    assert _values(helpers_mod.complete_pass_identifier(None, None, "")) == ["0", "Main"]
     assert _values(export_mod._complete_rt_target(_Ctx(), None, "")) == ["1"]


### PR DESCRIPTION
### **User description**
## Summary

Bundles fixes from a code review session:

- **B53**: Fix `_cleanup_temp_capture` path check — `in` → `startswith` on parent dir name (both `daemon_server.py` and `handlers/core.py`)
- **B54**: Guard histogram index in `tex_stats` for mismatched bucket counts across channels
- **B55**: Add debug logging to session shutdown exception handler (was silently swallowed)
- **R1**: Extract `_sort_numeric_like` from 3 duplicate copies into `_helpers.py`
- **R2**: Extract `_emit_error` helper replacing 7 inline `_json_mode()` blocks
- **R5**: Delete dead `_complete_pass_identifier` in `resources.py`
- **R7**: `chr(10)` → `"\n"` in `events.py`
- **R8**: `Path.expanduser()` instead of `os.path.expanduser()`
- **R9**: Remove unused `HandlerFunc` type alias from `handlers/__init__.py`
- **T1**: Replace tautological shutdown test with real `_process_request` test
- **T2**: Use socket context managers in timeout test

## Test plan

- [x] New tests for B53, B54, B55, R2 (emit_error)
- [x] T1 rewritten to exercise actual `_process_request` + `_DISPATCH` monkeypatch
- [x] `pixi run check` passes (lint + typecheck + 2399 tests, 94.18% coverage)
- [x] e2e tests pass (26/26)


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Extract `_sort_numeric_like` and `_emit_error` helpers to reduce duplication

- Fix path checks using `startswith()` instead of substring matching for safety

- Guard histogram indexing against mismatched bucket counts across channels

- Add debug logging to session shutdown exception handler

- Replace `chr(10)` with `"\n"` and `os.path.expanduser()` with `Path.expanduser()`

- Remove dead code and unused type aliases

- Rewrite shutdown test to exercise actual `_process_request` logic

- Use socket context managers in timeout test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Duplicate code<br/>in 3+ files"] -->|Extract to _helpers| B["_sort_numeric_like<br/>_emit_error helpers"]
  C["Unsafe path checks<br/>substring matching"] -->|Fix with startswith| D["Safe parent dir<br/>name validation"]
  E["Histogram indexing<br/>without bounds check"] -->|Add guard| F["Safe channel<br/>data assignment"]
  G["Silent exception<br/>in shutdown"] -->|Add logging| H["Debug visibility<br/>on failure"]
  I["Tautological test<br/>logic"] -->|Rewrite| J["Real _process_request<br/>test with monkeypatch"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>_helpers.py</strong><dd><code>Extract helpers and refactor error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/156/files#diff-6787742ce693fe1275bb76e13ddfceb33ea04828a1d261124f0701b345f56b4c">+24/-43</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>export.py</strong><dd><code>Import _sort_numeric_like from _helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/156/files#diff-25c17b1c2495d1f86a907b52d74e8cec7082648e27e65c8399afaca80675e68b">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>resources.py</strong><dd><code>Import _sort_numeric_like, remove dead function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/156/files#diff-87e1da2f58becc2bb669fd54128e2301aaf906dda02e31eab4473c00ef2c8264">+6/-33</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>usage.py</strong><dd><code>Import _sort_numeric_like from _helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/156/files#diff-07eb6bc2c60c4dd5a972d2b153e3d97ae4744fb84da2f6143a6245c3c65def3f">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>events.py</strong><dd><code>Replace chr(10) with newline string literal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/156/files#diff-2c0a7983b992244a8bcee9224a3f1eaa18b84c5394daa22676e61fbb76c8c637">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>session.py</strong><dd><code>Use Path.expanduser instead of os.path.expanduser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/156/files#diff-b481c2ee0ac01dfa93b837105679291fb99fe1adb9c44692d0caa59bcb4b268b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>daemon_server.py</strong><dd><code>Fix path check with startswith on parent dir name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/156/files#diff-c8fc48e38ee81838d8bad88541c08bdb66110557993c68cb1b97d8a98173398e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>core.py</strong><dd><code>Fix path check with startswith on parent dir name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/156/files#diff-717174bdb03658ee91de01bcc62ebb7356eaacc3648c9664167a1952efb8e7a5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>texture.py</strong><dd><code>Guard histogram index against bucket count mismatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/156/files#diff-bcef5d49260d8be22de30b99fa0b2c21b44d905256d8e8d8b9004a53515e4ed6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Remove unused HandlerFunc type alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/156/files#diff-f6e373e22737d9f4a6c1e5f94dc0090f1d9a0e047efbb6cf624b5e4a3c8d0167">+0/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>session_service.py</strong><dd><code>Add debug logging to shutdown exception handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/156/files#diff-a70c94d7741ece6acf17feb3b043ff3ca3da43d5be4d41af3567373e7c52fb97">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_daemon_server_unit.py</strong><dd><code>Rewrite shutdown test and add cleanup/emit_error tests</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/156/files#diff-998371b8a50a7573e8a47f6ba68ade138ac58354590bc2ebc63d545395c44b32">+71/-27</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_resource_semantic_completion.py</strong><dd><code>Update tests for moved _complete_pass_identifier function</code></dd></td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/156/files#diff-9f75b02c1b352e63c49b3a9d880bb66d971dab58e77a181fab6848614e90b6b5">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_tex_stats_handler.py</strong><dd><code>Add test for histogram channel length mismatch guard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/156/files#diff-e5dcbf05cd7d85670b792ebf13e7656f6dd6e8420a0f7df1288b170eace0f4b2">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential out-of-bounds error in histogram data processing for texture statistics.
  * Improved detection of temporary directories for remote capture cleanup.

* **Improvements**
  * Standardized error reporting across RPC operations for consistent messaging and behavior.
  * Added debug logging for shutdown-related failures to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->