### PR TITLE
feat(ux): wire progress callbacks and doctor hint map (Phase 9 PR 1/3)

### DIFF
--- a/src/rdc/_progress.py
+++ b/src/rdc/_progress.py
@@ -1,0 +1,46 @@
+"""Progress callback factory for RenderDoc long-running operations."""
+
+from __future__ import annotations
+
+import math
+import time
+from collections.abc import Callable
+
+import click
+
+
+def make_progress_cb(label: str, min_interval: float = 1.0) -> Callable[[float], None]:
+    """Return a callback suitable for RenderDoc ProgressCallback.
+
+    Writes to stderr. On tty: '\\r{label}: {pct:.0%}' in place, '\\n' at
+    completion. Non-tty: one line per call, throttled to min_interval seconds.
+    First call (progress=0.0001) and final call (progress>=1.0) always emit.
+    Clamps NaN/negative/inf to [0, 1].
+    """
+    last_echo: list[float] = [0.0]
+    first_seen: list[bool] = [False]
+
+    def _cb(progress: float) -> None:
+        if math.isnan(progress) or progress < 0:
+            progress = 0.0
+        elif math.isinf(progress) or progress > 1.0:
+            progress = 1.0
+
+        is_first = not first_seen[0]
+        is_done = progress >= 1.0
+        first_seen[0] = True
+
+        stderr = click.get_text_stream("stderr")
+        on_tty = stderr.isatty()
+
+        if on_tty:
+            end = "\n" if is_done else "\r"
+            click.echo(f"{label}: {progress:.0%}", nl=False, err=True)
+            click.echo(end, nl=False, err=True)
+        else:
+            now = time.monotonic()
+            if is_first or is_done or (now - last_echo[0] >= min_interval):
+                click.echo(f"{label}: {progress:.0%}", err=True)
+                last_echo[0] = now
+
+    return _cb

--- a/src/rdc/capture_core.py
+++ b/src/rdc/capture_core.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any
 
+import click
+
 from rdc import _platform
 from rdc.discover import find_renderdoc
 
@@ -220,7 +222,9 @@ def run_target_control_loop(
     else:
         tc.TriggerCapture(1)
 
-    deadline = time.monotonic() + timeout
+    start = time.monotonic()
+    deadline = start + timeout
+    last_echo = start
     while time.monotonic() < deadline:
         if not tc.Connected():
             return CaptureResult(error="target disconnected")
@@ -239,6 +243,10 @@ def run_target_control_loop(
             )
         if msg_type == 1:
             return CaptureResult(error="target disconnected")
+        now = time.monotonic()
+        if now - last_echo >= 5.0:
+            click.echo(f"waiting for capture... ({int(now - start):d}s)", err=True)
+            last_echo = now
         time.sleep(0.01)
 
     return CaptureResult(error="timeout waiting for capture")

--- a/src/rdc/commands/doctor.py
+++ b/src/rdc/commands/doctor.py
@@ -414,6 +414,37 @@ def run_doctor() -> list[CheckResult]:
     return results
 
 
+HINT_MAP: dict[str, str] = {
+    "replay-support": (
+        "renderdoc module found but replay API is missing"
+        " -- rebuild renderdoc with replay support enabled"
+    ),
+    "renderdoccmd": (
+        "install renderdoccmd or add it to PATH;"
+        " see https://bananasjim.github.io/rdc-cli/docs/install/"
+    ),
+    "platform": "rdc-cli capture requires Linux, macOS, or Windows",
+    "win-python-version": (
+        "rebuild renderdoc Python bindings against the running Python version,"
+        " or switch Python to match the .pyd tag"
+    ),
+    "win-vs-build-tools": (
+        "install Visual Studio 2022 Build Tools from https://visualstudio.microsoft.com/downloads/"
+    ),
+    "win-renderdoc-install": (
+        "install RenderDoc from https://renderdoc.org/builds or set RENDERDOC_PYTHON_PATH"
+    ),
+    "win-vulkan-layer": (
+        "re-install RenderDoc to restore the Vulkan implicit layer registry entry"
+    ),
+    "mac-xcode-cli": "run: xcode-select --install",
+    "mac-homebrew": "install Homebrew from https://brew.sh",
+    "mac-renderdoc-dylib": (
+        "build renderdoc for macOS; see https://bananasjim.github.io/rdc-cli/docs/install/"
+    ),
+}
+
+
 @click.command("doctor")
 def doctor_cmd() -> None:
     """Run environment checks for rdc-cli."""
@@ -426,7 +457,11 @@ def doctor_cmd() -> None:
         if not result.ok:
             has_error = True
             if result.name == "renderdoc-module":
-                click.echo(_RENDERDOC_BUILD_HINT, err=True)
+                click.echo(f"  hint: {_RENDERDOC_BUILD_HINT}", err=True)
+            else:
+                hint = HINT_MAP.get(result.name)
+                if hint:
+                    click.echo(f"  hint: {hint}", err=True)
 
     if has_error:
         raise SystemExit(1)

--- a/src/rdc/commands/doctor.py
+++ b/src/rdc/commands/doctor.py
@@ -416,8 +416,9 @@ def run_doctor() -> list[CheckResult]:
 
 HINT_MAP: dict[str, str] = {
     "replay-support": (
-        "renderdoc module found but replay API is missing"
-        " -- rebuild renderdoc with replay support enabled"
+        "renderdoc replay API unavailable"
+        " -- ensure renderdoc is installed with replay support enabled"
+        " (see renderdoc-module check above for module load status)"
     ),
     "renderdoccmd": (
         "install renderdoccmd or add it to PATH;"

--- a/src/rdc/daemon_server.py
+++ b/src/rdc/daemon_server.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from rdc import _platform
+from rdc._progress import make_progress_cb
 from rdc._transport import recv_line as _recv_line
 from rdc.adapter import RenderDocAdapter
 from rdc.handlers._helpers import (
@@ -340,7 +341,9 @@ def _load_remote_replay(state: DaemonState, remote_url: str) -> str | None:
     try:
         local_capture = Path(state.capture)
         if local_capture.exists():
-            remote_path = remote.CopyCaptureToRemote(str(local_capture), None)
+            remote_path = remote.CopyCaptureToRemote(
+                str(local_capture), make_progress_cb("uploading")
+            )
             state.local_capture_path = str(local_capture)
         else:
             remote_path = state.capture
@@ -348,7 +351,9 @@ def _load_remote_replay(state: DaemonState, remote_url: str) -> str | None:
 
             local_tmp = Path(tempfile.mkdtemp(prefix="rdc-remote-")) / "capture.rdc"
             try:
-                remote.CopyCaptureFromRemote(remote_path, str(local_tmp), None)
+                remote.CopyCaptureFromRemote(
+                    remote_path, str(local_tmp), make_progress_cb("downloading")
+                )
             except Exception as exc:  # noqa: BLE001
                 shutil.rmtree(local_tmp.parent, ignore_errors=True)
                 remote.ShutdownConnection()
@@ -367,7 +372,10 @@ def _load_remote_replay(state: DaemonState, remote_url: str) -> str | None:
                 tmp_cap.Shutdown()
 
         result, controller = remote.OpenCapture(
-            rd.RemoteServer.NoPreference, remote_path, remote_opts, None
+            rd.RemoteServer.NoPreference,
+            remote_path,
+            remote_opts,
+            make_progress_cb("opening capture"),
         )
         if result != rd.ResultCode.Succeeded:
             _cleanup_temp_capture(state)

--- a/src/rdc/remote_core.py
+++ b/src/rdc/remote_core.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import click
 
+from rdc._progress import make_progress_cb
 from rdc.capture_core import CaptureResult, build_capture_options, run_target_control_loop
 
 _PRIVATE_NETS = (
@@ -177,7 +178,7 @@ def remote_capture(
         result.remote_path = result.path
     elif not result.local:
         try:
-            remote.CopyCaptureFromRemote(result.path, output, None)
+            remote.CopyCaptureFromRemote(result.path, output, make_progress_cb("downloading"))
             result.path = output
             result.local = True
         except Exception as exc:

--- a/tests/unit/test_doctor_hints.py
+++ b/tests/unit/test_doctor_hints.py
@@ -1,0 +1,110 @@
+"""Unit tests for doctor HINT_MAP integration."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from rdc.commands.doctor import HINT_MAP, doctor_cmd
+
+_ALL_CHECK_NAMES = {
+    "python",
+    "platform",
+    "renderdoc-module",
+    "replay-support",
+    "renderdoccmd",
+    "win-python-version",
+    "win-vs-build-tools",
+    "win-renderdoc-install",
+    "win-vulkan-layer",
+    "mac-xcode-cli",
+    "mac-homebrew",
+    "mac-renderdoc-dylib",
+    "adb",
+    "android-apk",
+    "renderdoc-variant",
+}
+
+
+def test_all_hint_map_keys_are_valid_check_names() -> None:
+    """Every key in HINT_MAP must be a known check name."""
+    for key in HINT_MAP:
+        assert key in _ALL_CHECK_NAMES, f"HINT_MAP key '{key}' is not a known check name"
+
+
+def test_renderdoc_module_failure_emits_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("rdc.commands.doctor.sys.platform", "linux")
+    monkeypatch.setattr("rdc.commands.doctor.find_renderdoc", lambda: None)
+    monkeypatch.setattr("rdc.commands.doctor._get_diagnostic", lambda: None)
+    monkeypatch.setattr("rdc.commands.doctor.find_renderdoccmd", lambda: None)
+
+    result = CliRunner().invoke(doctor_cmd, [])
+    assert "hint:" in result.output
+    assert "renderdoc" in result.output.lower()
+
+
+def _fake_rd() -> SimpleNamespace:
+    return SimpleNamespace(
+        GetVersionString=lambda: "1.33",
+        __file__="/fake/renderdoc.so",
+        InitialiseReplay=lambda *a, **kw: 0,
+        ShutdownReplay=lambda: None,
+        GlobalEnvironment=lambda: object(),
+    )
+
+
+def test_renderdoccmd_failure_emits_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("rdc.commands.doctor.sys.platform", "linux")
+    monkeypatch.setattr("rdc.commands.doctor.find_renderdoc", lambda: _fake_rd())
+    monkeypatch.setattr("rdc.commands.doctor.find_renderdoccmd", lambda: None)
+
+    result = CliRunner().invoke(doctor_cmd, [])
+    assert result.exit_code == 1
+    assert "hint:" in result.output
+    assert "renderdoccmd" in result.output
+
+
+def test_passing_check_emits_no_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("rdc.commands.doctor.sys.platform", "linux")
+    monkeypatch.setattr("rdc.commands.doctor.find_renderdoc", lambda: _fake_rd())
+    monkeypatch.setattr(
+        "rdc.commands.doctor.find_renderdoccmd", lambda: Path("/usr/bin/renderdoccmd")
+    )
+    monkeypatch.setattr(
+        "rdc.commands.doctor.subprocess.run",
+        lambda *a, **kw: subprocess.CompletedProcess(args=[], returncode=0, stdout="v1.33"),
+    )
+
+    result = CliRunner().invoke(doctor_cmd, [])
+    assert result.exit_code == 0
+    assert "hint:" not in result.output
+
+
+def test_exit_code_preserved_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("rdc.commands.doctor.sys.platform", "linux")
+    monkeypatch.setattr("rdc.commands.doctor.find_renderdoc", lambda: None)
+    monkeypatch.setattr("rdc.commands.doctor._get_diagnostic", lambda: None)
+    monkeypatch.setattr("rdc.commands.doctor.find_renderdoccmd", lambda: None)
+
+    result = CliRunner().invoke(doctor_cmd, [])
+    assert result.exit_code == 1
+
+
+def test_output_order_check_then_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hints appear after the check line, not before."""
+    monkeypatch.setattr("rdc.commands.doctor.sys.platform", "linux")
+    monkeypatch.setattr("rdc.commands.doctor.find_renderdoc", lambda: None)
+    monkeypatch.setattr("rdc.commands.doctor._get_diagnostic", lambda: None)
+    monkeypatch.setattr("rdc.commands.doctor.find_renderdoccmd", lambda: None)
+
+    result = CliRunner().invoke(doctor_cmd, [])
+    output = result.output
+    fail_pos = output.find("[FAIL] renderdoc-module")
+    hint_pos = output.find("hint:")
+    assert fail_pos != -1
+    assert hint_pos != -1
+    assert fail_pos < hint_pos, "hint must appear after [FAIL] line"

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -1,0 +1,136 @@
+"""Unit tests for rdc._progress.make_progress_cb."""
+
+from __future__ import annotations
+
+import io
+import math
+from unittest.mock import patch
+
+from rdc._progress import make_progress_cb
+
+
+def _run_cb(values: list[float], *, tty: bool, now_seq: list[float] | None = None) -> str:
+    """Run callback for each value in values; return stderr output."""
+    buf = io.StringIO()
+    buf.isatty = lambda: tty  # type: ignore[method-assign]
+
+    idx = [0]
+
+    def _monotonic() -> float:
+        v = now_seq[idx[0]] if now_seq else 0.0
+        idx[0] = min(idx[0] + 1, len(now_seq) - 1) if now_seq else idx[0]
+        return v
+
+    def _echo(msg: object = "", *, nl: bool = True, **kw: object) -> None:
+        buf.write(str(msg))
+        if nl:
+            buf.write("\n")
+
+    with (
+        patch("rdc._progress.click.get_text_stream", return_value=buf),
+        patch("rdc._progress.click.echo", side_effect=_echo),
+        patch("rdc._progress.time.monotonic", side_effect=_monotonic),
+    ):
+        cb = make_progress_cb("test", min_interval=1.0)
+        for v in values:
+            cb(v)
+
+    return buf.getvalue()
+
+
+class TestTtyBranch:
+    def test_first_call_emits(self) -> None:
+        out = _run_cb([0.0001], tty=True)
+        assert "test: 0%" in out
+
+    def test_final_call_emits_newline(self) -> None:
+        out = _run_cb([0.0001, 1.0], tty=True)
+        assert "test: 100%" in out
+        assert "\n" in out
+
+    def test_intermediate_uses_carriage_return(self) -> None:
+        out = _run_cb([0.0001, 0.5, 1.0], tty=True)
+        assert "\r" in out
+
+    def test_completion_appends_newline_not_cr(self) -> None:
+        buf = io.StringIO()
+        buf.isatty = lambda: True  # type: ignore[method-assign]
+        written: list[str] = []
+
+        def _echo(msg: object = "", **kw: object) -> None:
+            written.append(str(msg))
+
+        with (
+            patch("rdc._progress.click.get_text_stream", return_value=buf),
+            patch("rdc._progress.click.echo", side_effect=_echo),
+        ):
+            cb = make_progress_cb("x")
+            cb(1.0)
+
+        assert "\n" in written
+        assert "\r" not in written
+
+
+class TestNonTtyBranch:
+    def test_first_call_always_emits(self) -> None:
+        now_seq = [0.0] * 10
+        out = _run_cb([0.0001], tty=False, now_seq=now_seq)
+        assert "test: 0%" in out
+
+    def test_final_call_always_emits(self) -> None:
+        # Use a now_seq that would throttle intermediate calls but still emit final
+        now_seq = [0.0, 0.0, 0.0, 0.0]
+        out = _run_cb([0.0001, 0.5, 1.0], tty=False, now_seq=now_seq)
+        assert "test: 100%" in out
+
+    def test_throttled_by_min_interval(self) -> None:
+        # All calls at t=0, so only first call should emit (interval not elapsed)
+        now_seq = [0.0] * 20
+        out = _run_cb([0.0001, 0.25, 0.5, 0.75], tty=False, now_seq=now_seq)
+        # Only first call emits; 0.25/0.5/0.75 are throttled
+        count = out.count("test:")
+        assert count == 1
+
+    def test_emits_after_interval_elapsed(self) -> None:
+        # t advances past min_interval between calls
+        now_seq = [0.0, 0.0, 1.5, 1.5, 3.5, 3.5]
+        out = _run_cb([0.0001, 0.25, 0.5, 0.75], tty=False, now_seq=now_seq)
+        # First call at t=0, next at t=1.5 (elapsed>=1.0), next at t=3.5 (elapsed>=1.0)
+        count = out.count("test:")
+        assert count >= 2
+
+    def test_uses_newline_not_cr(self) -> None:
+        now_seq = [0.0] * 10
+        out = _run_cb([0.0001, 1.0], tty=False, now_seq=now_seq)
+        assert "\r" not in out
+        assert "\n" in out
+
+
+class TestClamping:
+    def _single(self, v: float) -> str:
+        return _run_cb([v], tty=False, now_seq=[0.0] * 5)
+
+    def test_nan_clamped_to_zero(self) -> None:
+        out = self._single(math.nan)
+        assert "0%" in out
+
+    def test_negative_clamped_to_zero(self) -> None:
+        out = self._single(-0.5)
+        assert "0%" in out
+
+    def test_inf_clamped_to_100(self) -> None:
+        out = self._single(math.inf)
+        assert "100%" in out
+
+    def test_value_above_1_clamped(self) -> None:
+        out = self._single(2.0)
+        assert "100%" in out
+
+
+class TestRepeatedCalls:
+    def test_safe_across_multiple_intervals(self) -> None:
+        # Ensure callback doesn't crash or break state across many calls
+        now_seq = list(range(20))
+        out = _run_cb([i / 19 for i in range(20)], tty=False, now_seq=now_seq)
+        assert "test:" in out
+        assert "100%" in out

--- a/tests/unit/test_remote_core.py
+++ b/tests/unit/test_remote_core.py
@@ -218,9 +218,9 @@ class TestRemoteCapture:
         result = remote_capture(rd, remote, "host:39920", "/app", output="/tmp/out.rdc")
         assert result.success is True
         assert result.path == "/tmp/out.rdc"
-        remote.CopyCaptureFromRemote.assert_called_once_with(
-            "/remote/cap.rdc", "/tmp/out.rdc", None
-        )
+        args = remote.CopyCaptureFromRemote.call_args[0]
+        assert args[:2] == ("/remote/cap.rdc", "/tmp/out.rdc")
+        assert callable(args[2])
         tc.Shutdown.assert_called_once()
 
     def test_success_local_file(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_remote_replay.py
+++ b/tests/unit/test_remote_replay.py
@@ -113,7 +113,9 @@ class TestLoadRemoteReplay:
             err = _load_remote_replay(state, "host:39920")
 
         assert err is None
-        mock_remote.CopyCaptureToRemote.assert_called_once_with(str(local_capture), None)
+        args = mock_remote.CopyCaptureToRemote.call_args[0]
+        assert args[0] == str(local_capture)
+        assert callable(args[1])
         assert state.local_capture_path == str(local_capture)
 
     def test_remote_path_downloads(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Phase 9 PR 1 of 3 — wires up progress feedback to four silent-today RenderDoc operations and restructures \`rdc doctor\` to emit per-check actionable hints instead of only the \`renderdoc-module\` special case. No architectural change; this PR purely connects hooks that the underlying APIs already expose.

Closes the "silent long task" and "opaque doctor" halves of issue #212. Remote bootstrap command (\`rdc remote setup\`) and error taxonomy work are PR 2 and PR 3 of the same Phase.

## Changes

### Progress callbacks (P1)
- **New** \`src/rdc/_progress.py\` — \`make_progress_cb(label, min_interval=1.0)\` helper. Writes to stderr. tty path: \`\\r{label}: {pct:.0%}\` in-place + final \`\\n\`. Non-tty path: one new line per update, throttled. First call and final call always emit. Clamps NaN / inf / negative / >1.
- Wire-ups (were all \`None\`):
  - \`remote_core.py\` — \`CopyCaptureFromRemote\`
  - \`daemon_server.py\` — \`CopyCaptureFromRemote\`, \`CopyCaptureToRemote\`, \`OpenCapture\` (3 sites)
- \`capture_core.py\` — \`run_target_control_loop\` now emits \`waiting for capture... (Ns)\` every 5s to stderr so long inject waits don't look like a hang.

### Doctor hint map (P5)
- \`commands/doctor.py\` now has \`HINT_MAP\` keyed by check name. Each failing check emits its hint after the check result.
- Before: only \`renderdoc-module\` failure got a dedicated hint block; every other check (renderdoccmd, win-\*, mac-\*, replay-support, etc.) left the user without a next step.
- \`renderdoc-module\` is still special-cased to preserve the existing test that monkeypatches \`_RENDERDOC_BUILD_HINT\`.

### Tests (+220 LOC)
- \`tests/unit/test_progress.py\` — tty/non-tty/clamping/throttle branches; exercises every branch of \`_progress.py\`.
- \`tests/unit/test_doctor_hints.py\` — \`HINT_MAP\` key validation (typo guard), per-check hint emission, fallback for \`renderdoc-module\`, no-hint-on-pass, output ordering.

## Verification

- [x] \`pixi run lint\` — ruff clean
- [x] \`pixi run typecheck\` — mypy strict clean
- [x] \`pixi run test\` — 2800 passed, 6 skipped, **coverage 92.52%** (up from 92.51%)
- [x] \`rdc doctor\` smoke — output shape preserved
- [x] \`make_progress_cb\` bytes-level smoke test — tty and non-tty branches verified
- [x] Opus code reviewer (B1-B8 bug-class hunt: clamping order / shared callback state / click echo vs stderr / tick placement / HINT_MAP key matching / coverage regression / assertion relaxation / import cycles) — **zero blocking issues**

## Non-blocking follow-ups noted during review

- \`test_doctor_hints.py\` uses a hand-maintained \`_ALL_CHECK_NAMES\` allowlist rather than deriving from \`run_doctor()\`. Catches typos; may drift if new checks are added without updating the allowlist. Consider cross-platform dynamic derivation in a follow-up.
- \`HINT_MAP\` has entries for \`adb\`, \`android-apk\`, \`renderdoc-variant\` but those \`_check_*\` functions currently return \`ok=True\` even on "not found" (warnings only), so the hints never fire. Not a bug — consistent with prior behavior. Worth revisiting if those checks graduate to hard failures.
- 5s tick message uses \`int(now - start)\` which may drift under loop preemption. Acceptable for UX.

## Refs

- Issue: #212
- Phase plan: \`规划/Phase9-Remote-UX-Polish.md\` (vault)
- Research: \`调研/调研-Phase9-Remote-UX.md\` Section A (Progress API)
- ADRs: D-049 (hint injection over ErrorKind), D-051 (progress callback format)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added progress feedback during remote capture operations (uploading, downloading, opening) with throttled, TTY-aware output.
  * Expanded diagnostic output to include context-specific remediation hints for failed environment checks.

* **Tests**
  * Added tests for progress callback behavior and TTY/non-TTY output.
  * Added tests validating diagnostic hints and updated remote-related tests to accept progress callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->