### PR TITLE
fix(typecheck): cross-platform mypy unused-ignore

### DIFF
--- a/src/rdc/_platform.py
+++ b/src/rdc/_platform.py
@@ -35,7 +35,7 @@ def terminate_process(pid: int) -> bool:
         # GenerateConsoleCtrlEvent requires same console group. Acceptable for now.
         import ctypes
 
-        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined,unused-ignore]
         handle = kernel32.OpenProcess(0x0001, False, pid)  # PROCESS_TERMINATE
         if not handle:
             return False
@@ -80,7 +80,7 @@ def is_pid_alive(pid: int, *, tag: str = "rdc") -> bool:
         # TODO(W-next): check process name against tag on Windows
         import ctypes
 
-        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined,unused-ignore]
         handle = kernel32.OpenProcess(0x0400, False, pid)  # PROCESS_QUERY_INFORMATION
         if not handle:
             return False
@@ -124,7 +124,7 @@ def install_shutdown_signal(handler: Callable[[], None] | None = None) -> None:
             sys.exit(0)
 
     if _WIN:  # pragma: no cover
-        signal.signal(signal.SIGBREAK, _handler)  # type: ignore[attr-defined]
+        signal.signal(signal.SIGBREAK, _handler)  # type: ignore[attr-defined,unused-ignore]
     else:
         signal.signal(signal.SIGTERM, _handler)
 


### PR DESCRIPTION
## Summary
- Add `unused-ignore` to 3 `type: ignore[attr-defined]` comments in `_platform.py`
- On Windows, `ctypes.windll` and `signal.SIGBREAK` exist natively, making `attr-defined` suppression unnecessary
- mypy strict mode flags these as `unused-ignore` on Windows while they're needed on Linux
- Fix: `# type: ignore[attr-defined,unused-ignore]` satisfies both platforms

## Test plan
- [x] `pixi run lint` passes on Linux
- [x] `pixi run typecheck` passes on Linux (84 files, 0 errors)
- [x] `pixi run typecheck` passes on Windows VM (84 files, 0 errors)
- [x] `pixi run test` passes on both platforms (2579 Linux / 2516 Windows)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated type annotation configurations for improved code quality and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->