### PR TITLE
fix(docs): remove experimental label from Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ python scripts/build_renderdoc.py     # one-time build (needs cmake + ninja)
 rdc doctor                            # verify everything works
 ```
 
-**PyPI — Windows** (experimental)
+**PyPI — Windows**
 
 ```bash
 uv tool install rdc-cli               # or: pipx install rdc-cli
@@ -80,7 +80,7 @@ pixi run setup-renderdoc              # build renderdoc (pixi installs toolchain
 |----------|----------------------|--------------|
 | Linux | ✅ | ✅ |
 | macOS | ❌ (not supported yet) | ✅ (recommended) |
-| Windows | ✅ (experimental) | ✅ (experimental) |
+| Windows | ✅ | ✅ |
 
 ### RenderDoc bootstrap (all platforms)
 


### PR DESCRIPTION
## Summary
- Remove "(experimental)" from Windows install section and platform support matrix
- Windows fully tested through W4-W6 phases: 2516 unit tests, lint, typecheck, CLI commands, and GPU capture all passing

## Test plan
- [x] Visual check of README rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated platform support documentation to reflect that Windows support is no longer experimental, indicating full platform stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->