### PR TITLE
fix: support 'windows' platform string in addition to 'win32'

### DIFF
--- a/src/rdc/_platform.py
+++ b/src/rdc/_platform.py
@@ -14,7 +14,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-_WIN: bool = sys.platform == "win32"
+_WIN: bool = sys.platform in ("win32", "windows")
 _MAC: bool = sys.platform == "darwin"
 
 

--- a/src/rdc/commands/doctor.py
+++ b/src/rdc/commands/doctor.py
@@ -32,7 +32,7 @@ def _check_platform() -> CheckResult:
         return CheckResult("platform", True, "linux")
     if sys.platform == "darwin":
         return CheckResult("platform", True, "darwin (dev-host only for replay)")
-    if sys.platform == "win32":
+    if sys.platform in ("win32", "windows"):
         return CheckResult("platform", True, "windows")
     return CheckResult("platform", False, f"unsupported platform: {sys.platform}")
 


### PR DESCRIPTION
Some Python versions (e.g., 3.10.0rc2) on Windows return 'windows' instead of 'win32' for sys.platform. This fix ensures compatibility with such versions by checking for both platform strings.

Modified files:
- src/rdc/_platform.py: Updated _WIN variable
- src/rdc/commands/doctor.py: Updated _check_platform function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows platform detection to recognize additional platform identifiers, improving compatibility and reliability across all Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->