### PR TITLE
ci(aur): bump deploy-aur action v4.1.1 -> v4.1.3 (fix bash --command crash)

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: KSXGitHub/github-actions-deploy-aur@2ac5a4c1d7035885d46b10e3193393be8460b6f1 # v4.1.1
+      - uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3
         with:
           pkgname: rdc-cli-git
           pkgbuild: aur/PKGBUILD
@@ -69,7 +69,7 @@ jobs:
           sed -i "s/^pkgver=.*/pkgver=${VERSION}/" aur/stable/PKGBUILD
           sed -i "s/'PLACEHOLDER'/'${SHA256}'/" aur/stable/PKGBUILD
 
-      - uses: KSXGitHub/github-actions-deploy-aur@2ac5a4c1d7035885d46b10e3193393be8460b6f1 # v4.1.1
+      - uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3
         with:
           pkgname: rdc-cli
           pkgbuild: aur/stable/PKGBUILD

--- a/openspec/changes/2026-05-17-fix-aur-deploy-action-v413/proposal.md
+++ b/openspec/changes/2026-05-17-fix-aur-deploy-action-v413/proposal.md
@@ -1,0 +1,101 @@
+# Fix AUR Deploy Action Pin: v4.1.1 → v4.1.3
+
+## Problem
+
+### Symptom
+
+`AUR Publish` workflow run 26001352704, job `Publish rdc-cli (stable)`, failed on
+the v0.5.5 tag with:
+
+```
+bash: --command: invalid option
+```
+
+The job exited before `/build.sh` ran. The `aur-git` job was not triggered (it
+fires on branch push only). The v0.5.5 PyPI release and GitHub Release were
+already shipped; the AUR `rdc-cli` package was not updated.
+
+### Root cause
+
+Both jobs pin
+`KSXGitHub/github-actions-deploy-aur@2ac5a4c1d7035885d46b10e3193393be8460b6f1`
+(v4.1.1). That action's `entrypoint.sh` ends with:
+
+```sh
+exec runuser builder --command 'bash -l -c /build.sh'
+```
+
+With the `util-linux` `runuser` binary now present in the current `archlinux:base`
+Docker image, the `--command` flag is parsed as an option to `bash` (su(1)-compat
+syntax passes the argument onward), and bash has no `--command` option. The process
+crashes before `/build.sh` ever runs.
+
+This latent bug existed in v3.0.1 through v4.1.1 of the action. Earlier workflow
+runs on v0.5.2/v0.5.3 were green because the then-current `archlinux:base` image
+did not expose the issue. A recent Arch base image update surfaced it.
+
+### Why `post_process: git checkout -B master` is innocent
+
+`build.sh` (which clones the AUR repo, evaluates `$post_process`, commits, and
+force-pushes to AUR master) is byte-identical across v4.1.1, v4.1.2, and v4.1.3.
+The crash happens in `entrypoint.sh` before `build.sh` is ever invoked, so
+`post_process` was never reached and plays no role in the failure.
+
+### Fix-forward context
+
+The v0.5.5 PyPI package and GitHub Release are already published and cannot be
+retracted. The only outstanding item is the AUR `rdc-cli` package backfill, which
+requires a successful workflow run for version 0.5.5.
+
+## Solution
+
+Bump the action pin on **both** jobs in `.github/workflows/aur.yml`:
+
+| Location | Current | After |
+|---|---|---|
+| Line 25, job `aur-git` | `2ac5a4c1d7035885d46b10e3193393be8460b6f1 # v4.1.1` | `da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3` |
+| Line 72, job `aur-stable` | `2ac5a4c1d7035885d46b10e3193393be8460b6f1 # v4.1.1` | `da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3` |
+
+All other inputs on both jobs (`force_push: true`, `post_process: git checkout -B
+master`, `pkgname`, `pkgbuild`, credential secrets) remain unchanged.
+
+v4.1.3 fixes `entrypoint.sh` to:
+
+```sh
+exec runuser -u builder -- bash -l /build.sh
+```
+
+This is the POSIX-correct `runuser` invocation that does not pass arguments to
+bash. v4.1.2 used `runuser -u builder -- bash -l -c /build.sh` (also correct);
+v4.1.3 drops the redundant `-c`.
+
+## Why the bump is safe with respect to #183 and #184
+
+The `post_process: git checkout -B master` input (PR #183, detached-HEAD fix) and
+`force_push: true` input (PR #184) are passed to `build.sh` as environment
+variables, not to `entrypoint.sh`. Because `build.sh` is byte-identical across
+v4.1.1, v4.1.2, and v4.1.3, both fixes are fully preserved by this pin bump.
+
+## Residual risk
+
+The action uses `FROM archlinux:base` with no image digest pin. A future update to
+the Arch base image could introduce a different incompatibility regardless of the
+action tag. This is inherent to the action's design; no mitigation is proposed
+here beyond monitoring workflow runs after future Arch base image refreshes.
+
+## Spec delta
+
+There is no existing spec in `openspec/specs/` covering AUR publishing or CI
+release workflows. No spec delta applies.
+
+## Post-merge backfill (operational, not a code change)
+
+After this PR merges, manually trigger `AUR Publish` via `workflow_dispatch` with
+input `version=0.5.5`. The `aur-stable` job will:
+1. Normalize version → `0.5.5`
+2. Checkout `refs/tags/v0.5.5` (already exists)
+3. `curl` the tarball and compute sha256
+4. Patch `aur/stable/PKGBUILD`
+5. Deploy to AUR via the fixed action
+
+This is the acceptance gate for this change.

--- a/openspec/changes/2026-05-17-fix-aur-deploy-action-v413/tasks.md
+++ b/openspec/changes/2026-05-17-fix-aur-deploy-action-v413/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: AUR Deploy Action Pin v4.1.1 → v4.1.3
+
+- [ ] Opus review of `proposal.md` and `test-plan.md`; revise as needed
+- [ ] `.github/workflows/aur.yml` line 25: bump action pin from `2ac5a4c1d7035885d46b10e3193393be8460b6f1 # v4.1.1` to `da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3`
+- [ ] `.github/workflows/aur.yml` line 72: same pin bump (job `aur-stable`)
+- [ ] Static checks: grep confirms new SHA appears exactly twice, old SHA absent, both jobs retain `force_push: true` and `post_process: git checkout -B master`, YAML parses cleanly
+- [ ] Fresh review of the two-line diff
+- [ ] Open PR targeting `master`
+- [ ] After merge: trigger `AUR Publish` via `workflow_dispatch` with `version=0.5.5`
+- [ ] Verify job `Publish rdc-cli (stable)` succeeds (no `bash: --command` crash)
+- [ ] Verify AUR `rdc-cli` package shows `pkgver=0.5.5`
+- [ ] Archive this OpenSpec folder

--- a/openspec/changes/2026-05-17-fix-aur-deploy-action-v413/test-plan.md
+++ b/openspec/changes/2026-05-17-fix-aur-deploy-action-v413/test-plan.md
@@ -1,0 +1,34 @@
+# Test Plan: AUR Deploy Action Pin v4.1.1 → v4.1.3
+
+There are no unit tests for a workflow YAML change. Verification is static
+inspection followed by a live workflow run.
+
+## Static verification (pre-merge)
+
+1. **Pin appears exactly twice.** `grep` for
+   `da03e160361ce01bf087e790b6ffd196d7dccff7` in
+   `.github/workflows/aur.yml` returns exactly 2 lines, one per job.
+
+2. **Old pin is absent.** `grep` for `2ac5a4c1d7035885d46b10e3193393be8460b6f1`
+   or `v4.1.1` returns no matches.
+
+3. **Version comment is present on both lines.** Both occurrences of the new SHA
+   are followed by the comment `# v4.1.3`.
+
+4. **Preserved inputs — both jobs.** `grep` confirms both jobs retain:
+   - `force_push: true`
+   - `post_process: git checkout -B master`
+
+5. **YAML parses cleanly.** `python3 -c "import yaml, sys; yaml.safe_load(sys.stdin)"
+   < .github/workflows/aur.yml` exits 0. (The repo does not include actionlint or
+   yamllint; Python's yaml module is the available static check.)
+
+## Live verification (post-merge)
+
+6. **workflow_dispatch v0.5.5 succeeds.** Trigger `AUR Publish` via
+   `workflow_dispatch` with input `version=0.5.5`. Job `Publish rdc-cli (stable)`
+   must complete with a green check — specifically, the `entrypoint.sh` crash
+   (`bash: --command: invalid option`) must not appear.
+
+7. **AUR package updated.** After the dispatch run, the AUR `rdc-cli` package page
+   shows `pkgver=0.5.5`. This is the acceptance gate.


### PR DESCRIPTION
## Summary

Fix-forward: the `AUR Publish` workflow failed on the v0.5.5 tag (run 26001352704, job `Publish rdc-cli (stable)`) with `bash: --command: invalid option`, before any AUR git operation.

Root cause is in the pinned action itself, not our config: `KSXGitHub/github-actions-deploy-aur` at v4.1.1 (`2ac5a4c…`) ends its `entrypoint.sh` with `exec runuser builder --command 'bash -l -c /build.sh'`. With the `util-linux` `runuser` in the current `archlinux:base` image this uses the su(1)-compatible form, so `--command …` is passed to **bash** as a flag — bash has no `--command`, it crashes before `/build.sh` runs. The `post_process: git checkout -B master` input is never reached and is innocent. The workflow was green on earlier tags; a recent Arch base image surfaced this latent action bug (present v3.0.1–v4.1.1; upstream fixed it in v4.1.2/v4.1.3).

## Change

Bump both pins in `.github/workflows/aur.yml` (jobs `aur-git`, `aur-stable`) from `2ac5a4c… # v4.1.1` to `da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3`. `force_push: true` and `post_process: git checkout -B master` unchanged.

`gh api compare/v4.1.1...v4.1.3` confirms only `README.md` + `entrypoint.sh` changed between the two tags — `build.sh` is byte-identical, so the #183 (detached-HEAD → `post_process`) and #184 (`force_push`) fixes are fully preserved; only the entrypoint crash is fixed.

Residual risk (inherent, monitor): the action is `using: docker` `FROM archlinux:base` with no digest pin, so a future Arch base change could break it again regardless of action tag.

## After merge

v0.5.5 PyPI + GitHub Release already shipped; only the AUR package is outstanding. Once merged, the v0.5.5 AUR `rdc-cli` package is backfilled by running `AUR Publish` via `workflow_dispatch` with `version=0.5.5`.

OpenSpec: `openspec/changes/2026-05-17-fix-aur-deploy-action-v413/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AUR package publishing workflow to resolve prior deployment failures.

* **Documentation**
  * Added specification proposal, task checklist, and test plan for the workflow update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BANANASJIM/rdc-cli/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->