### PR TITLE
feat(replay): add --gpu override to rdc open

### DIFF
--- a/docs-astro/src/data/commands.json
+++ b/docs-astro/src/data/commands.json
@@ -9,7 +9,7 @@
           "name": "open",
           "id": "open",
           "help": "Create local default session and start daemon skeleton.",
-          "usage": "rdc open [CAPTURE] [--preload] [--proxy HOST[:PORT]|adb://SERIAL] [--android] [--serial TEXT] [--remote HOST[:PORT]] [--listen [ADDR]:PORT] [--connect HOST:PORT] [--token TEXT] [--timeout FLOAT]"
+          "usage": "rdc open [CAPTURE] [--preload] [--proxy HOST[:PORT]|adb://SERIAL] [--android] [--serial TEXT] [--remote HOST[:PORT]] [--listen [ADDR]:PORT] [--connect HOST:PORT] [--token TEXT] [--timeout FLOAT] [--gpu INDEX|NAME|DEVICEID]"
         },
         {
           "name": "close",

--- a/openspec/changes/2026-06-04-open-gpu-override/proposal.md
+++ b/openspec/changes/2026-06-04-open-gpu-override/proposal.md
@@ -1,0 +1,83 @@
+# Add `--gpu` override to `rdc open`
+
+## Problem
+
+When a capture is replayed, the daemon picks the replay GPU automatically via
+`_match_capture_gpu()`: it matches the capture's recorded device name (Vulkan)
+or adapter description / DeviceId (D3D12), and **falls back to vendor priority
+(nVidia > AMD > Intel)** when nothing matches.
+
+On a multi-GPU host that fallback is `filtered[0]` after a stable sort, i.e. the
+first-enumerated device of the highest-priority vendor — frequently the
+integrated GPU. There is no way for the user to override it:
+
+- `rdc open` exposes no GPU selection flag.
+- The fallback cannot be steered toward a discrete GPU, a specific device, or a
+  GPU whose name does not match the capture's recorded name (common when
+  replaying a capture taken on different hardware).
+
+This complements the recent multi-GPU auto-matching work (#225) by giving the
+analyst an explicit escape hatch when auto-selection picks the wrong device.
+
+Note: an explicit GPU choice does not make a capture portable across
+incompatible hardware (RADV descriptor layouts differ per GPU generation); it
+only controls *which* available GPU replay is attempted on.
+
+## Solution
+
+Add an optional `--gpu INDEX|NAME|DEVICEID` flag to `rdc open` that forces the
+replay GPU, overriding auto-selection.
+
+Resolution order against `cap.GetAvailableGPUs()`:
+
+1. **0-based index** — `--gpu 1` selects the second enumerated GPU.
+2. **device ID** — decimal or `0x` hex (`--gpu 0x747e`), matched against
+   `GPUDevice.deviceID`.
+3. **name substring** — case-insensitive (`--gpu "7800 XT"`).
+
+If the preference matches no available GPU, a warning is logged listing the
+available GPUs and replay falls back to the existing auto-selection (non-fatal).
+
+### Plumbing
+
+The flag threads CLI → daemon, reusing the existing daemon-arg channel:
+
+- `commands/session.py`: `--gpu` option on `open_cmd`; ignored (with a warning)
+  for `--connect` (an external daemon is already running). Passed to
+  `open_session` / `listen_open_session`.
+- `services/session_service.py`: `start_daemon(..., gpu=...)` appends
+  `--gpu <value>` to the daemon argv; `open_session` / `listen_open_session`
+  forward it.
+- `daemon_server.py`: `--gpu` arg → `DaemonState.gpu_pref`; `_match_capture_gpu`
+  gains a `pref` parameter that short-circuits to the resolved GPU before
+  auto-matching. Applied at both the local and remote replay call sites.
+
+Out of scope: changing the default auto-selection (vendor priority is unchanged).
+
+## Spec Delta
+
+The existing scenario "Multi-GPU capture replay" under **Requirement: Replay
+lifecycle** in `openspec/specs/daemon/spec.md` (added by #226, amended by #230)
+is amended so the user `--gpu` preference takes precedence over auto-selection:
+
+```diff
+ #### Scenario: Multi-GPU capture replay
+ - **WHEN** the capture was taken on a multi-GPU system
+ - **AND** multiple GPUs are available for replay
+-- **THEN** the daemon walks structured-data chunks whose name contains any of
++- **THEN** if the user passed `--gpu` (a 0-based index, a PCI device ID in
++  decimal or `0x` hex, or a case-insensitive name substring) that resolves to an
++  available GPU, that GPU is selected and structured-data inspection is skipped
++- **AND** otherwise the daemon walks structured-data chunks whose name contains any of
+   "Driver Initialisation Parameters", "DriverInit", "EnumAdapters", or
+   "CreateDXGIFactory"
+ ...
+ - **AND** if no structured-data match exists, Software/WARP adapters are excluded
+   and the highest-ranked discrete GPU is preferred (nVidia > AMD > Intel)
++- **AND** an unresolved `--gpu` preference logs a warning and falls back to the
++  auto-selection above
+ - **AND** a single available GPU is always returned directly without inspection
+```
+
+This delta has been applied to `openspec/specs/daemon/spec.md` as part of this
+change.

--- a/openspec/changes/2026-06-04-open-gpu-override/tasks.md
+++ b/openspec/changes/2026-06-04-open-gpu-override/tasks.md
@@ -1,0 +1,14 @@
+# Tasks: Add `--gpu` override to `rdc open`
+
+- [x] `daemon_server.py`: add `_resolve_gpu_pref()` (index / deviceID / name substring)
+- [x] `daemon_server.py`: add `pref` param to `_match_capture_gpu()`; short-circuit before auto-match, warn + fall back when no match
+- [x] `daemon_server.py`: `--gpu` arg, `DaemonState.gpu_pref`, pass `state.gpu_pref` at local + remote call sites
+- [x] `services/session_service.py`: `start_daemon(gpu=...)` appends `--gpu`; forward through `open_session` / `listen_open_session`
+- [x] `commands/session.py`: `--gpu` option on `open_cmd`; warn-and-ignore with `--connect`; pass to open paths
+- [x] `openspec/specs/daemon/spec.md`: apply Spec Delta to the "Multi-GPU capture replay" scenario (user `--gpu` precedence + unresolved fallback)
+- [x] Unit tests: `_resolve_gpu_pref` forms; `_match_capture_gpu` pref precedence + no-match fallback warning; `start_daemon` argv; CLI passthrough + `--connect` warning
+- [x] Update existing fakes broken by new signature/attr (`test_remote_replay_passes_sd` spy, sigterm-handler `mock_args`)
+- [x] `pixi run check` green (lint + typecheck + tests)
+- [ ] Fresh review of the diff
+- [ ] Open PR targeting `master`
+- [ ] Archive this OpenSpec folder after merge

--- a/openspec/changes/2026-06-04-open-gpu-override/test-plan.md
+++ b/openspec/changes/2026-06-04-open-gpu-override/test-plan.md
@@ -1,0 +1,36 @@
+# Test Plan: `--gpu` override for `rdc open`
+
+## Unit (mocked — no GPU required)
+
+`tests/unit/test_daemon_server_unit.py` (`TestMatchCaptureGpu`):
+
+1. **Index** — `pref="1"` returns the second GPU.
+2. **Name substring** — `pref="7800 xt"` matches case-insensitively.
+3. **Device ID** — `pref="29822"` (decimal) and `pref="0x747e"` (hex) both match
+   `deviceID==29822`.
+4. **Precedence** — with a Vulkan `deviceName` chunk that would auto-match GPU B,
+   `pref="AMD"` still selects GPU A.
+5. **No match** — `pref="Matrox"` logs a `--gpu` warning and falls back to the
+   vendor-priority auto-selection.
+6. **`_resolve_gpu_pref`** — index / name / hex resolve; unknown and empty → None.
+
+`tests/unit/test_session_service.py`:
+
+7. `start_daemon(gpu="1")` puts `--gpu 1` in the daemon argv; default omits `--gpu`.
+
+`tests/unit/test_session_commands.py`:
+
+8. `rdc open CAP --gpu 1` forwards `gpu="1"` to `start_daemon`.
+9. `rdc open --connect host:port --token T --gpu 1` prints
+   `warning: --gpu is ignored with --connect`.
+
+Run: `pixi run test` (unit only; no GPU/e2e). Full gate: `pixi run check`.
+
+## Manual (requires a multi-GPU host + renderdoc)
+
+- `rdc open frame.rdc --gpu <discrete-name>` then `rdc status` / a replay query;
+  daemon log shows `replay GPU (user --gpu=...)`.
+- `rdc open frame.rdc --gpu nonsense` logs the no-match warning and still opens
+  via auto-selection.
+
+(Not run in CI: needs real hardware; out of scope for the unit suite.)

--- a/openspec/specs/daemon/spec.md
+++ b/openspec/specs/daemon/spec.md
@@ -38,7 +38,10 @@ ReplayController for the duration of the session.
 #### Scenario: Multi-GPU capture replay
 - **WHEN** the capture was taken on a multi-GPU system
 - **AND** multiple GPUs are available for replay
-- **THEN** the daemon walks structured-data chunks whose name contains any of
+- **THEN** if the user passed `--gpu` (a 0-based index, a PCI device ID in
+  decimal or `0x` hex, or a case-insensitive name substring) that resolves to an
+  available GPU, that GPU is selected and structured-data inspection is skipped
+- **AND** otherwise the daemon walks structured-data chunks whose name contains any of
   "Driver Initialisation Parameters", "DriverInit", "EnumAdapters", or
   "CreateDXGIFactory"
 - **AND** within each such chunk descends recursively (depth ≤ 5) to locate an
@@ -49,6 +52,8 @@ ReplayController for the duration of the session.
   DeviceId match is found
 - **AND** if no structured-data match exists, Software/WARP adapters are excluded
   and the highest-ranked discrete GPU is preferred (nVidia > AMD > Intel)
+- **AND** an unresolved `--gpu` preference logs a warning and falls back to the
+  auto-selection above
 - **AND** a single available GPU is always returned directly without inspection
 
 ### Requirement: Navigation methods

--- a/src/rdc/_skills/references/commands-quick-ref.md
+++ b/src/rdc/_skills/references/commands-quick-ref.md
@@ -644,6 +644,7 @@ Create local default session and start daemon skeleton.
 | `--connect` | Connect to an already-running external daemon. | text |  |
 | `--token` | Authentication token (required with --connect). | text |  |
 | `--timeout` | Daemon startup timeout in seconds. | float |  |
+| `--gpu` | Force the replay GPU by 0-based index, name substring, or device ID (overrides auto-selection). | text |  |
 
 ## `rdc pass`
 

--- a/src/rdc/commands/session.py
+++ b/src/rdc/commands/session.py
@@ -186,6 +186,14 @@ def _complete_capture_path(
     default=None,
     help="Daemon startup timeout in seconds.",
 )
+@click.option(
+    "--gpu",
+    "gpu",
+    default=None,
+    metavar="INDEX|NAME|DEVICEID",
+    help="Force the replay GPU by 0-based index, name substring, or device ID "
+    "(overrides auto-selection).",
+)
 def open_cmd(
     capture: str | None,
     preload: bool,
@@ -197,6 +205,7 @@ def open_cmd(
     connect: str | None,
     connect_token: str | None,
     timeout: float | None,
+    gpu: str | None,
 ) -> None:
     """Create local default session and start daemon skeleton."""
     # Handle --remote deprecation
@@ -242,6 +251,11 @@ def open_cmd(
     if connect is None and connect_token is not None:
         click.echo("warning: --token is ignored without --connect", err=True)
 
+    # --gpu configures the daemon's replay; an external daemon (--connect) is
+    # already running, so it cannot apply here.
+    if gpu is not None and connect is not None:
+        click.echo("warning: --gpu is ignored with --connect", err=True)
+
     # Dispatch: --connect
     if connect is not None:
         assert connect_token is not None
@@ -276,7 +290,9 @@ def open_cmd(
             click.echo(f"error: file not found: {capture}", err=True)
             raise SystemExit(1)
         try:
-            ok, result = listen_open_session(capture, listen, remote_url=proxy_url, timeout=timeout)
+            ok, result = listen_open_session(
+                capture, listen, remote_url=proxy_url, timeout=timeout, gpu=gpu
+            )
         except ValueError as exc:
             click.echo(f"error: {exc}", err=True)
             raise SystemExit(1) from None
@@ -300,7 +316,7 @@ def open_cmd(
     if proxy_url is None and not Path(capture).exists():
         click.echo(f"error: file not found: {capture}", err=True)
         raise SystemExit(1)
-    ok, message = open_session(capture, remote_url=proxy_url, timeout=timeout)
+    ok, message = open_session(capture, remote_url=proxy_url, timeout=timeout, gpu=gpu)
     if not ok:
         click.echo(message, err=True)
         raise SystemExit(1)

--- a/src/rdc/daemon_server.py
+++ b/src/rdc/daemon_server.py
@@ -141,6 +141,7 @@ class DaemonState:
     _debug_messages_cache: list[Any] | None = None
     remote: Any = None
     remote_url: str = ""
+    gpu_pref: str = ""
     is_remote: bool = False
     local_capture_path: str = ""
     local_capture_is_temp: bool = False
@@ -226,18 +227,49 @@ def _find_adapter_description(chunk: Any) -> AdapterMatch | None:
         return None
 
 
-def _match_capture_gpu(cap: Any, sd: Any = None, rd: Any = None) -> Any | None:
+def _resolve_gpu_pref(gpus: list[Any], pref: str) -> Any | None:
+    """Resolve a user ``--gpu`` preference against the available GPUs.
+
+    Accepts, in order: a 0-based index, a device ID (decimal or ``0x`` hex),
+    or a case-insensitive substring of the GPU name. Returns the matching
+    ``GPUDevice``, or ``None`` if nothing matches.
+    """
+    pref = pref.strip()
+    if not pref:
+        return None
+    if pref.isdigit() and int(pref) < len(gpus):
+        return gpus[int(pref)]
+    try:
+        want_id = int(pref, 0)
+    except ValueError:
+        want_id = None
+    if want_id is not None:
+        for g in gpus:
+            if g.deviceID == want_id:
+                return g
+    needle = pref.lower()
+    for g in gpus:
+        if needle in g.name.lower():
+            return g
+    return None
+
+
+def _match_capture_gpu(
+    cap: Any, sd: Any = None, rd: Any = None, pref: str | None = None
+) -> Any | None:
     """Pick the replay GPU that produced ``cap``.
 
-    Walks structured-data chunks to match the capture's Vulkan
-    ``vkEnumeratePhysicalDevices`` device name or the D3D12 adapter
-    description. Falls back to vendor priority (nVidia > AMD > Intel,
-    Software/WARP excluded) when no chunk-based match succeeds.
+    When *pref* is given (the user's ``--gpu``), it takes precedence over
+    auto-selection. Otherwise walks structured-data chunks to match the
+    capture's Vulkan ``vkEnumeratePhysicalDevices`` device name or the D3D12
+    adapter description, falling back to vendor priority (nVidia > AMD >
+    Intel, Software/WARP excluded) when no chunk-based match succeeds.
 
     Args:
         cap: An open renderdoc capture file.
         sd: Optional structured data from ``cap.GetStructuredData()``.
         rd: Optional renderdoc module, used for ``GPUVendor`` enum lookup.
+        pref: Optional user GPU preference (index, device ID, or name substring).
 
     Returns:
         The selected ``GPUDevice`` or ``None`` when no GPUs are available.
@@ -246,6 +278,16 @@ def _match_capture_gpu(cap: Any, sd: Any = None, rd: Any = None) -> Any | None:
         gpus = cap.GetAvailableGPUs()
         if not gpus:
             return None
+        if pref:
+            chosen = _resolve_gpu_pref(gpus, pref)
+            if chosen is not None:
+                _log.info("replay GPU (user --gpu=%r): %s", pref, chosen.name)
+                return chosen
+            _log.warning(
+                "--gpu=%r matched no available GPU; available=%r -- using auto-selection",
+                pref,
+                [(g.name, g.deviceID) for g in gpus],
+            )
         if len(gpus) == 1:
             return gpus[0]
 
@@ -363,7 +405,7 @@ def _load_replay(state: DaemonState) -> str | None:
         return "local replay not supported on this platform"
 
     opts = rd.ReplayOptions()
-    gpu = _match_capture_gpu(cap, cap.GetStructuredData(), rd)
+    gpu = _match_capture_gpu(cap, cap.GetStructuredData(), rd, state.gpu_pref or None)
     if gpu is not None:
         opts.forceGPUVendor = gpu.vendor
         opts.forceGPUDeviceID = gpu.deviceID
@@ -520,7 +562,9 @@ def _load_remote_replay(state: DaemonState, remote_url: str) -> str | None:
                 try:
                     open_result = tmp_cap.OpenFile(state.local_capture_path, "", None)
                     if open_result == rd.ResultCode.Succeeded:
-                        gpu = _match_capture_gpu(tmp_cap, tmp_cap.GetStructuredData(), rd)
+                        gpu = _match_capture_gpu(
+                            tmp_cap, tmp_cap.GetStructuredData(), rd, state.gpu_pref or None
+                        )
                         if gpu is not None:
                             remote_opts.forceGPUVendor = gpu.vendor
                             remote_opts.forceGPUDeviceID = gpu.deviceID
@@ -703,9 +747,12 @@ def main() -> None:  # pragma: no cover
     parser.add_argument("--idle-timeout", type=int, default=1800)
     parser.add_argument("--no-replay", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--remote-url", default=None)
+    parser.add_argument("--gpu", default=None)
     args = parser.parse_args()
 
-    state = DaemonState(capture=args.capture, current_eid=0, token=args.token)
+    state = DaemonState(
+        capture=args.capture, current_eid=0, token=args.token, gpu_pref=args.gpu or ""
+    )
 
     if not args.no_replay:
         if args.remote_url:

--- a/src/rdc/services/session_service.py
+++ b/src/rdc/services/session_service.py
@@ -46,6 +46,7 @@ def start_daemon(
     host: str = "127.0.0.1",
     idle_timeout: int = 1800,
     remote_url: str | None = None,
+    gpu: str | None = None,
 ) -> subprocess.Popen[str]:
     cmd = [
         sys.executable,
@@ -62,6 +63,8 @@ def start_daemon(
         "--idle-timeout",
         str(idle_timeout),
     ]
+    if gpu:
+        cmd += ["--gpu", gpu]
     if remote_url:
         cmd += ["--remote-url", remote_url]
     elif not _renderdoc_available():
@@ -136,6 +139,7 @@ def open_session(
     *,
     remote_url: str | None = None,
     timeout: float | None = None,
+    gpu: str | None = None,
 ) -> tuple[bool, str]:
     exists, err = _check_existing_session()
     if exists:
@@ -148,7 +152,7 @@ def open_session(
     for _attempt in range(max_attempts):
         port = pick_port()
         token = secrets.token_hex(16)
-        proc = start_daemon(str(capture), port, token, remote_url=remote_url)
+        proc = start_daemon(str(capture), port, token, remote_url=remote_url, gpu=gpu)
 
         ok, detail = wait_for_ping(host, port, token, timeout_s=resolved_timeout, proc=proc)
         if ok:
@@ -382,6 +386,7 @@ def listen_open_session(
     *,
     remote_url: str | None = None,
     timeout: float | None = None,
+    gpu: str | None = None,
 ) -> tuple[bool, dict[str, Any] | str]:
     """Open a session with the daemon listening on a specified address.
 
@@ -408,6 +413,7 @@ def listen_open_session(
         token,
         host=bind_host,
         remote_url=remote_url,
+        gpu=gpu,
     )
 
     ok, detail = wait_for_ping(

--- a/tests/unit/test_daemon_server_unit.py
+++ b/tests/unit/test_daemon_server_unit.py
@@ -21,6 +21,7 @@ from rdc.daemon_server import (
     _load_replay,
     _match_capture_gpu,
     _process_request,
+    _resolve_gpu_pref,
     _set_frame_event,
 )
 
@@ -294,16 +295,63 @@ class TestMatchCaptureGpu:
         cap = self._cap([])
         assert _match_capture_gpu(cap, None, self._FakeRD) is None
 
+    def test_pref_by_index(self) -> None:
+        a = self._gpu("AMD Radeon Graphics", self._AMD)
+        b = self._gpu("NVIDIA RTX 4500 Ada", self._NVIDIA)
+        cap = self._cap([a, b])
+        assert _match_capture_gpu(cap, None, self._FakeRD, pref="1") is b
+
+    def test_pref_by_name_substring_case_insensitive(self) -> None:
+        a = self._gpu("AMD Radeon RX 7800 XT", self._AMD)
+        b = self._gpu("NVIDIA RTX 4500 Ada", self._NVIDIA)
+        cap = self._cap([a, b])
+        assert _match_capture_gpu(cap, None, self._FakeRD, pref="7800 xt") is a
+
+    def test_pref_by_device_id_decimal_and_hex(self) -> None:
+        a = SimpleNamespace(name="iGPU", vendor=self._AMD, deviceID=5710, driver="")
+        b = SimpleNamespace(name="dGPU", vendor=self._AMD, deviceID=29822, driver="")
+        cap = self._cap([a, b])
+        assert _match_capture_gpu(cap, None, self._FakeRD, pref="29822") is b
+        assert _match_capture_gpu(cap, None, self._FakeRD, pref="0x747e") is b
+
+    def test_pref_overrides_auto_match(self) -> None:
+        """An explicit --gpu wins even when the capture's deviceName matches another GPU."""
+        a = self._gpu("AMD Radeon Graphics", self._AMD)
+        b = self._gpu("NVIDIA RTX 4500 Ada", self._NVIDIA)
+        cap = self._cap([a, b])
+        sd = self._vulkan_sd("NVIDIA RTX 4500 Ada")  # would auto-match b
+        assert _match_capture_gpu(cap, sd, self._FakeRD, pref="AMD") is a
+
+    def test_pref_no_match_warns_and_falls_back(self, caplog: pytest.LogCaptureFixture) -> None:
+        igpu = self._gpu("AMD Radeon Graphics", self._AMD)
+        discrete = self._gpu("NVIDIA RTX 4500 Ada", self._NVIDIA)
+        cap = self._cap([igpu, discrete])
+        with caplog.at_level(logging.WARNING, logger="rdc.daemon"):
+            chosen = _match_capture_gpu(cap, None, self._FakeRD, pref="Matrox")
+        assert chosen is discrete  # vendor-priority fallback still applies
+        assert any("--gpu" in r.message for r in caplog.records)
+
+    def test_resolve_gpu_pref_forms(self) -> None:
+        a = SimpleNamespace(name="iGPU RADEON", vendor=self._AMD, deviceID=5710, driver="")
+        b = SimpleNamespace(name="dGPU NAVI", vendor=self._AMD, deviceID=29822, driver="")
+        gpus = [a, b]
+        assert _resolve_gpu_pref(gpus, "0") is a
+        assert _resolve_gpu_pref(gpus, "navi") is b
+        assert _resolve_gpu_pref(gpus, "0x747e") is b
+        assert _resolve_gpu_pref(gpus, "nope") is None
+        assert _resolve_gpu_pref(gpus, "") is None
+
     def test_remote_replay_passes_sd(self, monkeypatch: Any) -> None:
         """The remote-replay call site must pass non-None sd and rd to the matcher."""
         import mock_renderdoc as mock_rd
 
         captured: dict[str, Any] = {}
 
-        def _spy(cap: Any, sd: Any = None, rd: Any = None) -> Any:
+        def _spy(cap: Any, sd: Any = None, rd: Any = None, pref: Any = None) -> Any:
             captured["cap"] = cap
             captured["sd"] = sd
             captured["rd"] = rd
+            captured["pref"] = pref
             return None
 
         monkeypatch.setattr("rdc.daemon_server._match_capture_gpu", _spy)
@@ -685,6 +733,7 @@ class TestSigtermHandler:
                 token="tok",
                 idle_timeout=1800,
                 no_replay=True,
+                gpu=None,
             )
             mock_parser_cls.return_value.parse_args.return_value = mock_args
 

--- a/tests/unit/test_session_commands.py
+++ b/tests/unit/test_session_commands.py
@@ -305,6 +305,32 @@ def test_open_android_resolves_adb_url(monkeypatch: pytest.MonkeyPatch, tmp_path
     assert recorded["calls"][0]["kwargs"]["remote_url"] == "adb://ABC123"
 
 
+def test_open_gpu_passed_to_daemon(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _setup_data_dir(monkeypatch, tmp_path)
+    monkeypatch.delenv("RDC_SESSION", raising=False)
+    recorded = _mock_daemon_capture(monkeypatch)
+    capture_file = tmp_path / "capture.rdc"
+    capture_file.touch()
+
+    result = CliRunner().invoke(main, ["open", str(capture_file), "--gpu", "1"])
+    assert result.exit_code == 0, result.output + (result.stderr or "")
+    assert recorded["calls"][0]["kwargs"]["gpu"] == "1"
+
+
+def test_open_gpu_ignored_with_connect(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _setup_data_dir(monkeypatch, tmp_path)
+    monkeypatch.delenv("RDC_SESSION", raising=False)
+    monkeypatch.setattr(
+        "rdc.commands.session.connect_session", lambda *a, **kw: (True, "connected")
+    )
+
+    result = CliRunner().invoke(
+        main, ["open", "--connect", "host:1234", "--token", "tok", "--gpu", "1"]
+    )
+    assert result.exit_code == 0, result.output + (result.stderr or "")
+    assert "--gpu is ignored with --connect" in (result.stderr or "") + result.output
+
+
 def test_open_android_with_serial(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     _setup_data_dir(monkeypatch, tmp_path)
     monkeypatch.delenv("RDC_SESSION", raising=False)

--- a/tests/unit/test_session_service.py
+++ b/tests/unit/test_session_service.py
@@ -195,6 +195,33 @@ def test_start_daemon_idle_timeout_default(monkeypatch: pytest.MonkeyPatch) -> N
     assert captured_cmd[idx + 1] == "1800"
 
 
+def test_start_daemon_gpu_passed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(session_service, "_renderdoc_available", lambda: False)
+    captured_cmd: list[str] = []
+
+    def fake_popen(cmd: list[str], **kwargs: object) -> MagicMock:
+        captured_cmd.extend(cmd)
+        return MagicMock()
+
+    monkeypatch.setattr(session_service.subprocess, "Popen", fake_popen)
+    session_service.start_daemon("test.rdc", 9999, "tok", gpu="1")
+    idx = captured_cmd.index("--gpu")
+    assert captured_cmd[idx + 1] == "1"
+
+
+def test_start_daemon_gpu_omitted_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(session_service, "_renderdoc_available", lambda: False)
+    captured_cmd: list[str] = []
+
+    def fake_popen(cmd: list[str], **kwargs: object) -> MagicMock:
+        captured_cmd.extend(cmd)
+        return MagicMock()
+
+    monkeypatch.setattr(session_service.subprocess, "Popen", fake_popen)
+    session_service.start_daemon("test.rdc", 9999, "tok")
+    assert "--gpu" not in captured_cmd
+
+
 def test_open_session_retries_on_port_conflict(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## What

Add `rdc open --gpu INDEX|NAME|DEVICEID` to force which GPU replay runs on,
overriding the daemon's automatic GPU selection.

## Why

`_match_capture_gpu()` matches the capture's recorded GPU and otherwise falls
back to vendor priority (nVidia > AMD > Intel) → the first-enumerated device of
the highest-priority vendor, which on a multi-GPU host is frequently the
integrated GPU. There was no way to steer replay onto a different GPU when
auto-selection picked the wrong one, or when the capture's GPU name matched
nothing locally. This complements the multi-GPU auto-matching from #225 with an
explicit user escape hatch.

This does not make a capture portable across incompatible hardware (RADV
descriptor layouts differ per GPU generation); it only controls which available
GPU replay is attempted on.

## How

`--gpu` is resolved against `cap.GetAvailableGPUs()` in this order: 0-based
index, device ID (decimal or `0x` hex), then case-insensitive name substring.
It short-circuits auto-selection; an unresolved preference logs a warning
listing the available GPUs and falls back to the existing logic (non-fatal).

- `daemon_server.py`: `_resolve_gpu_pref()`; `pref` param on `_match_capture_gpu`
  (applied at both the local and remote replay call sites); `--gpu` arg →
  `DaemonState.gpu_pref`.
- `services/session_service.py`: `start_daemon(gpu=...)` appends `--gpu` to the
  daemon argv; forwarded by `open_session` / `listen_open_session`.
- `commands/session.py`: `--gpu` option on `open`; ignored with a warning for
  `--connect` (an external daemon is already running).
- openspec: `2026-06-04-open-gpu-override`; regenerated `commands-quick-ref.md`.

The default auto-selection (vendor priority) is unchanged.

## Test plan

- [x] `pixi run check` passes (lint + typecheck + tests; 92.90% coverage)
- [x] Added unit tests: `_resolve_gpu_pref` forms; `_match_capture_gpu` pref
      precedence + no-match fallback warning; `start_daemon` argv; CLI
      passthrough and the `--connect` warning
- [ ] Manual on a multi-GPU host: `rdc open frame.rdc --gpu <name>` selects the
      named GPU (daemon log shows `replay GPU (user --gpu=...)`); an unknown
      `--gpu` warns and still opens via auto-selection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--gpu` to `rdc open` to force replay GPU by 0-based index, name substring, or device ID; unresolved prefs warn and fall back to auto-selection. Ignored with a warning when used with `--connect`.

* **Documentation**
  * Added spec, tasks, test-plan, command reference, and usage docs describing the GPU override behavior.

* **Tests**
  * Added unit tests covering preference parsing, match precedence, fallback warning, and CLI/daemon forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->