### PR TITLE
refactor(daemon): centralize _no_replay into frozenset registry

### DIFF
--- a/src/rdc/handlers/capture.py
+++ b/src/rdc/handlers/capture.py
@@ -188,12 +188,6 @@ def _handle_remote_capture(
     return _result_response(request_id, _serialize(result)), True
 
 
-_handle_capture_run._no_replay = True  # type: ignore[attr-defined]
-_handle_remote_connect._no_replay = True  # type: ignore[attr-defined]
-_handle_remote_list._no_replay = True  # type: ignore[attr-defined]
-_handle_remote_capture._no_replay = True  # type: ignore[attr-defined]
-
-
 HANDLERS: dict[str, Handler] = {
     "capture_run": _handle_capture_run,
     "remote_connect_run": _handle_remote_connect,

--- a/src/rdc/handlers/core.py
+++ b/src/rdc/handlers/core.py
@@ -155,13 +155,6 @@ def _handle_file_read(
     ), True
 
 
-_handle_ping._no_replay = True  # type: ignore[attr-defined]
-_handle_status._no_replay = True  # type: ignore[attr-defined]
-_handle_goto._no_replay = True  # type: ignore[attr-defined]
-_handle_shutdown._no_replay = True  # type: ignore[attr-defined]
-_handle_count._no_replay = True  # type: ignore[attr-defined]
-_handle_file_read._no_replay = True  # type: ignore[attr-defined]
-
 HANDLERS: dict[str, Handler] = {
     "ping": _handle_ping,
     "status": _handle_status,

--- a/tests/unit/test_split_binary.py
+++ b/tests/unit/test_split_binary.py
@@ -189,9 +189,11 @@ class TestFileReadHandler:
         """T3.6: file_read is registered in HANDLERS."""
         assert "file_read" in HANDLERS
 
-    def test_no_replay_flag(self) -> None:
-        """T3.7: _no_replay is True."""
-        assert getattr(_handle_file_read, "_no_replay", False) is True
+    def test_file_read_in_no_replay_methods(self) -> None:
+        """T3.7: file_read is in _NO_REPLAY_METHODS registry."""
+        from rdc.daemon_server import _NO_REPLAY_METHODS
+
+        assert "file_read" in _NO_REPLAY_METHODS
 
 
 # ===========================================================================


### PR DESCRIPTION
### **User description**
## Summary

- Replace 10 scattered `handler._no_replay = True` attribute injections with a centralized `_NO_REPLAY_METHODS` frozenset in `daemon_server.py`
- Change `_handle_request` from `getattr(handler, "_no_replay", False)` to `method not in _NO_REPLAY_METHODS`
- Remove 10 `# type: ignore[attr-defined]` suppressions from `handlers/core.py` and `handlers/capture.py`

## Test plan

- [x] New `test_no_replay_methods_exact_contents` asserts registry has exactly 10 methods
- [x] Updated `test_split_binary.py` to check registry membership
- [x] Updated `TestProcessRequest` tests to monkeypatch registry instead of attribute
- [x] `pixi run check` passes (lint + typecheck + 2396 tests, 94.07% coverage)
- [x] e2e tests pass (26/26)


___

### **PR Type**
Enhancement


___

### **Description**
- Centralize scattered `_no_replay` attribute injections into `_NO_REPLAY_METHODS` frozenset

- Replace dynamic attribute checks with static registry membership tests

- Remove 10 `type: ignore[attr-defined]` suppressions from handler files

- Update tests to use registry instead of attribute-based approach


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Scattered handler attributes<br/>_no_replay = True"] -->|Consolidate| B["_NO_REPLAY_METHODS<br/>frozenset in daemon_server.py"]
  C["getattr handler<br/>_no_replay check"] -->|Replace with| D["method in _NO_REPLAY_METHODS"]
  E["10 type: ignore<br/>suppressions"] -->|Remove| F["Clean type hints"]
  B --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>daemon_server.py</strong><dd><code>Create and use _NO_REPLAY_METHODS registry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdc/daemon_server.py

<ul><li>Added <code>_NO_REPLAY_METHODS</code> frozenset containing 10 method names to <br>registry<br> <li> Exported <code>_NO_REPLAY_METHODS</code> in <code>__all__</code> for backward compatibility<br> <li> Changed <code>_handle_request</code> to check <code>method not in _NO_REPLAY_METHODS</code> <br>instead of <code>getattr(handler, "_no_replay", False)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/157/files#diff-c8fc48e38ee81838d8bad88541c08bdb66110557993c68cb1b97d8a98173398e">+17/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>core.py</strong><dd><code>Remove scattered _no_replay attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdc/handlers/core.py

<ul><li>Removed 6 <code>_no_replay = True</code> attribute assignments with <code>type: </code><br><code>ignore[attr-defined]</code> comments<br> <li> Affected methods: <code>_handle_ping</code>, <code>_handle_status</code>, <code>_handle_goto</code>, <br><code>_handle_shutdown</code>, <code>_handle_count</code>, <code>_handle_file_read</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/157/files#diff-717174bdb03658ee91de01bcc62ebb7356eaacc3648c9664167a1952efb8e7a5">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>capture.py</strong><dd><code>Remove scattered _no_replay attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdc/handlers/capture.py

<ul><li>Removed 4 <code>_no_replay = True</code> attribute assignments with <code>type: </code><br><code>ignore[attr-defined]</code> comments<br> <li> Affected methods: <code>_handle_capture_run</code>, <code>_handle_remote_connect</code>, <br><code>_handle_remote_list</code>, <code>_handle_remote_capture</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/157/files#diff-dbc37be7e906b0480eaaf879b0ac553fec729f9d02d50dff8f1286fdb586ee3b">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_daemon_server_unit.py</strong><dd><code>Update tests to use registry instead of attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_daemon_server_unit.py

<ul><li>Added import of <code>_NO_REPLAY_METHODS</code> from <code>rdc.daemon_server</code><br> <li> Updated three test methods to monkeypatch <code>_NO_REPLAY_METHODS</code> registry <br>instead of setting handler attributes<br> <li> Added new <code>TestNoReplayRegistry</code> class with test asserting exact <br>registry contents</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/157/files#diff-998371b8a50a7573e8a47f6ba68ade138ac58354590bc2ebc63d545395c44b32">+36/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_split_binary.py</strong><dd><code>Update test to check registry membership</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_split_binary.py

<ul><li>Renamed test from <code>test_no_replay_flag</code> to <br><code>test_file_read_in_no_replay_methods</code><br> <li> Changed assertion from checking handler attribute to checking registry <br>membership<br> <li> Added import of <code>_NO_REPLAY_METHODS</code> from <code>rdc.daemon_server</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/157/files#diff-3119fcca455e71e5f43ffdffb1826275238ced29b35ec18393bded71fb13c706">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal handler configuration to use a centralized registry for tracking methods that can operate without a loaded replay session, replacing previous per-handler flags with a consolidated approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->