### PR TITLE
fix(ci): force push AUR stable to resolve non-fast-forward

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -76,4 +76,5 @@ jobs:
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: "Update rdc-cli to v${{ steps.ver.outputs.version }}"
+          force_push: true
           post_process: git checkout -B master


### PR DESCRIPTION
## Summary
- #183 fixed the detached HEAD issue (commit + branch creation works now)
- But push is rejected: `non-fast-forward` because AUR repo HEAD (c329075b) diverged from master (811ecf06)
- Add `force_push: true` to overwrite the stale AUR master branch

## Context
This is a one-time fix. After the force push succeeds, HEAD and master will be in sync and future pushes will be fast-forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to enable automatic force-push during package deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->