### PR TITLE
feat: Phase 8 — pass analysis enhancement (design discussion)

### DIFF
--- a/openspec/changes/2026-03-20-phase8-pass-analysis-enhancement/proposal.md
+++ b/openspec/changes/2026-03-20-phase8-pass-analysis-enhancement/proposal.md
@@ -43,8 +43,12 @@ Default TSV adds columns: DISPATCHES, TRIANGLES, BEGIN_EID, END_EID.
 
 ### T2: load/store extraction
 
-New `_parse_load_store_ops(begin_name, end_name)` function. Regex: `r'([CDS]+)=([^,)]+)'`.
-Attach `load_ops`/`store_ops` dicts to each pass in `_build_pass_list()`.
+New `_parse_load_store_ops(begin_name, end_name)` function. Regex: `r'(C|D|S|DS)=([^,)]+)'`.
+Returns `load_ops`/`store_ops` as `list[dict]` (not dict — multi-RT captures repeat
+`C=` keys, e.g., `C=Store, C=Don't Care`). Attach to each pass in `_build_pass_list()`.
+
+Note: `C`/`D`/`S`/`DS` are per-attachment-type keys (C=Color, D=Depth, S=Stencil),
+not per-individual-color-attachment. A single `C=Clear` may apply to all color targets.
 
 ### T3: `rdc passes --deps --table` — per-pass I/O view
 
@@ -53,11 +57,13 @@ them after computing edges. Return them alongside edges.
 
 New `--table` flag renders the design spec's PASS/READS/WRITES/LOAD_STORE table.
 Edge view remains the default. `--json` always includes both.
+`--table` is mutually exclusive with `--dot`/`--graph` (UsageError if combined).
 
 ### T4: `rdc pass <name>` — attachment detail
 
 Enrich each attachment with name, format, dimensions from `state.tex_map`.
-Include load/store from T2 (aggregated level, not per-attachment).
+Include per-attachment-type load/store from T2 (C/D/S/DS keys, not per-individual-
+color-attachment since a single `C=Clear` may apply to all color targets).
 
 ### T5: GL/GLES/D3D11 synthetic pass inference (#195)
 
@@ -74,7 +80,9 @@ New `_build_synthetic_pass_list(actions)` using **RT-switch hybrid approach**:
 
 Does NOT modify `walk_actions()`. Fallback at `get_pass_hierarchy()` level only.
 
-Prerequisites: `mock_renderdoc.py` must add `outputs`/`depthOut` to `ActionDescription`.
+Prerequisites: `mock_renderdoc.py` must add `outputs: list[ResourceId]` (8 elements,
+default all-zero) and `depthOut: ResourceId` (default zero) to `ActionDescription`.
+RT tuple comparison: `tuple(int(x) for x in a.outputs) + (int(a.depthOut),)`.
 
 ### T6: `rdc unused-targets` — new command (#196)
 

--- a/openspec/changes/2026-03-20-phase8-pass-analysis-enhancement/tasks.md
+++ b/openspec/changes/2026-03-20-phase8-pass-analysis-enhancement/tasks.md
@@ -2,54 +2,58 @@
 
 ## Wave 1 (parallel, no dependencies)
 
-- [ ] **T1**: `rdc passes` surface existing data
-  - [ ] `get_pass_hierarchy()` — stop discarding dispatches/triangles/eid range
+- [ ] **T1+T2**: `rdc passes` surface existing data + load/store extraction
+  - [ ] `_parse_load_store_ops(begin_name, end_name)` in `query_service.py`
+    - Regex: `r'(C|D|S|DS)=([^,)]+)'`
+    - Returns `list[tuple[str, str]]` to handle multi-RT duplicate keys
+  - [ ] Integrate into `_build_pass_list()` — attach load_ops/store_ops per pass
+  - [ ] `get_pass_hierarchy()` — stop discarding dispatches/triangles/eid range/load_store
   - [ ] `_handle_passes()` — pass through new fields
   - [ ] `passes_cmd` — add TSV columns DISPATCHES, TRIANGLES, BEGIN_EID, END_EID
+  - [ ] Tests: regex parsing (Clear/Load/Store/Don't Care/None/DS= compound key)
+  - [ ] Tests: multi-RT duplicate C= keys → list accumulation (not dict overwrite)
+  - [ ] Tests: dynamic rendering (`vkCmdBeginRendering`)
   - [ ] Tests: update existing passes tests for new columns
-
-- [ ] **T2**: load/store extraction from action names
-  - [ ] New `_parse_load_store_ops(begin_name, end_name)` in `query_service.py`
-  - [ ] Integrate into `_build_pass_list()` — attach load_ops/store_ops to pass dict
-  - [ ] Tests: regex parsing unit tests (Clear/Load/Store/Don't Care/None variants)
-  - [ ] Tests: passes with dynamic rendering (`vkCmdBeginRendering`)
 
 - [ ] **T7**: `rdc stats` Largest Resources section
   - [ ] `_handle_stats()` — collect top N resources by byte size
   - [ ] `stats_cmd` — render third section
   - [ ] Tests: stats output with largest resources
+  - [ ] Tests: fewer than 5 resources → show all available
 
 ## Wave 2 (depends on Wave 1)
 
 - [ ] **T3**: `rdc passes --deps --table` per-pass I/O
   - [ ] `build_pass_deps()` — return per_pass list with reads/writes/load/store
   - [ ] `_handle_pass_deps()` — include per_pass in response
-  - [ ] `_passes_deps` — new `--table` flag rendering
+  - [ ] `_passes_deps` — new `--table` flag rendering (mutually exclusive with --dot/--graph)
   - [ ] `--json` response includes both edges and per_pass
-  - [ ] Tests: table output format, json schema
+  - [ ] Tests: table output format, json schema, mutual exclusion errors
 
 - [ ] **T4**: `rdc pass <name>` attachment detail
-  - [ ] `_handle_pass()` — enrich attachments with name/format/dims from tex_map
-  - [ ] `_handle_pass()` — include load/store from pass data (T2)
+  - [ ] `_handle_pass()` — enrich existing target dicts with name/format/dims from tex_map
+  - [ ] `_handle_pass()` — include per-attachment-type load/store from pass data (T1+T2)
   - [ ] `pass_cmd` — render enriched attachment blocks
-  - [ ] Tests: pass detail with attachment info
+  - [ ] Tests: pass detail with attachment info, unknown resource fallback
 
 - [ ] **T5**: GL/GLES/D3D11 synthetic pass inference (#195)
-  - [ ] `mock_renderdoc.py` — add `outputs` (8-tuple) and `depthOut` to `ActionDescription`
+  - [ ] `mock_renderdoc.py` — add `outputs: list[ResourceId]` (8 elements, default all-zero) and `depthOut: ResourceId` (default zero) to `ActionDescription`
   - [ ] New `_build_synthetic_pass_list(actions)` in `query_service.py`
-  - [ ] RT-switch detection: `(outputs[0:8], depthOut)` tuple change = pass boundary
-  - [ ] Pass naming: marker stack primary, `_friendly_pass_name()` fallback
+  - [ ] RT-switch detection: `tuple(int(x) for x in a.outputs) + (int(a.depthOut),)` change = pass boundary
+  - [ ] Ignore zero-valued ResourceId slots (unused RT slots ≠ pass boundary)
+  - [ ] Pass naming: marker stack primary, RT-info-based `_friendly_pass_name()` fallback
   - [ ] `_SYNTHETIC_MARKER_IGNORE` filter for engine-internal markers
   - [ ] Fallback in `get_pass_hierarchy()` when `_build_pass_list()` returns empty
-  - [ ] Tests: RT-switch based grouping, marker naming, empty capture, mixed markers
+  - [ ] Tests: RT-switch grouping, marker naming, empty capture, zero-padded outputs equality, D3D11
 
 ## Wave 3 (depends on T3 for T6, depends on T5 for T8)
 
 - [ ] **T6**: `rdc unused-targets` command (#196)
   - [ ] New `commands/unused.py` — Click command with TSV/JSON/quiet output
-  - [ ] New handler in `query.py` or new `handlers/unused.py`
-  - [ ] Service function: swapchain reachability → wave-based pruning
-  - [ ] Register in `cli.py`
+  - [ ] New `handlers/unused.py` — daemon handler
+  - [ ] Register handler in handler dispatch (HANDLERS dict or `_all_handlers()`)
+  - [ ] Service function in `query_service.py`: swapchain reachability → wave-based pruning
+  - [ ] Register command in `cli.py`
   - [ ] Tests: command, handler, service (empty/no-unused/multi-wave scenarios)
 
 - [ ] **T8**: `rdc passes --switches` — event-level RT switch detection

--- a/openspec/changes/2026-03-20-phase8-pass-analysis-enhancement/test-plan.md
+++ b/openspec/changes/2026-03-20-phase8-pass-analysis-enhancement/test-plan.md
@@ -2,19 +2,18 @@
 
 ## Unit tests
 
-### T1: passes surface existing data
+### T1+T2: passes surface existing data + load/store extraction
 - `rdc passes` TSV output includes DISPATCHES, TRIANGLES, BEGIN_EID, END_EID columns
-- `rdc passes --json` includes all fields per pass
+- `rdc passes --json` includes all fields per pass (including load_ops/store_ops)
 - `rdc passes --no-header` omits header row
 - `rdc passes --quiet` outputs only pass names
 - `rdc passes --jsonl` outputs one JSON object per line per pass
 - Backward compat: existing tests still pass with new columns
-
-### T2: load/store extraction
-- `_parse_load_store_ops("vkCmdBeginRenderPass(C=Clear, D=Load)", "vkCmdEndRenderPass(C=Store, DS=Don't Care)")` → `{"load": {"C": "Clear", "D": "Load"}, "store": {"C": "Store", "DS": "Don't Care"}}`
+- `_parse_load_store_ops("vkCmdBeginRenderPass(C=Clear, D=Load)", "vkCmdEndRenderPass(C=Store, DS=Don't Care)")` → `{"load": [("C", "Clear"), ("D", "Load")], "store": [("C", "Store"), ("DS", "Don't Care")]}`
+- Multi-RT: `"vkCmdEndRenderPass(C=Store, C=Don't Care, DS=Don't Care)"` → store has 2 C entries (list, not dict)
 - Dynamic rendering: `vkCmdBeginRendering(C=Clear, D=Clear)` format
-- Missing end pass name → store_ops is empty dict
-- No load/store in name (GL/GLES) → both dicts empty
+- Missing end pass name → store_ops is empty list
+- No load/store in name (GL/GLES) → both lists empty
 - Aggregated "Different load ops" → preserved as-is
 - Edge case: `DS=` combined key vs separate `D=`/`S=` keys
 
@@ -40,7 +39,8 @@
 - D3D11 capture → same RT-switch detection as GL
 - Empty action tree → empty pass list
 - RT-switch grouping: consecutive same-tuple actions = one pass
-- Pass naming: nearest marker preferred, `_friendly_pass_name()` fallback
+- Zero-padded outputs: actions with same non-zero outputs but different zero-padding in unused slots = same pass (no false boundary)
+- Pass naming: nearest marker preferred, RT-info `_friendly_pass_name()` fallback
 - Engine markers (Unity RenderLoop.Draw) → filtered via `_SYNTHETIC_MARKER_IGNORE`
 - GL load/store → `"unknown"` (no BeginPass name to parse)
 
@@ -57,6 +57,7 @@
 - `rdc stats` includes "Largest Resources" section
 - Top 5 resources by byte size
 - Resource with zero byte size → excluded
+- Fewer than 5 resources → show all available
 - `rdc stats --json` includes `largest_resources` array
 
 ### T8: event-level RT switch detection
@@ -73,7 +74,9 @@
 - `pixi run rdc open tests/fixtures/vkcube.rdc` → `rdc passes` shows new columns
 - `rdc passes --deps --table` shows per-pass I/O for vkcube
 - `rdc pass <name>` shows enriched attachments
+- `rdc stats` shows Largest Resources section
 - `rdc unused-targets` runs without error
+- `rdc passes --switches` shows RT switch counts
 
 ## Manual tests
 


### PR DESCRIPTION
## Context

PR #193 proposed a `rdc tbr` command for TBR optimization triage. The use case is real, but the implementation overlaps significantly with existing commands (`passes --deps`, `pass`, `stats`) and introduces a new top-level command where extending existing ones would suffice.

Investigation revealed the current pass analysis commands fall short of the design spec. This Phase aims to close those gaps.

## What this PR contains (for now)

OpenSpec only — proposal, tasks, and test plan. No code yet.

## Planned changes

| Task | Description | Related |
|------|-------------|---------|
| T1 | `rdc passes` — surface dispatches/triangles/eid range (data exists, currently discarded) | #194 |
| T2 | Extract load/store ops from BeginPass/EndPass action name strings via regex | #194 |
| T3 | `rdc passes --deps --io` — per-pass READS/WRITES/LOAD_STORE view | #194 |
| T4 | `rdc pass <name>` — enrich attachments with name/format/dims/load_store | |
| T5 | GL/GLES/D3D11 synthetic pass inference via RT switch detection | #195 |
| T6 | `rdc unused-targets` — dead render target detection (separate command) | #196 |
| T7 | `rdc stats` — add Largest Resources section | |

## Key design decisions

- **No new `rdc tbr` command** — extend existing `passes`/`pass`/`stats` instead
- **load/store from action names** — RenderDoc encodes `C=Clear, D=Load` in BeginPass name, already captured by `_build_pass_list()`
- **`unused-targets` as separate command** — output entity is resource (not pass), different schema requires different command
- **No `walk_actions()` global changes** — synthetic pass is a fallback at `get_pass_hierarchy()` level only

## Update (2026-03-21): GL/GLES synthetic pass — RT switch detection

After discussion with @FrankyLin2 on #194 and #195, the original T5 plan (pure marker-based inference) has been revised.

**Problem**: Logical passes ≠ hardware passes. SSAO or Bloom may appear as one logical pass but involve multiple RT switches. For TBR optimization, hardware pass boundaries (RT transitions) matter more than marker grouping.

**Finding**: `ActionDescription.outputs[]` and `depthOut` are populated for **all APIs** (Vulkan/GL/GLES/D3D11). RenderDoc docs describe them as for "coarse bucketing of actions into similar passes by their outputs."

**Revised T5 approach — hybrid RT switch + marker naming**:
- **Grouping**: detect pass boundaries by tracking `(outputs[0:8], depthOut)` tuple changes across actions — reflects actual hardware RT transitions
- **Naming**: use nearest PushMarker name if available, fallback to auto-generated name from RT info
- **Filtering**: `_SYNTHETIC_MARKER_IGNORE` still used for cleaning up engine-internal markers
- **Load/Store**: GL lacks BeginPass action name encoding → marked as `unknown` (Vulkan extracted via regex as before)

This covers GL/GLES/D3D11 without relying on engine-specific marker conventions.

## Design review resolved decisions

### `--table` → renamed to `--io`

The planned global `--table`/`--columns`/`-o wide` option (design spec principle 7) would conflict with a `--table` flag on `passes --deps`. The edge view (`SRC | DST | RESOURCES`) and per-pass I/O view (`PASS | READS | WRITES | LOAD | STORE`) are different projections of the same dependency data — similar to how `--dot`/`--graph` are alternative projections of edge data.

**Decision**: `rdc passes --deps --io`

### Default columns: no LOAD/STORE in TSV

Load/store ops are per-attachment qualitative data (`C=Clear,D=Load`) that compress poorly into a single TSV field. For GL/GLES these would always be `unknown`. Keeping the list view lean and pipeable:

**Decision**: Default `NAME | DRAWS | DISPATCHES | TRIANGLES | BEGIN_EID | END_EID` (6 columns). Load/store available via `--json`, `rdc pass <name>` detail, and `rdc passes --deps --io`.

### Command naming: `rdc unused-targets`

- `unused-resources` — scope too broad (vertex buffers etc.)
- `dead-targets` — compiler jargon, not intuitive for graphics engineers
- `unused-targets` — scoped to render targets, follows existing hyphenated pattern (`pick-pixel`, `setup-renderdoc`)

**Decision**: `rdc unused-targets`

## Implementation notes

**Must address before coding**:
- Mock `ActionDescription` needs `outputs`/`depthOut` fields for T5 unit tests
- T6 needs explicit swapchain identification strategy (`ActionFlags.Present` or `ResourceType.SwapchainImage`)
- T5 fallback guard: only run RT-switch heuristic when `_build_pass_list()` returns empty

**Wave execution**:
```
Wave 1 (parallel): T1, T2, T5, T7
Wave 2 (depends on W1): T3, T4
Wave 3 (depends on W2): T6
```

T5 moved to Wave 1 — no file conflict with T1/T2/T7 (touches different code paths).