### PR TITLE
fix(ci): escape Astro expressions, add AUR force_push

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -30,6 +30,7 @@ jobs:
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: "Update PKGBUILD"
+          force_push: true
           post_process: git checkout -B master
 
   aur-stable:

--- a/docs-astro/src/pages/docs/examples.astro
+++ b/docs-astro/src/pages/docs/examples.astro
@@ -273,7 +273,7 @@ rdc draws --pass GBuffer
 rdc passes --json | jq '.[] | select(.draw_count > 50)'
 
 {"# Largest triangle passes"}
-rdc passes --json | jq 'sort_by(.triangles) | reverse | .[0:5] | .[] | {name, triangles}'
+rdc passes --json | jq 'sort_by(.triangles) | reverse | .[0:5] | .[] | {"{ name, triangles }"}'
 
 {"# Passes that clear then discard (load=Clear, store=Discard — wasted work)"}
 rdc passes --json | jq '.[] | select(.load_ops[]? == "Clear" and .store_ops[]? == "Discard")'</code></pre>
@@ -287,7 +287,7 @@ rdc passes --deps --table
 rdc passes --switches
 
 {"# Passes with RT_SWITCHES > 2 (high bandwidth pressure on tile-based GPUs)"}
-rdc passes --switches --json | jq '.[] | select(.rt_switches > 2) | {name, rt_switches}'
+rdc passes --switches --json | jq '.[] | select(.rt_switches > 2) | {"{ name, rt_switches }"}'
 
 {"# Full dependency graph as DOT (render with Graphviz)"}
 rdc passes --deps --dot | dot -Tsvg -o passes.svg</code></pre>
@@ -301,7 +301,7 @@ rdc unused-targets
 rdc unused-targets -q
 
 {"# JSON — get name + writer + wave for each dead target"}
-rdc unused-targets --json | jq '.unused[] | {name, written_by, wave}'
+rdc unused-targets --json | jq '.unused[] | {"{ name, written_by, wave }"}'
 
 {"# Count dead targets (useful as a CI assert)"}
 rdc unused-targets -q | wc -l</code></pre>

--- a/docs-astro/src/pages/docs/usage.astro
+++ b/docs-astro/src/pages/docs/usage.astro
@@ -114,7 +114,7 @@ rdc passes --switches
 rdc pass GBuffer
 
 # JSON output — includes load_ops/store_ops per pass
-rdc passes --json | jq '.[] | {name: .name, load: .load_ops, store: .store_ops}'</code></pre>
+rdc passes --json | jq '.[] | {"{ name: .name, load: .load_ops, store: .store_ops }"}'</code></pre>
 
   <h2>Dead Render Target Detection</h2>
   <pre><code># List render targets written but never sampled/read


### PR DESCRIPTION
## Summary

- Fix Astro build: escape jq `{...}` literals in code blocks (treated as JSX)
- Fix AUR git publish: add `force_push: true` to aur-git job

Triggered by v0.5.0 tag CI failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AUR deployment configuration for both stable and git package versions.

* **Documentation**
  * Updated JSON processing examples in documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->