### PR TITLE
fix(ci): resolve AUR stable push on detached HEAD

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -30,6 +30,7 @@ jobs:
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: "Update PKGBUILD"
+          post_process: git checkout -B master
 
   aur-stable:
     name: Publish rdc-cli (stable)
@@ -75,3 +76,4 @@ jobs:
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: "Update rdc-cli to v${{ steps.ver.outputs.version }}"
+          post_process: git checkout -B master


### PR DESCRIPTION
## Summary
- AUR `rdc-cli` repo has HEAD != refs/heads/master, causing `git clone` to produce detached HEAD
- The deploy action's `git push origin master` fails: `src refspec master does not match any`
- Fix: add `post_process: git checkout -B master` to create a local master branch before commit/push

## Root cause
```
$ git ls-remote https://aur.archlinux.org/rdc-cli.git
c329075b  HEAD           <- detached
811ecf06  refs/heads/master  <- different commit
```

## Test plan
- [x] Verified AUR repo state via `git ls-remote`
- [x] Confirmed action's `post_process` runs before commit (read action source)
- [ ] Trigger via `workflow_dispatch` after merge to verify