### PR TITLE
fix(ci): upgrade AUR deploy action to v4.1.1

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -36,20 +36,20 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.event.inputs.version && format('v{0}', github.event.inputs.version) || github.ref }}
-
-      - name: Extract version
+      - name: Normalize version
         id: ver
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           if [ -n "${INPUT_VERSION}" ]; then
-            echo "version=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "version=${INPUT_VERSION#v}" >> "$GITHUB_OUTPUT"
           else
             echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
           fi
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ steps.ver.outputs.version && format('refs/tags/v{0}', steps.ver.outputs.version) || github.ref }}
 
       - name: Compute tarball sha256
         id: sha


### PR DESCRIPTION
## Summary
- Upgrade `KSXGitHub/github-actions-deploy-aur` from v2.7.2 to v4.1.1
- v2.7.2 fails with newer git versions: clone results in detached HEAD, then `git push origin master` fails with "src refspec master does not match any"
- All v0.4.0/v0.4.1 AUR publishes have been failing since this regression

## Test plan
- [x] CI passes on this PR
- [ ] After merge + new tag, verify AUR publish succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added manual workflow triggering with a required version input to support on-demand releases.
  * Improved version handling to prefer the provided input and fall back to tag-derived versions.
  * Refined job triggers and updated deployment action versions for more reliable release automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->