### PR TITLE
fix(build): resolve relative paths and preserve zip execute bits (#217)

### DIFF
--- a/src/rdc/_build_renderdoc.py
+++ b/src/rdc/_build_renderdoc.py
@@ -295,6 +295,10 @@ def _safe_extractall(zf: zipfile.ZipFile, dest: Path) -> None:
             sys.stderr.write(f"ERROR: zip-slip attempt detected: {member.filename}\n")
             raise SystemExit(1)
         zf.extract(member, dest)
+        # Restore Unix execute bits that zipfile.extract() drops.
+        unix_mode = member.external_attr >> 16
+        if unix_mode and (unix_mode & 0o111):
+            target.chmod(target.stat().st_mode | (unix_mode & 0o111))
 
 
 def download_swig(build_dir: Path) -> None:
@@ -756,8 +760,10 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
 
     plat = _platform()
-    install_dir = Path(args.install_dir) if args.install_dir else default_install_dir()
-    build_dir = Path(args.build_dir) if args.build_dir else install_dir.parent / "renderdoc-build"
+    install_dir = Path(args.install_dir).resolve() if args.install_dir else default_install_dir()
+    build_dir = (
+        Path(args.build_dir).resolve() if args.build_dir else install_dir.parent / "renderdoc-build"
+    )
 
     if _artifacts_present(install_dir, plat):
         _log(f"renderdoc already exists at {install_dir}/")


### PR DESCRIPTION
_safe_extractall() now restores Unix execute bits from zip entries, fixing SWIG autogen.sh exit-126 on Linux.  CLI-supplied install/build dirs are resolved to absolute paths so cmake never mis-resolves them relative to the source tree.

Closes #217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed issue where Unix executable permissions were lost during the build extraction process. Executable permission bits are now properly restored after extraction.
  * Improved handling of CLI-provided installation and build directory paths with enhanced path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->