### PR TITLE
fix(handlers): B56 enum filter, B57 shader reflect, B58 negative coords

### DIFF
--- a/src/rdc/handlers/debug.py
+++ b/src/rdc/handlers/debug.py
@@ -131,6 +131,8 @@ def _handle_debug_pixel(
     eid = int(params["eid"])
     x = int(params["x"])
     y = int(params["y"])
+    if x < 0 or y < 0:
+        return _error_response(request_id, -32602, "pixel coordinates must be >= 0"), True
 
     err = _set_frame_event(state, eid)
     if err:

--- a/src/rdc/handlers/descriptor.py
+++ b/src/rdc/handlers/descriptor.py
@@ -55,7 +55,7 @@ def _handle_descriptors(
                     "address_u": _enum_name(au),
                     "address_v": _enum_name(av),
                     "address_w": _enum_name(aw),
-                    "filter": str(getattr(s, "filter", "")),
+                    "filter": _enum_name(getattr(s, "filter", "")),
                     "compare_function": _enum_name(cf),
                     "min_lod": float(getattr(s, "minLOD", 0.0)),
                     "max_lod": float(getattr(s, "maxLOD", 0.0)),

--- a/tests/unit/test_debug_handlers.py
+++ b/tests/unit/test_debug_handlers.py
@@ -937,3 +937,25 @@ def test_debug_pixel_api_exception() -> None:
     assert resp["error"]["code"] == -32603
     err_msg = resp["error"]["message"]
     assert "DebugPixel failed" in err_msg or "GPU error" in err_msg
+
+
+def test_debug_pixel_negative_x() -> None:
+    """Negative x coordinate returns -32602."""
+    state = _make_state()
+    resp, running = _handle_request(
+        rpc_request("debug_pixel", {"eid": 100, "x": -1, "y": 0}), state
+    )
+    assert running
+    assert resp["error"]["code"] == -32602
+    assert ">= 0" in resp["error"]["message"]
+
+
+def test_debug_pixel_negative_y() -> None:
+    """Negative y coordinate returns -32602."""
+    state = _make_state()
+    resp, running = _handle_request(
+        rpc_request("debug_pixel", {"eid": 100, "x": 0, "y": -1}), state
+    )
+    assert running
+    assert resp["error"]["code"] == -32602
+    assert ">= 0" in resp["error"]["message"]

--- a/tests/unit/test_descriptors_daemon.py
+++ b/tests/unit/test_descriptors_daemon.py
@@ -11,6 +11,7 @@ from mock_renderdoc import (
     Descriptor,
     DescriptorAccess,
     DescriptorType,
+    FilterMode,
     MockPipeState,
     ResourceId,
     SamplerDescriptor,
@@ -127,7 +128,7 @@ def test_descriptors_mixed_types() -> None:
                 addressU=AddressMode.ClampEdge,
                 addressV=AddressMode.Wrap,
                 addressW=AddressMode.Mirror,
-                filter="Linear",
+                filter=FilterMode.Linear,
                 compareFunction="",
                 minLOD=0.0,
                 maxLOD=1000.0,
@@ -162,6 +163,7 @@ def test_descriptors_mixed_types() -> None:
     assert s["address_u"] == "ClampEdge"
     assert s["address_v"] == "Wrap"
     assert s["address_w"] == "Mirror"
+    assert s["filter"] == "Linear"
 
     for entry in non_sampler_entries:
         assert "sampler" not in entry


### PR DESCRIPTION
### **User description**
## Summary

- **B56** (P2): Sampler `filter` field leaked SWIG object to JSON — changed `str()` to `_enum_name()` in `descriptor.py:58`, matching the pattern already used for `address_u/v/w`
- **B57** (P2): `--reflect` flag on `rdc shader` produced no additional data — added `reflect` param handling in `_handle_shader` (query.py) to build reflection dict from `GetShaderReflection()`
- **B58** (P3): Negative pixel coordinates exposed unfriendly SWIG uint32_t error — added `x >= 0 and y >= 0` validation in `_handle_debug_pixel` (debug.py)

## Test plan

- [x] B56: `test_descriptors_mixed_types` asserts `filter == "Linear"` using real `FilterMode` enum
- [x] B57: `test_shader_handler_reflect_param` verifies reflection dict with real `SigParameter`/`CompType` enum values; `test_shader_handler_no_reflect_by_default` confirms opt-in behavior
- [x] B58: `test_debug_pixel_negative_x` and `test_debug_pixel_negative_y` assert `-32602` error with friendly message
- [x] `pixi run check` passes (lint + typecheck + 2407 tests, 93.87% coverage)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix enum serialization for sampler filter field using `_enum_name()` instead of `str()`

- Add shader reflection data support via optional `reflect` parameter in shader handler

- Validate pixel coordinates are non-negative to prevent SWIG uint32_t errors

- Add comprehensive unit tests for all three bug fixes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sampler Filter Enum"] -->|use _enum_name| B["Proper JSON Serialization"]
  C["Shader Reflect Param"] -->|GetShaderReflection| D["Reflection Data Dict"]
  E["Pixel Coordinates"] -->|validate >= 0| F["Friendly Error Message"]
  B --> G["Bug Fixes Applied"]
  D --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>descriptor.py</strong><dd><code>Use _enum_name for filter enum serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdc/handlers/descriptor.py

<ul><li>Changed sampler <code>filter</code> field serialization from <code>str()</code> to <code>_enum_name()</code> <br>on line 59<br> <li> Aligns with existing pattern used for <code>address_u/v/w</code> fields<br> <li> Ensures enum values are properly serialized to JSON without SWIG <br>object leakage</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/159/files#diff-4afdca2f6c84840540aec1ce11b2731c8fc8e609c24efd9c6c881cf622eea007">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>debug.py</strong><dd><code>Validate pixel coordinates are non-negative</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdc/handlers/debug.py

<ul><li>Added validation to check pixel coordinates are non-negative (x >= 0 <br>and y >= 0)<br> <li> Returns error code -32602 with friendly message when coordinates are <br>negative<br> <li> Prevents unfriendly SWIG uint32_t conversion errors</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/159/files#diff-622c7abd388378ed21a4d7a760e7313d4de4ce5e27f186b31052f0eddb0829a1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>query.py</strong><dd><code>Add shader reflection data support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdc/handlers/query.py

<ul><li>Added import of <code>_enum_name</code> helper function<br> <li> Implemented <code>reflect</code> parameter handling in <code>_handle_shader</code> function<br> <li> Builds reflection dictionary containing input/output signatures and <br>constant buffers<br> <li> Extracts shader reflection data using <code>GetShaderReflection()</code> when <br><code>reflect=True</code></ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/159/files#diff-e4af179314fccf26ec08bfb80be9ced05eda995474f3357cad4c1e9970178872">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_daemon_shader_extended.py</strong><dd><code>Add shader reflection parameter tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_daemon_shader_extended.py

<ul><li>Added <code>test_shader_handler_reflect_param()</code> to verify reflection data is <br>included when <code>reflect=True</code><br> <li> Tests input/output signatures with real <code>SigParameter</code> and <code>CompType</code> enum <br>values<br> <li> Added <code>test_shader_handler_no_reflect_by_default()</code> to confirm <br>reflection is excluded by default<br> <li> Validates reflection structure contains inputs, outputs, and constant <br>buffers</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/159/files#diff-fc765831518a126ee252a7eda8c2cda54f9e2e325026245288c412c8a0e2d292">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_debug_handlers.py</strong><dd><code>Add negative coordinate validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_debug_handlers.py

<ul><li>Added <code>test_debug_pixel_negative_x()</code> to verify -32602 error for <br>negative x coordinate<br> <li> Added <code>test_debug_pixel_negative_y()</code> to verify -32602 error for <br>negative y coordinate<br> <li> Both tests assert friendly error message contains ">= 0" text</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/159/files#diff-c636d24fcdb98e0394877d6763032cf0701781f34deac75f696fdc003e74c8e9">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_descriptors_daemon.py</strong><dd><code>Update descriptor tests for filter enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/test_descriptors_daemon.py

<ul><li>Added <code>FilterMode</code> import from mock_renderdoc<br> <li> Changed test fixture to use <code>FilterMode.Linear</code> enum instead of string <br><code>"Linear"</code><br> <li> Added assertion <code>assert s["filter"] == "Linear"</code> to verify proper enum <br>serialization<br> <li> Ensures filter field is serialized as bare enum name without SWIG <br>object wrapper</ul>


</details>


  </td>
  <td><a href="https://github.com/BANANASJIM/rdc-cli/pull/159/files#diff-aec7c70964d26f69f92d39f798f7c705b6ab2e7e4a5d5e34f54e03002c2e3381">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shader reflection: request detailed shader inputs, outputs, and constant-buffer layouts for improved inspection.

* **Bug Fixes**
  * Pixel coordinate validation: negative x/y are now rejected with a clear error message.

* **Chores**
  * Sampler filter serialization now uses enum-style names for more consistent descriptor output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->