### PR TITLE
feat(remote): add setup / status / disconnect subcommands (Phase 9 PR 2/3)

### DIFF
--- a/docs-astro/src/data/commands.json
+++ b/docs-astro/src/data/commands.json
@@ -474,6 +474,24 @@
           "usage": "rdc remote capture <APP> -o <PATH> [--url TEXT] [--args TEXT] [--workdir TEXT] [--frame INTEGER] [--timeout FLOAT] [--api-validation] [--callstacks] [--hook-children] [--ref-all-resources] [--soft-memory-limit INTEGER] [--keep-remote] [--json]"
         },
         {
+          "name": "remote setup",
+          "id": "remote-setup",
+          "help": "Verify a remote server is reachable, handshake, and save state.",
+          "usage": "rdc remote setup <URL> [--timeout FLOAT] [--json]"
+        },
+        {
+          "name": "remote status",
+          "id": "remote-status",
+          "help": "Show the currently saved remote server state.",
+          "usage": "rdc remote status [--json]"
+        },
+        {
+          "name": "remote disconnect",
+          "id": "remote-disconnect",
+          "help": "Delete the saved remote server state (local only).",
+          "usage": "rdc remote disconnect [--json]"
+        },
+        {
           "name": "android setup",
           "id": "android-setup",
           "help": "Start RenderDoc remote server on an Android device.",

--- a/scripts/gen-commands.py
+++ b/scripts/gen-commands.py
@@ -69,6 +69,7 @@ CATEGORIES: list[tuple[str, str, str | None, list[str]]] = [
         "Remote", "remote",
         "Connect to a remote RenderDoc server for remote capture and replay.",
         ["serve", "remote connect", "remote list", "remote capture",
+         "remote setup", "remote status", "remote disconnect",
          "android setup", "android stop", "android capture"],
     ),
     ("Utilities", "utilities", None, [

--- a/src/rdc/_skills/references/commands-quick-ref.md
+++ b/src/rdc/_skills/references/commands-quick-ref.md
@@ -760,6 +760,16 @@ Connect to a remote RenderDoc server.
 |------|------|------|---------|
 | `--json` | Output as JSON. | flag |  |
 
+## `rdc remote disconnect`
+
+Delete the saved remote server state (local only).
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--json` | Output as JSON. | flag |  |
+
 ## `rdc remote list`
 
 List capturable applications on a remote host.
@@ -769,6 +779,33 @@ List capturable applications on a remote host.
 | Flag | Help | Type | Default |
 |------|------|------|---------|
 | `--url` | Override saved remote (host:port). | text |  |
+| `--json` | Output as JSON. | flag |  |
+
+## `rdc remote setup`
+
+Verify a remote server is reachable, handshake, and save state.
+
+**Arguments:**
+
+| Name | Type | Required |
+|------|------|----------|
+| `url` | text | yes |
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
+| `--timeout` | TCP probe timeout in seconds. | float | 10.0 |
+| `--json` | Output as JSON. | flag |  |
+
+## `rdc remote status`
+
+Show the currently saved remote server state.
+
+**Options:**
+
+| Flag | Help | Type | Default |
+|------|------|------|---------|
 | `--json` | Output as JSON. | flag |  |
 
 ## `rdc resource`

--- a/src/rdc/commands/remote.py
+++ b/src/rdc/commands/remote.py
@@ -1,10 +1,12 @@
-"""Remote RenderDoc server commands: connect, list, capture."""
+"""Remote RenderDoc server commands: connect, list, capture, setup, status, disconnect."""
 
 from __future__ import annotations
 
 import dataclasses
 import json
+import socket
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +30,7 @@ from rdc.remote_core import (
 )
 from rdc.remote_state import (
     RemoteServerState,
+    delete_remote_state,
     load_latest_remote_state,
     save_remote_state,
 )
@@ -285,3 +288,194 @@ def _download_split_remote_capture(result: CaptureResult, output: Path) -> Captu
     if not result.success or not result.path:
         return result
     return write_capture_to_path(result, output)
+
+
+def _tcp_probe(host: str, port: int, timeout_s: float) -> str | None:
+    """Probe TCP reachability. Returns None on success or a failure literal."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout_s):
+            return None
+    except ConnectionRefusedError:
+        return "refused"
+    except TimeoutError:
+        return "timeout"
+    except OSError:
+        return "unreachable"
+
+
+def _setup_hint_for(failure: str, host: str, port: int, timeout_s: float = 10.0) -> str:
+    """Map a failure literal to an actionable hint string."""
+    if failure == "refused":
+        return (
+            f"rdc serve does not appear to be running on {host}:{port}. "
+            f"On the target, run: rdc serve --daemon --port {port}"
+        )
+    if failure == "timeout":
+        return (
+            f"cannot reach {host}:{port} within {timeout_s:g}s -- "
+            "check network path, firewall, or docker port mapping"
+        )
+    if failure == "unreachable":
+        return f"cannot resolve or reach {host} -- check hostname and network route"
+    if failure == "ping_failed":
+        return (
+            f"TCP reachable but renderdoc handshake failed -- the process listening on "
+            f"{host}:{port} may not be renderdoccmd remoteserver, or versions differ. "
+            f"Run 'rdc doctor' locally and compare with 'rdc --version' on {host}"
+        )
+    return f"unknown failure class: {failure}"
+
+
+def _emit_setup_failure(
+    host: str,
+    port: int,
+    failure: str,
+    detail: str,
+    timeout_s: float,
+    use_json: bool,
+) -> None:
+    hint = _setup_hint_for(failure, host, port, timeout_s)
+    if use_json:
+        click.echo(
+            json.dumps(
+                {
+                    "host": host,
+                    "port": port,
+                    "error": detail,
+                    "failure": failure,
+                    "hint": hint,
+                }
+            ),
+            err=True,
+        )
+    else:
+        click.echo(f"error: {detail}", err=True)
+        click.echo(f"hint: {hint}", err=True)
+    raise SystemExit(1)
+
+
+def _renderdoc_handshake(host: str, port: int) -> None:
+    """Perform CreateRemoteServerConnection + Ping + Shutdown. Raises RuntimeError on failure."""
+    rd = require_renderdoc()
+    conn_url = build_conn_url(host, port)
+    remote = connect_remote_server(rd, conn_url)
+    try:
+        remote.Ping()
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(str(exc)) from exc
+    finally:
+        remote.ShutdownConnection()
+
+
+@remote_group.command("setup")
+@click.argument("url")
+@click.option(
+    "--timeout", "timeout_s", type=float, default=10.0, help="TCP probe timeout in seconds."
+)
+@click.option("--json", "use_json", is_flag=True, help="Output as JSON.")
+def remote_setup_cmd(url: str, timeout_s: float, use_json: bool) -> None:
+    """Verify a remote server is reachable, handshake, and save state."""
+    try:
+        host, port = parse_url(url)
+    except ValueError as exc:
+        click.echo(f"error: {exc}", err=True)
+        raise SystemExit(1) from None
+    _check_public_ip(host)
+
+    failure = _tcp_probe(host, port, timeout_s)
+    if failure is not None:
+        detail_map = {
+            "refused": f"cannot reach {host}:{port} (connection refused)",
+            "timeout": f"cannot reach {host}:{port} (timeout after {timeout_s:g}s)",
+            "unreachable": f"cannot reach {host} (network unreachable)",
+        }
+        _emit_setup_failure(host, port, failure, detail_map[failure], timeout_s, use_json)
+
+    try:
+        _renderdoc_handshake(host, port)
+    except RuntimeError as exc:
+        _emit_setup_failure(
+            host,
+            port,
+            "ping_failed",
+            f"TCP reachable but renderdoc handshake failed: {exc}",
+            timeout_s,
+            use_json,
+        )
+
+    save_remote_state(RemoteServerState(host=host, port=port, connected_at=time.time()))
+
+    if use_json:
+        click.echo(json.dumps({"host": host, "port": port, "next": "rdc remote list"}))
+    else:
+        click.echo(f"connected: {host}:{port}")
+        click.echo("next: rdc remote list", err=True)
+
+
+def _format_age(seconds: float) -> str:
+    s = max(0, int(seconds))
+    h, rem = divmod(s, 3600)
+    m, sec = divmod(rem, 60)
+    if h:
+        return f"{h}h{m}m"
+    if m:
+        return f"{m}m{sec}s"
+    return f"{sec}s"
+
+
+@remote_group.command("status")
+@click.option("--json", "use_json", is_flag=True, help="Output as JSON.")
+def remote_status_cmd(use_json: bool) -> None:
+    """Show the currently saved remote server state."""
+    state = load_latest_remote_state()
+    if state is None:
+        if use_json:
+            click.echo(json.dumps({"state": None}))
+        else:
+            click.echo("no saved remote state", err=True)
+            click.echo(
+                "hint: run 'rdc remote setup HOST[:PORT]' "
+                "or 'rdc remote connect HOST[:PORT]' first",
+                err=True,
+            )
+        return
+
+    saved_at_iso = datetime.fromtimestamp(state.connected_at, tz=timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    age = _format_age(time.time() - state.connected_at)
+    if use_json:
+        click.echo(
+            json.dumps(
+                {
+                    "host": state.host,
+                    "port": state.port,
+                    "saved_at": saved_at_iso,
+                    "age": age,
+                }
+            )
+        )
+    else:
+        click.echo(f"host: {state.host}")
+        click.echo(f"port: {state.port}")
+        click.echo(f"saved_at: {saved_at_iso}")
+        click.echo(f"age: {age}")
+
+
+@remote_group.command("disconnect")
+@click.option("--json", "use_json", is_flag=True, help="Output as JSON.")
+def remote_disconnect_cmd(use_json: bool) -> None:
+    """Delete the saved remote server state (local only)."""
+    state = load_latest_remote_state()
+    if state is None:
+        if use_json:
+            click.echo(json.dumps({"disconnected": None}))
+        else:
+            click.echo("nothing to disconnect", err=True)
+        return
+    delete_remote_state(state.host, state.port)
+    label = f"{state.host}:{state.port}"
+    if use_json:
+        click.echo(json.dumps({"disconnected": label}))
+    else:
+        click.echo(f"disconnected: {label}")

--- a/tests/unit/test_remote_setup.py
+++ b/tests/unit/test_remote_setup.py
@@ -1,0 +1,221 @@
+"""Tests for `rdc remote setup` command and its helpers."""
+
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from rdc.commands.remote import (
+    _setup_hint_for,
+    _tcp_probe,
+    remote_setup_cmd,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
+
+
+def _stderr_spy(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    lines: list[str] = []
+    orig = click.echo
+
+    def spy(message: Any = None, err: bool = False, **kw: Any) -> Any:
+        if err:
+            lines.append(str(message))
+        return orig(message, err=err, **kw)
+
+    monkeypatch.setattr("rdc.commands.remote.click.echo", spy)
+    return lines
+
+
+class TestTcpProbe:
+    def test_success_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sock = MagicMock()
+        sock.__enter__ = MagicMock(return_value=sock)
+        sock.__exit__ = MagicMock(return_value=False)
+        monkeypatch.setattr(socket, "create_connection", lambda *a, **kw: sock)
+        assert _tcp_probe("h", 1, 1.0) is None
+
+    def test_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def raise_refused(*a: Any, **kw: Any) -> None:
+            raise ConnectionRefusedError
+
+        monkeypatch.setattr(socket, "create_connection", raise_refused)
+        assert _tcp_probe("h", 1, 1.0) == "refused"
+
+    def test_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def raise_timeout(*a: Any, **kw: Any) -> None:
+            raise TimeoutError
+
+        monkeypatch.setattr(socket, "create_connection", raise_timeout)
+        assert _tcp_probe("h", 1, 1.0) == "timeout"
+
+    def test_unreachable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def raise_os(*a: Any, **kw: Any) -> None:
+            raise OSError("no route")
+
+        monkeypatch.setattr(socket, "create_connection", raise_os)
+        assert _tcp_probe("h", 1, 1.0) == "unreachable"
+
+
+class TestSetupHintFor:
+    def test_refused_mentions_rdc_serve(self) -> None:
+        msg = _setup_hint_for("refused", "target", 39920)
+        assert "rdc serve" in msg
+        assert "target:39920" in msg
+        assert "--daemon" in msg
+
+    def test_timeout_mentions_network(self) -> None:
+        msg = _setup_hint_for("timeout", "target", 39920, 5.0)
+        assert "5s" in msg
+        assert "firewall" in msg or "network" in msg
+
+    def test_unreachable_mentions_hostname(self) -> None:
+        msg = _setup_hint_for("unreachable", "bad-host", 39920)
+        assert "bad-host" in msg
+        assert "hostname" in msg or "route" in msg
+
+    def test_ping_failed_mentions_handshake(self) -> None:
+        msg = _setup_hint_for("ping_failed", "target", 39920)
+        assert "handshake" in msg
+        assert "renderdoccmd" in msg
+        assert "rdc doctor" in msg
+
+    def test_unknown_falls_through(self) -> None:
+        assert "unknown" in _setup_hint_for("whatever", "h", 1)
+
+
+class TestRemoteSetupCmd:
+    def _patch_rd(self, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+        rd = MagicMock()
+        monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
+        return rd
+
+    def test_success_saves_state_and_prints(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_rd(monkeypatch)
+        monkeypatch.setattr("rdc.commands.remote._tcp_probe", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            "rdc.commands.remote.connect_remote_server",
+            lambda rd, url: MagicMock(),
+        )
+        saved: list[Any] = []
+        monkeypatch.setattr(
+            "rdc.commands.remote.save_remote_state", lambda state: saved.append(state)
+        )
+
+        result = CliRunner().invoke(remote_setup_cmd, ["192.168.1.10"])
+        assert result.exit_code == 0
+        assert "connected: 192.168.1.10:39920" in result.output
+        assert len(saved) == 1
+        assert saved[0].host == "192.168.1.10"
+        assert saved[0].port == 39920
+
+    def test_success_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_rd(monkeypatch)
+        monkeypatch.setattr("rdc.commands.remote._tcp_probe", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            "rdc.commands.remote.connect_remote_server",
+            lambda rd, url: MagicMock(),
+        )
+        monkeypatch.setattr("rdc.commands.remote.save_remote_state", lambda state: None)
+
+        result = CliRunner().invoke(remote_setup_cmd, ["192.168.1.10", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == {"host": "192.168.1.10", "port": 39920, "next": "rdc remote list"}
+
+    def test_refused_emits_hint_and_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        lines = _stderr_spy(monkeypatch)
+        monkeypatch.setattr("rdc.commands.remote._tcp_probe", lambda *a, **kw: "refused")
+        saved: list[Any] = []
+        monkeypatch.setattr(
+            "rdc.commands.remote.save_remote_state", lambda state: saved.append(state)
+        )
+
+        result = CliRunner().invoke(remote_setup_cmd, ["192.168.1.10"])
+        assert result.exit_code == 1
+        assert saved == []
+        assert any("connection refused" in s for s in lines)
+        assert any("rdc serve" in s for s in lines)
+
+    def test_timeout_emits_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        lines = _stderr_spy(monkeypatch)
+        monkeypatch.setattr("rdc.commands.remote._tcp_probe", lambda *a, **kw: "timeout")
+        result = CliRunner().invoke(remote_setup_cmd, ["192.168.1.10", "--timeout", "3"])
+        assert result.exit_code == 1
+        assert any("timeout" in s for s in lines)
+        assert any("3s" in s for s in lines)
+
+    def test_unreachable_emits_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        lines = _stderr_spy(monkeypatch)
+        monkeypatch.setattr("rdc.commands.remote._tcp_probe", lambda *a, **kw: "unreachable")
+        result = CliRunner().invoke(remote_setup_cmd, ["192.168.1.10"])
+        assert result.exit_code == 1
+        assert any("unreachable" in s for s in lines)
+
+    def test_ping_failed_emits_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_rd(monkeypatch)
+        lines = _stderr_spy(monkeypatch)
+        monkeypatch.setattr("rdc.commands.remote._tcp_probe", lambda *a, **kw: None)
+        remote = MagicMock()
+        remote.Ping.side_effect = RuntimeError("proto mismatch")
+        monkeypatch.setattr(
+            "rdc.commands.remote.connect_remote_server",
+            lambda rd, url: remote,
+        )
+
+        result = CliRunner().invoke(remote_setup_cmd, ["192.168.1.10"])
+        assert result.exit_code == 1
+        assert any("handshake failed" in s for s in lines)
+        assert any("rdc doctor" in s for s in lines)
+        remote.ShutdownConnection.assert_called_once()
+
+    def test_failure_json_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        lines = _stderr_spy(monkeypatch)
+        monkeypatch.setattr("rdc.commands.remote._tcp_probe", lambda *a, **kw: "refused")
+
+        result = CliRunner().invoke(remote_setup_cmd, ["192.168.1.10", "--json"])
+        assert result.exit_code == 1
+        assert lines, "expected stderr output"
+        payload = json.loads(lines[0])
+        assert payload["host"] == "192.168.1.10"
+        assert payload["port"] == 39920
+        assert payload["failure"] == "refused"
+        assert "hint" in payload
+        assert "error" in payload
+
+    def test_timeout_flag_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_rd(monkeypatch)
+        captured: dict[str, Any] = {}
+
+        def fake_probe(host: str, port: int, timeout_s: float) -> str | None:
+            captured["timeout_s"] = timeout_s
+            return None
+
+        monkeypatch.setattr("rdc.commands.remote._tcp_probe", fake_probe)
+        monkeypatch.setattr(
+            "rdc.commands.remote.connect_remote_server",
+            lambda rd, url: MagicMock(),
+        )
+        monkeypatch.setattr("rdc.commands.remote.save_remote_state", lambda state: None)
+
+        result = CliRunner().invoke(remote_setup_cmd, ["192.168.1.10", "--timeout", "7.5"])
+        assert result.exit_code == 0
+        assert captured["timeout_s"] == 7.5
+
+    def test_bad_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        result = CliRunner().invoke(remote_setup_cmd, ["host:notanint"])
+        assert result.exit_code == 1
+
+    def test_help(self) -> None:
+        result = CliRunner().invoke(remote_setup_cmd, ["--help"])
+        assert result.exit_code == 0

--- a/tests/unit/test_remote_status_disconnect.py
+++ b/tests/unit/test_remote_status_disconnect.py
@@ -1,0 +1,114 @@
+"""Tests for `rdc remote status` and `rdc remote disconnect`."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from rdc.commands.remote import (
+    remote_disconnect_cmd,
+    remote_group,
+    remote_status_cmd,
+)
+from rdc.remote_state import RemoteServerState, save_remote_state
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("rdc._platform.data_dir", lambda: tmp_path / ".rdc")
+
+
+def _stderr_spy(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    lines: list[str] = []
+    orig = click.echo
+
+    def spy(message: Any = None, err: bool = False, **kw: Any) -> Any:
+        if err:
+            lines.append(str(message))
+        return orig(message, err=err, **kw)
+
+    monkeypatch.setattr("rdc.commands.remote.click.echo", spy)
+    return lines
+
+
+def _save(host: str = "192.168.1.42", port: int = 39920, at: float | None = None) -> None:
+    save_remote_state(
+        RemoteServerState(host=host, port=port, connected_at=at if at is not None else time.time())
+    )
+
+
+class TestRemoteStatus:
+    def test_with_state_prints_fields(self) -> None:
+        _save(at=time.time() - 3700)
+        result = CliRunner().invoke(remote_status_cmd, [])
+        assert result.exit_code == 0
+        assert "host: 192.168.1.42" in result.output
+        assert "port: 39920" in result.output
+        assert "saved_at:" in result.output
+        assert "age: 1h" in result.output
+
+    def test_with_state_json(self) -> None:
+        _save(at=time.time() - 120)
+        result = CliRunner().invoke(remote_status_cmd, ["--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["host"] == "192.168.1.42"
+        assert data["port"] == 39920
+        assert "saved_at" in data
+        assert "age" in data
+
+    def test_no_state_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        lines = _stderr_spy(monkeypatch)
+        result = CliRunner().invoke(remote_status_cmd, [])
+        assert result.exit_code == 0
+        assert any("no saved remote state" in s for s in lines)
+        assert any("rdc remote setup" in s for s in lines)
+
+    def test_no_state_json(self) -> None:
+        result = CliRunner().invoke(remote_status_cmd, ["--json"])
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {"state": None}
+
+
+class TestRemoteDisconnect:
+    def test_with_state_deletes(self) -> None:
+        _save()
+        result = CliRunner().invoke(remote_disconnect_cmd, [])
+        assert result.exit_code == 0
+        assert "disconnected: 192.168.1.42:39920" in result.output
+        # Re-running should say "nothing to disconnect"
+        result2 = CliRunner().invoke(remote_disconnect_cmd, [])
+        assert result2.exit_code == 0
+
+    def test_with_state_json(self) -> None:
+        _save()
+        result = CliRunner().invoke(remote_disconnect_cmd, ["--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == {"disconnected": "192.168.1.42:39920"}
+
+    def test_no_state(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        lines = _stderr_spy(monkeypatch)
+        result = CliRunner().invoke(remote_disconnect_cmd, [])
+        assert result.exit_code == 0
+        assert any("nothing to disconnect" in s for s in lines)
+
+    def test_no_state_json(self) -> None:
+        result = CliRunner().invoke(remote_disconnect_cmd, ["--json"])
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {"disconnected": None}
+
+
+class TestGroupRegistration:
+    def test_group_lists_new_commands(self) -> None:
+        result = CliRunner().invoke(remote_group, ["--help"])
+        assert result.exit_code == 0
+        assert "setup" in result.output
+        assert "status" in result.output
+        assert "disconnect" in result.output


### PR DESCRIPTION
## Summary

Phase 9 PR 2 of 3 — three new \`rdc remote\` subcommands that close the PC-to-PC bootstrap gap for Linux/embedded remote capture workflows. No SSH subprocess (per ADR D-050); verify-and-connect only, with actionable failure hints that tell the user exactly what to run on the target host.

## New commands

### \`rdc remote setup HOST[:PORT] [--timeout SEC] [--json]\`
TCP probe + RenderDoc Ping handshake + state save, in one command. On failure, classifies into one of four kinds and emits a hint specific to that class.

- \`refused\` → suggest \`rdc serve --daemon --port PORT\` on target
- \`timeout\` → suggest network path / firewall / NAT review
- \`unreachable\` → suggest hostname resolution and route check
- \`ping_failed\` → suggest \`rdc doctor\` + \`rdc --version\` comparison (reached only after TCP succeeded, so the target process is up but not the right one / wrong version)

On success: saves state and prints \`next: rdc remote list\`.

### \`rdc remote status [--json]\`
Prints saved host/port/saved_at/age. Exits 0 with stderr hint when no state.

### \`rdc remote disconnect [--json]\`
Deletes the latest saved state. Pure local operation, does not contact the remote.

## Why

This PR does not introduce any new architecture. It reuses \`save_remote_state\` / \`load_latest_remote_state\` / \`delete_remote_state\` from the existing \`remote_state.py\` and follows the same Click + JSON dispatch pattern as \`remote connect\`. The value is onboarding: before PR 2, a new user had to remember to \`ssh HOST rdc serve --daemon\` then come back and \`rdc remote connect HOST\`, with no feedback until they tried \`remote list\` or \`remote capture\`. After PR 2, one command does the probe + handshake + save and explains every failure mode.

## Implementation notes

- **\`_tcp_probe\`**: pure stdlib \`socket\`, 11 LOC, 3 exception branches with specific→general ordering (\`ConnectionRefusedError\` is an \`OSError\` subclass; \`TimeoutError\` aliases \`socket.timeout\` on Python 3.10+).
- **\`_renderdoc_handshake\`**: inline replacement for \`_ensure_remote_reachable\` because the existing helper raises \`SystemExit\`, which cannot be intercepted to distinguish \`ping_failed\` from TCP-level failures. The new helper raises \`RuntimeError\` cleanly so \`remote_setup_cmd\` can route it to the \`ping_failed\` hint.
- **\`_emit_setup_failure\`**: shared emitter for the 4 failure paths to avoid 4-way duplication of JSON + plain output blocks.
- **\`_format_age\`**: h/m/s granularity (no days; acceptable per Phase doc follow-up).

## Tests (+325 LOC)

- \`test_remote_setup.py\` — 4 tcp_probe paths, 5 hint branches, success path, all 4 failure classes including \`ping_failed\` via \`connect_remote_server().Ping.side_effect = RuntimeError\`, JSON failure shape, \`--timeout\` propagation, bad URL.
- \`test_remote_status_disconnect.py\` — 8 branches (with/without state × plain/json × status/disconnect) + group-registration assertion that all three commands show up in \`rdc remote --help\`.

## Verification

- [x] \`pixi run lint\` — ruff clean
- [x] \`pixi run typecheck\` — mypy strict clean
- [x] \`pixi run test\` — 2828 passed, 6 skipped, **coverage 92.59%** (up from 92.52% after PR 1)
- [x] Manual smoke: success / refused / timeout / --json paths all end-to-end verified
- [x] Opus code review: 14 fact-checks verified clean, **0 blocking issues**. Hint wording accuracy verified for all 4 failure classes (no cross-pollution between classes, distinct remediation per class).

## Non-blocking follow-ups noted during review

- \`_format_age\` uses h/m/s granularity without days. For long-saved state (>24h) this prints e.g. \`72h0m\`. Acceptable for engineer-facing CLI.
- \`remote disconnect\` only deletes the single latest state, matching the \`load_latest_remote_state\` / \`delete_remote_state\` semantics. If multiple remote states accumulate, \`disconnect --all\` could be a future enhancement.
- \`test_bad_url\` only asserts \`exit_code == 1\` without checking error text. Minor test robustness.

## Refs

- Phase plan: \`规划/Phase9-Remote-UX-Polish.md\` (vault, Section "PR 2 · Remote Setup + Status/Disconnect")
- Research: \`调研/调研-Phase9-Remote-UX.md\` Section B (remote setup transport design)
- ADRs: D-049 (hint injection over ErrorKind), D-050 (verify-only, no SSH subprocess)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rdc remote setup` command to configure a remote server connection (requires URL; supports `--timeout` and `--json` options)
  * Added `rdc remote status` command to view currently saved remote server state
  * Added `rdc remote disconnect` command to delete saved remote server configuration
  * All commands support JSON output via `--json` flag

* **Documentation**
  * Updated quick reference guide with new remote management subcommands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->