### PR TITLE
fix(daemon): match D3D12 adapter on multi-GPU hosts (#225)

### DIFF
--- a/openspec/changes/2026-05-15-fix-225-d3d12-multi-gpu/proposal.md
+++ b/openspec/changes/2026-05-15-fix-225-d3d12-multi-gpu/proposal.md
@@ -1,0 +1,90 @@
+# Fix #225: D3D12 Multi-GPU Capture Replay
+
+## Summary
+
+Fix `_match_capture_gpu()` incorrectly returning the integrated GPU on multi-GPU
+systems when replaying D3D12 captures, causing an `E_INVALIDARG` heap failure on
+devices with insufficient VRAM.
+
+## Motivation
+
+`_match_capture_gpu()` only matches GPUs via the Vulkan `vkEnumeratePhysicalDevices`
+structured-data chunk. For D3D12 captures that chunk is absent, so the function
+falls through to `return gpus[0]`. On reporter's machine the GPU enumeration order
+was: AMD Radeon Graphics iGPU 2 GB, NVIDIA RTX 4500 Ada 24 GB, WARP. The iGPU was
+selected, D3D12 heap creation required more VRAM than available, and renderdoc
+returned `E_INVALIDARG`.
+
+The same fall-through also affects the remote-replay call site at line 368, which
+additionally never passes `sd` to the helper, so even the Vulkan path was silently
+bypassed on every remote replay.
+
+## Design
+
+### 1. D3D12 structured-data matching
+
+Walk the capture's structured data looking for chunks whose name contains
+`DriverInit`, `EnumAdapters`, or `CreateDXGIFactory`. Inside each matching chunk
+descend into child objects to find a child named `AdapterDesc` and within it a
+string field named `Description` or `DeviceName`. Perform a case-insensitive
+substring match of that string against `gpu.name`. Return the first GPU that
+matches.
+
+### 2. Vendor-preference fallback
+
+When no structured-data chunk produces a match, filter out Software/WARP adapters
+(`renderdoc.GPUVendor.Software`), then rank remaining GPUs by vendor:
+nVidia > AMD > Intel. Return the highest-ranked GPU, or the first non-Software GPU
+if no ranked match exists.
+
+### 3. Single-GPU short-circuit
+
+If `len(gpus) == 1` return that GPU immediately without inspecting structured data.
+
+### 4. Signature and call-site corrections
+
+Pass `rd` (the renderdoc module) into `_match_capture_gpu()` so that
+`GPUVendor` enum values are accessible without a module-level import assumption.
+Update the remote-replay call site (line 368) to pass `sd` in addition to `rd`,
+matching the local-replay call site.
+
+## Spec Delta
+
+A new scenario "Multi-GPU capture replay" should be appended under the existing
+**Requirement: Replay lifecycle** section in `openspec/specs/daemon/spec.md`:
+
+```
+#### Scenario: Multi-GPU capture replay
+- WHEN the capture was taken on a multi-GPU system
+- AND multiple GPUs are available for replay
+- THEN the daemon selects the GPU whose name matches structured-data adapter
+  metadata extracted from the capture
+- AND if no structured-data match exists, Software/WARP adapters are excluded
+  and the highest-ranked discrete GPU is preferred (nVidia > AMD > Intel)
+- AND a single available GPU is always returned directly without inspection
+```
+
+This proposal targets that scenario. The spec file itself is not modified here;
+the delta is applied in the implementing task (see `tasks.md`).
+
+## Files Changed
+
+- `src/rdc/daemon_server.py` — `_match_capture_gpu` body; call sites at lines 223
+  and 368
+- `tests/unit/test_daemon_server_unit.py` — new unit tests (see `test-plan.md`)
+
+## Risks
+
+- The exact D3D12 chunk name (`DriverInit` / `EnumAdapters` / `CreateDXGIFactory`)
+  has not been confirmed against a real renderdoc 1.42 D3D12 capture. The matching
+  uses substring search rather than exact equality as a defensive measure; a real
+  capture should be obtained from the issue reporter for verification before merge.
+- `renderdoc.GPUVendor.nVidia` uses a lower-case `n`. Attribute access should use
+  `getattr(rd.GPUVendor, "nVidia", 4)` with an integer fallback to avoid
+  `AttributeError` on builds where the spelling differs.
+- The Vulkan low-VRAM edge case (structured-data match returns a GPU that has less
+  VRAM than required) is not addressed here; the fix only corrects selection
+  behaviour and does not validate VRAM sufficiency.
+- Integration testing on Linux is not possible without Windows D3D12 multi-GPU
+  hardware. The unit tests use mocks. Full verification must be performed by the
+  issue reporter on their machine.

--- a/openspec/changes/2026-05-15-fix-225-d3d12-multi-gpu/tasks.md
+++ b/openspec/changes/2026-05-15-fix-225-d3d12-multi-gpu/tasks.md
@@ -1,0 +1,10 @@
+# Fix #225: Tasks
+
+- [ ] `daemon_server.py`: add D3D12 structured-data matching to `_match_capture_gpu` (walk `DriverInit`/`EnumAdapters`/`CreateDXGIFactory` chunks, match `AdapterDesc.Description`/`DeviceName` against `gpu.name`)
+- [ ] `daemon_server.py`: add vendor-preference fallback (drop Software/WARP, prefer nVidia > AMD > Intel via `getattr` on `rd.GPUVendor`)
+- [ ] `daemon_server.py`: add single-GPU short-circuit at top of `_match_capture_gpu`
+- [ ] `daemon_server.py`: add `rd` parameter to `_match_capture_gpu` signature; update both call sites (lines 223 and 368)
+- [ ] `daemon_server.py`: pass `sd` at the remote-replay call site (line 368)
+- [ ] `openspec/specs/daemon/spec.md`: append "Multi-GPU capture replay" scenario under **Requirement: Replay lifecycle**
+- [ ] `tests/unit/test_daemon_server_unit.py`: implement all 8 unit test cases from `test-plan.md`
+- [ ] `pixi run lint && pixi run test` passes

--- a/openspec/changes/2026-05-15-fix-225-d3d12-multi-gpu/test-plan.md
+++ b/openspec/changes/2026-05-15-fix-225-d3d12-multi-gpu/test-plan.md
@@ -1,0 +1,33 @@
+# Fix #225: Test Plan
+
+## Unit tests — `tests/unit/test_daemon_server_unit.py`
+
+- [ ] `test_single_gpu_returns_it` — given `len(gpus) == 1` with any `sd` value
+  (including `None`), assert that GPU is returned without inspecting structured data
+
+- [ ] `test_vulkan_match_by_devicename` — regression guard for the existing Vulkan
+  path; mock structured data containing a `vkEnumeratePhysicalDevices` chunk with a
+  `DeviceName` field matching one of two GPU names; assert the matching GPU is
+  returned
+
+- [ ] `test_d3d12_match_via_driverinit_adapterdesc` — mock structured data with a
+  `DriverInit` chunk whose `AdapterDesc` child has a `Description` field matching
+  one GPU among three (iGPU, discrete, WARP); assert the discrete GPU is returned
+
+- [ ] `test_d3d12_fallback_skips_warp_prefers_nvidia` — no structured-data match;
+  three GPUs with vendors Software (WARP), AMD (iGPU), nVidia (discrete); assert
+  the nVidia GPU is returned
+
+- [ ] `test_d3d12_fallback_amd_over_intel` — no structured-data match; vendors
+  [Intel, AMD, Software]; assert the AMD GPU is returned
+
+- [ ] `test_no_structured_data_uses_fallback_not_gpu0` — `sd=None`; two GPUs in
+  order [AMD iGPU, NVIDIA discrete]; assert NVIDIA is returned, reproducing the
+  literal issue #225 scenario (iGPU was previously returned as `gpus[0]`)
+
+- [ ] `test_empty_gpu_list_returns_none` — `gpus=[]`; assert return value is `None`
+  (no exception raised)
+
+- [ ] `test_remote_replay_passes_sd` — mock the `_match_capture_gpu` call site at
+  the remote-replay path (line 368); assert it is invoked with a non-`None` `sd`
+  argument when structured data is available

--- a/openspec/specs/daemon/spec.md
+++ b/openspec/specs/daemon/spec.md
@@ -35,6 +35,15 @@ ReplayController for the duration of the session.
 - **THEN** it calls controller.Shutdown() and cap.Shutdown()
 - **AND** the process exits
 
+#### Scenario: Multi-GPU capture replay
+- **WHEN** the capture was taken on a multi-GPU system
+- **AND** multiple GPUs are available for replay
+- **THEN** the daemon selects the GPU whose name matches structured-data adapter
+  metadata extracted from the capture
+- **AND** if no structured-data match exists, Software/WARP adapters are excluded
+  and the highest-ranked discrete GPU is preferred (nVidia > AMD > Intel)
+- **AND** a single available GPU is always returned directly without inspection
+
 ### Requirement: Navigation methods
 The daemon MUST support event navigation with SetFrameEvent caching.
 

--- a/src/rdc/daemon_server.py
+++ b/src/rdc/daemon_server.py
@@ -242,8 +242,10 @@ def _match_capture_gpu(cap: Any, sd: Any = None, rd: Any = None) -> Any | None:
                 if any(marker in cname for marker in d3d_markers):
                     desc = _find_adapter_description(c)
                     if desc:
+                        desc_l = desc.lower()
                         for g in gpus:
-                            if desc in g.name or g.name in desc:
+                            name_l = g.name.lower()
+                            if desc_l in name_l or name_l in desc_l:
                                 return g
 
         vendor_enum = getattr(rd, "GPUVendor", None) if rd is not None else None
@@ -252,12 +254,33 @@ def _match_capture_gpu(cap: Any, sd: Any = None, rd: Any = None) -> Any | None:
         intel = getattr(vendor_enum, "Intel", 5)
         software = getattr(vendor_enum, "Software", 9)
         priority = {nvidia: 0, amd: 1, intel: 2}
+        available = [(g.name, g.vendor, g.deviceID) for g in gpus]
         filtered = [g for g in gpus if g.vendor != software]
         if not filtered:
+            _log.warning(
+                "GPU match fallback: no name/desc match and only software GPUs; "
+                "available=%r choosing gpus[0]=%s",
+                available,
+                gpus[0].name,
+            )
             return gpus[0]
         filtered.sort(key=lambda g: priority.get(g.vendor, 99))
-        return filtered[0]
-    except Exception:  # noqa: BLE001
+        chosen = filtered[0]
+        _log.warning(
+            "GPU match fallback: no name/desc match; available=%r choosing "
+            "vendor-priority %s (vendor=%d id=%d)",
+            available,
+            chosen.name,
+            chosen.vendor,
+            chosen.deviceID,
+        )
+        return chosen
+    except Exception as exc:  # noqa: BLE001
+        _log.warning(
+            "GPU match raised %s: %s -- falling back to gpus[0]",
+            type(exc).__name__,
+            exc,
+        )
         try:
             return gpus[0] if gpus else None
         except NameError:
@@ -449,6 +472,12 @@ def _load_remote_replay(state: DaemonState, remote_url: str) -> str | None:
                         if gpu is not None:
                             remote_opts.forceGPUVendor = gpu.vendor
                             remote_opts.forceGPUDeviceID = gpu.deviceID
+                            _log.info(
+                                "remote replay GPU: %s (vendor=%d id=%d)",
+                                gpu.name,
+                                gpu.vendor,
+                                gpu.deviceID,
+                            )
                 finally:
                     tmp_cap.Shutdown()
             except Exception as exc:  # noqa: BLE001

--- a/src/rdc/daemon_server.py
+++ b/src/rdc/daemon_server.py
@@ -167,33 +167,101 @@ def _cleanup_temp(state: DaemonState) -> None:
 _log = logging.getLogger("rdc.daemon")
 
 
-def _match_capture_gpu(cap: Any, sd: Any = None) -> Any | None:
-    """Find the GPU used for capture by matching structured data against available GPUs."""
+def _find_adapter_description(chunk: Any) -> str | None:
+    """Extract D3D12 adapter description string from a structured-data chunk.
+
+    Args:
+        chunk: A renderdoc SDChunk (or SDObject) whose subtree may contain an
+            ``AdapterDesc``/``pAdapter``/``adapter`` child with a ``Description``
+            or ``DeviceName`` field, or a direct ``Description``/``DeviceName``
+            child.
+
+    Returns:
+        The adapter description string when found, otherwise ``None``.
+    """
+    try:
+        for i in range(chunk.NumChildren()):
+            child = chunk.GetChild(i)
+            cname = child.name
+            if cname in ("Description", "DeviceName"):
+                value = child.AsString()
+                if value:
+                    return str(value)
+            if cname in ("AdapterDesc", "pAdapter", "adapter"):
+                for j in range(child.NumChildren()):
+                    grand = child.GetChild(j)
+                    if grand.name in ("Description", "DeviceName"):
+                        value = grand.AsString()
+                        if value:
+                            return str(value)
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _match_capture_gpu(cap: Any, sd: Any = None, rd: Any = None) -> Any | None:
+    """Pick the replay GPU that produced ``cap``.
+
+    Walks structured-data chunks to match the capture's Vulkan
+    ``vkEnumeratePhysicalDevices`` device name or the D3D12 adapter
+    description. Falls back to vendor priority (nVidia > AMD > Intel,
+    Software/WARP excluded) when no chunk-based match succeeds.
+
+    Args:
+        cap: An open renderdoc capture file.
+        sd: Optional structured data from ``cap.GetStructuredData()``.
+        rd: Optional renderdoc module, used for ``GPUVendor`` enum lookup.
+
+    Returns:
+        The selected ``GPUDevice`` or ``None`` when no GPUs are available.
+    """
     try:
         gpus = cap.GetAvailableGPUs()
         if not gpus:
             return None
         if len(gpus) == 1:
             return gpus[0]
-        if sd is None:
+
+        if sd is not None:
+            d3d_markers = ("DriverInit", "EnumAdapters", "CreateDXGIFactory")
+            for i in range(len(sd.chunks)):
+                c = sd.chunks[i]
+                cname = c.name
+                if cname == "vkEnumeratePhysicalDevices":
+                    for j in range(c.NumChildren()):
+                        child = c.GetChild(j)
+                        if child.name == "physProps":
+                            for k in range(child.NumChildren()):
+                                prop = child.GetChild(k)
+                                if prop.name == "deviceName":
+                                    name = prop.AsString()
+                                    for g in gpus:
+                                        if g.name == name:
+                                            return g
+                    break
+                if any(marker in cname for marker in d3d_markers):
+                    desc = _find_adapter_description(c)
+                    if desc:
+                        for g in gpus:
+                            if desc in g.name or g.name in desc:
+                                return g
+
+        vendor_enum = getattr(rd, "GPUVendor", None) if rd is not None else None
+        nvidia = getattr(vendor_enum, "nVidia", 6)
+        amd = getattr(vendor_enum, "AMD", 2)
+        intel = getattr(vendor_enum, "Intel", 5)
+        software = getattr(vendor_enum, "Software", 9)
+        priority = {nvidia: 0, amd: 1, intel: 2}
+        filtered = [g for g in gpus if g.vendor != software]
+        if not filtered:
             return gpus[0]
-        for i in range(len(sd.chunks)):
-            c = sd.chunks[i]
-            if c.name == "vkEnumeratePhysicalDevices":
-                for j in range(c.NumChildren()):
-                    child = c.GetChild(j)
-                    if child.name == "physProps":
-                        for k in range(child.NumChildren()):
-                            prop = child.GetChild(k)
-                            if prop.name == "deviceName":
-                                name = prop.AsString()
-                                for g in gpus:
-                                    if g.name == name:
-                                        return g
-                break
+        filtered.sort(key=lambda g: priority.get(g.vendor, 99))
+        return filtered[0]
     except Exception:  # noqa: BLE001
-        pass
-    return gpus[0] if gpus else None
+        try:
+            return gpus[0] if gpus else None
+        except NameError:
+            return None
 
 
 def _load_replay(state: DaemonState) -> str | None:
@@ -220,7 +288,7 @@ def _load_replay(state: DaemonState) -> str | None:
         return "local replay not supported on this platform"
 
     opts = rd.ReplayOptions()
-    gpu = _match_capture_gpu(cap, cap.GetStructuredData())
+    gpu = _match_capture_gpu(cap, cap.GetStructuredData(), rd)
     if gpu is not None:
         opts.forceGPUVendor = gpu.vendor
         opts.forceGPUDeviceID = gpu.deviceID
@@ -377,7 +445,7 @@ def _load_remote_replay(state: DaemonState, remote_url: str) -> str | None:
                 try:
                     open_result = tmp_cap.OpenFile(state.local_capture_path, "", None)
                     if open_result == rd.ResultCode.Succeeded:
-                        gpu = _match_capture_gpu(tmp_cap)
+                        gpu = _match_capture_gpu(tmp_cap, tmp_cap.GetStructuredData(), rd)
                         if gpu is not None:
                             remote_opts.forceGPUVendor = gpu.vendor
                             remote_opts.forceGPUDeviceID = gpu.deviceID

--- a/src/rdc/daemon_server.py
+++ b/src/rdc/daemon_server.py
@@ -194,7 +194,8 @@ def _find_adapter_description(chunk: Any) -> str | None:
                         value = grand.AsString()
                         if value:
                             return str(value)
-    except Exception:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
+        _log.debug("adapter-desc parse failed: %s: %s", type(exc).__name__, exc)
         return None
     return None
 
@@ -481,7 +482,7 @@ def _load_remote_replay(state: DaemonState, remote_url: str) -> str | None:
                 finally:
                     tmp_cap.Shutdown()
             except Exception as exc:  # noqa: BLE001
-                _log.warning("GPU probe skipped: %s", exc)
+                _log.warning("GPU probe skipped: %s: %s", type(exc).__name__, exc)
 
         step = "open remote capture"
         result, controller = remote.OpenCapture(

--- a/tests/unit/test_daemon_server_unit.py
+++ b/tests/unit/test_daemon_server_unit.py
@@ -226,6 +226,14 @@ class TestMatchCaptureGpu:
         sd = self._vulkan_sd("NVIDIA RTX 4500 Ada")
         assert _match_capture_gpu(cap, sd, self._FakeRD) is b
 
+    def test_vulkan_no_name_match_falls_back_to_vendor_priority(self) -> None:
+        """Vulkan chunk present but deviceName matches no GPU → vendor-priority fallback, not gpu[0]."""  # noqa: E501
+        igpu = self._gpu("AMD Radeon Graphics", self._AMD)
+        discrete = self._gpu("NVIDIA RTX 4500 Ada", self._NVIDIA)
+        cap = self._cap([igpu, discrete])
+        sd = self._vulkan_sd("NVIDIA GTX 1080 (uninstalled hardware)")
+        assert _match_capture_gpu(cap, sd, self._FakeRD) is discrete
+
     def test_d3d12_match_via_driverinit_adapterdesc(self) -> None:
         igpu = self._gpu("AMD Radeon Graphics", self._AMD)
         discrete = self._gpu("NVIDIA RTX 4500 Ada Generation", self._NVIDIA)

--- a/tests/unit/test_daemon_server_unit.py
+++ b/tests/unit/test_daemon_server_unit.py
@@ -18,6 +18,7 @@ from rdc.daemon_server import (
     _cleanup_temp_capture,
     _handle_request,
     _load_replay,
+    _match_capture_gpu,
     _process_request,
     _set_frame_event,
 )
@@ -167,6 +168,145 @@ class TestHandleRequest:
         )
         assert "error" in resp
         assert resp["error"]["code"] == -32002
+
+
+class TestMatchCaptureGpu:
+    """Multi-GPU selection logic (#225 D3D12 + Vulkan + fallback)."""
+
+    # GPUVendor ordinals match RenderDoc's replay_enums.h.
+    _SOFTWARE = 9
+    _AMD = 2
+    _INTEL = 5
+    _NVIDIA = 6
+
+    class _FakeRD:
+        # Mirrors renderdoc.GPUVendor; the lowercase 'n' in nVidia matches upstream.
+        class GPUVendor:
+            Software = 9
+            AMD = 2
+            Intel = 5
+            nVidia = 6  # noqa: N815
+
+    @staticmethod
+    def _gpu(name: str, vendor: int) -> SimpleNamespace:
+        return SimpleNamespace(name=name, vendor=vendor, deviceID=0, driver="")
+
+    @staticmethod
+    def _cap(gpus: list[Any]) -> SimpleNamespace:
+        return SimpleNamespace(GetAvailableGPUs=lambda: gpus)
+
+    @staticmethod
+    def _vulkan_sd(device_name: str) -> SimpleNamespace:
+        import mock_renderdoc as rd
+
+        prop = rd.SDObject(name="deviceName", data=rd.SDData(basic=rd.SDBasic(value=device_name)))
+        phys = rd.SDObject(name="physProps", children=[prop])
+        chunk = rd.SDChunk(name="vkEnumeratePhysicalDevices", children=[phys])
+        return rd.StructuredFile(chunks=[chunk])
+
+    @staticmethod
+    def _d3d12_sd(description: str, chunk_name: str = "DriverInit") -> SimpleNamespace:
+        import mock_renderdoc as rd
+
+        desc = rd.SDObject(name="Description", data=rd.SDData(basic=rd.SDBasic(value=description)))
+        adapter = rd.SDObject(name="AdapterDesc", children=[desc])
+        chunk = rd.SDChunk(name=chunk_name, children=[adapter])
+        return rd.StructuredFile(chunks=[chunk])
+
+    def test_single_gpu_returns_it(self) -> None:
+        only = self._gpu("Mock GPU", self._AMD)
+        cap = self._cap([only])
+        assert _match_capture_gpu(cap, None, self._FakeRD) is only
+        assert _match_capture_gpu(cap, self._vulkan_sd("does-not-matter"), self._FakeRD) is only
+
+    def test_vulkan_match_by_devicename(self) -> None:
+        a = self._gpu("AMD Radeon Graphics", self._AMD)
+        b = self._gpu("NVIDIA RTX 4500 Ada", self._NVIDIA)
+        cap = self._cap([a, b])
+        sd = self._vulkan_sd("NVIDIA RTX 4500 Ada")
+        assert _match_capture_gpu(cap, sd, self._FakeRD) is b
+
+    def test_d3d12_match_via_driverinit_adapterdesc(self) -> None:
+        igpu = self._gpu("AMD Radeon Graphics", self._AMD)
+        discrete = self._gpu("NVIDIA RTX 4500 Ada Generation", self._NVIDIA)
+        warp = self._gpu("Microsoft Basic Render Driver (WARP)", self._SOFTWARE)
+        cap = self._cap([igpu, discrete, warp])
+        sd = self._d3d12_sd("NVIDIA RTX 4500 Ada Generation")
+        assert _match_capture_gpu(cap, sd, self._FakeRD) is discrete
+
+    def test_d3d12_fallback_skips_warp_prefers_nvidia(self) -> None:
+        warp = self._gpu("WARP", self._SOFTWARE)
+        igpu = self._gpu("AMD Radeon Graphics", self._AMD)
+        discrete = self._gpu("NVIDIA RTX 4500 Ada", self._NVIDIA)
+        cap = self._cap([warp, igpu, discrete])
+        # No structured data → fallback.
+        assert _match_capture_gpu(cap, None, self._FakeRD) is discrete
+
+    def test_d3d12_fallback_amd_over_intel(self) -> None:
+        intel = self._gpu("Intel UHD Graphics", self._INTEL)
+        amd = self._gpu("AMD Radeon RX", self._AMD)
+        warp = self._gpu("WARP", self._SOFTWARE)
+        cap = self._cap([intel, amd, warp])
+        assert _match_capture_gpu(cap, None, self._FakeRD) is amd
+
+    def test_no_structured_data_uses_fallback_not_gpu0(self) -> None:
+        """Regression: issue #225 literal scenario — iGPU was previously returned as gpus[0]."""
+        igpu = self._gpu("AMD Radeon Graphics", self._AMD)
+        discrete = self._gpu("NVIDIA RTX 4500 Ada", self._NVIDIA)
+        cap = self._cap([igpu, discrete])
+        assert _match_capture_gpu(cap, None, self._FakeRD) is discrete
+
+    def test_empty_gpu_list_returns_none(self) -> None:
+        cap = self._cap([])
+        assert _match_capture_gpu(cap, None, self._FakeRD) is None
+
+    def test_remote_replay_passes_sd(self, monkeypatch: Any) -> None:
+        """The remote-replay call site must pass non-None sd and rd to the matcher."""
+        import mock_renderdoc as mock_rd
+
+        captured: dict[str, Any] = {}
+
+        def _spy(cap: Any, sd: Any = None, rd: Any = None) -> Any:
+            captured["cap"] = cap
+            captured["sd"] = sd
+            captured["rd"] = rd
+            return None
+
+        monkeypatch.setattr("rdc.daemon_server._match_capture_gpu", _spy)
+
+        # Force the remote connection to succeed and short-circuit OpenCapture so
+        # the function exits cleanly after the spy is called. Names mirror the
+        # renderdoc CamelCase API.
+        remote = SimpleNamespace(
+            CopyCaptureToRemote=lambda path, cb: path,
+            CopyCaptureFromRemote=lambda path, dst, cb: None,
+            OpenCapture=lambda pref, path, opts, cb: (mock_rd.ResultCode.InternalError, None),
+            ShutdownConnection=lambda: None,
+            Ping=lambda: None,
+        )
+
+        def _create_remote(url: str) -> tuple[Any, Any]:
+            return mock_rd.ResultCode.Succeeded, remote
+
+        monkeypatch.setattr(mock_rd, "CreateRemoteServerConnection", _create_remote, raising=False)
+
+        # Make local_capture exist so the upload branch is taken.
+        cap_path = Path("test.rdc")
+        cap_path.write_bytes(b"\x00")
+        try:
+            sys.modules["renderdoc"] = mock_rd  # type: ignore[assignment]
+            try:
+                from rdc.daemon_server import _load_remote_replay
+
+                state = DaemonState(capture=str(cap_path), current_eid=0, token="tok")
+                _load_remote_replay(state, "remote://example")
+            finally:
+                sys.modules.pop("renderdoc", None)
+        finally:
+            cap_path.unlink(missing_ok=True)
+
+        assert captured.get("sd") is not None
+        assert captured.get("rd") is mock_rd
 
 
 class TestShutdownExceptionStops:

--- a/tests/unit/test_daemon_server_unit.py
+++ b/tests/unit/test_daemon_server_unit.py
@@ -242,6 +242,31 @@ class TestMatchCaptureGpu:
         sd = self._d3d12_sd("NVIDIA RTX 4500 Ada Generation")
         assert _match_capture_gpu(cap, sd, self._FakeRD) is discrete
 
+    def test_d3d12_match_case_insensitive(self) -> None:
+        """#225: mixed-case adapter Description matches a differently-cased GPU name.
+
+        With a case-sensitive match this would miss and fall to vendor priority;
+        case-insensitive matching must return the named GPU directly.
+        """
+        nvidia = self._gpu("NVIDIA RTX 4500 Ada", self._NVIDIA)
+        amd = self._gpu("amd radeon rx 7900 xtx", self._AMD)
+        cap = self._cap([nvidia, amd])
+        # Capture was produced on the AMD card; desc differs only in case.
+        sd = self._d3d12_sd("AMD Radeon RX 7900 XTX")
+        # Vendor-priority fallback would pick NVIDIA; case-insensitive match must
+        # return the AMD card the capture actually came from.
+        assert _match_capture_gpu(cap, sd, self._FakeRD) is amd
+
+    def test_fallback_emits_diagnostic_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Vendor-priority fallback must log the available GPUs and the chosen one."""
+        igpu = self._gpu("AMD Radeon Graphics", self._AMD)
+        discrete = self._gpu("NVIDIA RTX 4500 Ada", self._NVIDIA)
+        cap = self._cap([igpu, discrete])
+        with caplog.at_level(logging.WARNING, logger="rdc.daemon"):
+            assert _match_capture_gpu(cap, None, self._FakeRD) is discrete
+        assert any("fallback" in r.message.lower() for r in caplog.records)
+        assert any("NVIDIA RTX 4500 Ada" in r.message for r in caplog.records)
+
     def test_d3d12_fallback_skips_warp_prefers_nvidia(self) -> None:
         warp = self._gpu("WARP", self._SOFTWARE)
         igpu = self._gpu("AMD Radeon Graphics", self._AMD)


### PR DESCRIPTION
Fixes #225.

## Problem

`_match_capture_gpu()` in `daemon_server.py` previously matched GPUs only via the Vulkan `vkEnumeratePhysicalDevices` structured-data chunk. D3D12 captures don't emit that chunk, so the function fell through to `return gpus[0]`. On the reporter's multi-GPU Windows machine (NVIDIA RTX 4500 Ada discrete + AMD Radeon iGPU + WARP) `gpus[0]` was the AMD iGPU with ~2 GB VRAM, which is insufficient for the D3D12 heaps the capture needs — replay failed with `E_INVALIDARG` on heap creation.

A second latent bug was discovered alongside it: the remote-replay call site never passed structured data to `_match_capture_gpu`, so even Vulkan matching was silently bypassed in remote mode.

## Fix

`src/rdc/daemon_server.py`
- `_match_capture_gpu(cap, sd=None, rd=None)` short-circuits on 0/1 GPUs, then walks `sd.chunks`:
  - Vulkan path preserved (existing `vkEnumeratePhysicalDevices` → `physProps` → `deviceName` match).
  - **New D3D12 path**: chunks whose name contains `DriverInit`, `EnumAdapters`, or `CreateDXGIFactory` are searched via a new `_find_adapter_description` helper that walks one or two levels deep looking for `AdapterDesc`/`pAdapter`/`adapter` containers and `Description`/`DeviceName` strings, then matches by substring against `gpu.name`.
- When structured-data matching produces no hit, the fallback now drops Software/WARP and sorts the rest by vendor priority **nVidia > AMD > Intel** via `renderdoc.GPUVendor` (accessed defensively with `getattr` + integer fallback so missing enum members don't crash).
- Both call sites (local replay at the `OpenCapture` path, remote replay at the metadata-load path) now pass `cap.GetStructuredData()` and `rd`.

## Test plan

`tests/unit/test_daemon_server_unit.py` — new `TestMatchCaptureGpu` class with 9 cases:
1. Single GPU returns it
2. Vulkan match by `deviceName` (regression guard for existing path)
3. **Vulkan chunk present but `deviceName` matches nothing → vendor fallback** (pins contract for swapped/uninstalled hardware)
4. D3D12 match via `DriverInit`/`AdapterDesc`
5. D3D12 fallback skips WARP, prefers NVIDIA over AMD iGPU
6. D3D12 fallback prefers AMD over Intel
7. No structured data → vendor fallback (the literal #225 scenario)
8. Empty GPU list → `None`
9. Remote-replay call site passes structured data (asserts via spy)

```
$ pixi run pytest tests/unit/test_daemon_server_unit.py::TestMatchCaptureGpu -v
collected 9 items
========================== 9 passed in 0.03s ==========================

$ pixi run test
2855 passed, 6 skipped in 15.29s
Total coverage: 92.73%

$ pixi run lint
All checks passed!  # ruff + mypy strict
```

## Spec

Adds a "Multi-GPU capture replay" scenario under `### Requirement: Replay lifecycle` in `openspec/specs/daemon/spec.md`. OpenSpec change docs under `openspec/changes/2026-05-15-fix-225-d3d12-multi-gpu/`.

## Cannot verify locally

This is a Linux dev box without a Windows multi-GPU + D3D12 setup. Logic is exercised end-to-end via mocked structured data, but the exact D3D12 chunk name emitted by renderdoc 1.42 (`DriverInit` vs `SystemChunk::DriverInit` vs version variants) and the `AdapterDesc` child layout are educated guesses based on the renderdoc source. The matcher uses **substring matching and a two-tier helper** as defensive measures, but a real capture from the reporter is the only way to confirm the field names actually line up.

@YunHsiao — would you mind grabbing this branch (or waiting for the merged build) and re-running `rdc open` on the original D3D12 capture? If it still picks the iGPU, the chunk-name guess is wrong and we can iterate on the `_find_adapter_description` walk. Thanks for the very detailed bug report — `forceGPUVendor` / `forceGPUDeviceID` evidence made the root cause obvious.

## Commits

- `ec40b10` fix(daemon): match D3D12 adapter on multi-GPU hosts (#225)
- `45543e9` test(daemon): cover vulkan-no-match fallback path (#225)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GPU selection during capture replay on multi-GPU systems to intelligently match source hardware using capture metadata.
  * Implemented vendor-priority GPU fallback (NVIDIA > AMD > Intel) for improved replay accuracy when exact matches unavailable.

* **Documentation**
  * Added multi-GPU capture replay scenario specifications and comprehensive test coverage documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/rdc-cli/pull/226)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->