### PR TITLE
fix(export): unify depth export decode path across local and remote modes

### DIFF
--- a/openspec/changes/2026-06-09-depth-export-consistency/proposal.md
+++ b/openspec/changes/2026-06-09-depth-export-consistency/proposal.md
@@ -1,0 +1,186 @@
+# OpenSpec: 2026-06-09-depth-export-consistency
+
+## Summary
+
+Unify local and remote depth export so both modes produce identical grayscale
+mode-L PNG files with min-max normalisation. Local mode currently calls
+`SaveTexture`, producing an RGBA PNG with raw linear depth in the red channel;
+remote mode uses `GetTextureData` + `_decode_texture_png(is_depth=True)`,
+producing grayscale mode-L. Same capture, different file per mode.
+
+## Context and Motivation
+
+The divergence was introduced unintentionally: the remote path added in PR #237
+chose `_decode_texture_png` for cross-host portability (no filesystem access on
+the remote GPU machine), but the local path was left on the original
+`SaveTexture` route. Consequences:
+
+- `rdc assert-image` golden comparisons break when the reference was captured
+  in one mode and the assertion runs in the other.
+- Users inspecting depth PNGs in local mode see RGBA files (depth in red
+  channel, G=B=0) rather than grayscale, which is surprising and
+  undocumented.
+- vkcube real capture example: local produces R 243-255 / G=0 / B=0 RGBA;
+  remote produces grayscale 0-255. Both are technically lossless depth
+  representations but visually and structurally incompatible.
+
+The fix is straightforward: make `_handle_rt_depth` use
+`GetTextureData` + `_decode_texture_png(is_depth=True)` regardless of
+`state.is_remote`, matching the precedent already set by `_handle_tex_raw`
+which calls `GetTextureData` without an `is_remote` guard.
+
+Color export (`_handle_rt_export`, `_handle_tex_export`) keeps `SaveTexture`
+locally; this change is scoped to depth only.
+
+## Behaviour Change (changelog-worthy)
+
+**Before**: `rdc rt <EID> --depth -o depth.png` in local mode writes an RGBA
+PNG. Depth occupies the R channel as linear float-to-8-bit. G and B channels
+are zero. Alpha is 255.
+
+**After**: same command writes a grayscale mode-L PNG with min-max stretch
+(same format as remote mode). Cross-mode golden files are now byte-identical
+for decodable formats.
+
+This is a breaking change for any script that reads the R channel of a
+locally-exported depth PNG. It is changelog-worthy and must appear in the
+release notes.
+
+## Design
+
+### Primary path: unified GetTextureData
+
+In `_handle_rt_depth`, replace the local `SaveTexture` branch with the same
+call used by `_export_remote`:
+
+```python
+# current local branch (remove)
+texsave = _make_texsave(state.rd, depth.resource)
+success = state.adapter.controller.SaveTexture(texsave, str(temp_path))
+...
+
+# replacement (both local and remote)
+tex = state.tex_map.get(int(depth.resource))
+if tex is None:
+    return _error_response(..., "depth target not found in tex_map"), True
+return _export_remote(request_id, state, tex, depth.resource, temp_path, 0, is_depth=True)
+```
+
+`_export_remote` already calls `GetTextureData` + `_decode_texture_png` and is
+mode-agnostic: it uses `state.adapter.controller` which is available in local
+mode. The function does not check `state.is_remote`. The existing remote branch
+in `_handle_rt_depth` is removed; there is now one branch.
+
+### Fallback: combined depth-stencil formats
+
+`_decode_texture_png` returns `None` for non-Regular formats (except the
+packed HDR color formats R11G11B10/R9G9B9E5 added in #240, which never occur
+as depth targets). The combined depth-stencil formats (`D16S8`, `D24S8`,
+`D32S8`, `S8`) are all non-Regular (mock values 19-22 in
+`ResourceFormatType`). When `_export_remote`
+returns -32002 for such a format in local mode, `SaveTexture` can still export
+them (RenderDoc handles the split internally). To preserve this local
+capability:
+
+In `_handle_rt_depth`, after `_export_remote` returns, inspect the result:
+
+- If `_export_remote` succeeded, return it.
+- If it returned -32002 **and** `state.is_remote is False`: fall back to
+  `SaveTexture` on `depth.resource` and return that result.
+- If it returned -32002 **and** `state.is_remote is True`: return the -32002
+  error unchanged (remote behaviour is unchanged).
+
+Contract note (verified against `texture.py:66-96`): `_export_remote` writes
+the PNG to `temp_path` itself and returns a complete JSON-RPC response tuple
+`(dict, True)`; the handler inspects `resp.get("error", {}).get("code")`. All
+`_export_remote` failure modes share code -32002 — GetTextureData exception,
+empty data, decode rejection (`_decode_texture_png` returning `None`), and
+file-write `OSError` — so the local fallback intentionally triggers on **any**
+of them, not only decode rejection. This is acceptable: it subsumes the
+pre-change local behaviour (SaveTexture only), and the worst case is a second
+failure ("SaveTexture failed") replacing the original error message.
+Distinguishing decode rejection specifically would require splitting
+`_export_remote` into fetch/decode steps or adding a structured error reason;
+that refactor is deliberately not done.
+
+Remote behaviour is therefore identical to pre-change. Local behaviour for
+decodable formats changes (grayscale instead of RGBA). Local behaviour for
+combined depth-stencil formats is preserved via SaveTexture fallback (result is
+still RGBA, but these formats were never part of any cross-mode golden workflow
+since remote could not decode them at all).
+
+The fallback does not need to be documented as stable API; it exists purely to
+avoid a regression on combined depth-stencil formats.
+
+### `snapshot.py` comment
+
+The existing comment on the `rt_depth` call in `snapshot.py` (line 63) already
+reads "surface a warning when remote depth decode is unsupported (e.g. D24S8 or
+MSAA)". After this change, D24S8 will succeed locally via fallback; the comment
+should be updated to "depth decode unsupported (combined depth-stencil or MSAA
+in remote mode)".
+
+## Regression Risk: Formats Where `_decode_texture_png` Returns None
+
+The following formats currently export locally via `SaveTexture` but will be
+routed through `_decode_texture_png` first. Formats where the decoder returns
+`None` will fall back to `SaveTexture` (hybrid behaviour). Formats where the
+decoder succeeds will switch to grayscale output.
+
+| Format | ResourceFormatType | Regular? | Decoder result | After change |
+|--------|--------------------|----------|----------------|--------------|
+| D16 | Regular (compType=Depth, cbw=2) | Yes | succeeds | grayscale L (behaviour change) |
+| D32_FLOAT | Regular (compType=Depth, cbw=4) | Yes | succeeds | grayscale L (behaviour change) |
+| D24_UNORM (pure, no stencil) | Regular (compType=Depth, cbw=4) | Yes | succeeds | grayscale L (behaviour change) |
+| D16S8 | D16S8 (type=19) | No | None → -32002 | SaveTexture fallback (unchanged) |
+| D24S8 | D24S8 (type=20) | No | None → -32002 | SaveTexture fallback (unchanged) |
+| D32S8 | D32S8 (type=21) | No | None → -32002 | SaveTexture fallback (unchanged) |
+| S8 | S8 (type=22) | No | None → -32002 | SaveTexture fallback (unchanged) |
+| MSAA depth | Regular (msSamp > 1) | Yes but MSAA | None → -32002 | SaveTexture fallback (local only) |
+
+The MSAA depth fallback is a local-only preservation and a **documented
+divergence**: local MSAA depth stays on SaveTexture (RGBA output), remote MSAA
+depth stays -32002, exactly as before this change. This divergence is accepted
+and does not need unification.
+
+D24_UNORM pure depth (no stencil) is Regular and goes through the same decode
+path as D16/D32_FLOAT; it needs **no special capture verification** beyond the
+unit tests — manual real-GPU verification on D16 covers the Regular depth
+path.
+
+## Risks
+
+- **Unit test `test_tex_export_local_uses_savetexture`** (test_tex_stats_handler.py
+  line 802) tests that tex_export routes through SaveTexture locally. This is
+  unchanged. However `TestRtDepth.test_happy_path` (test_binary_daemon.py line
+  403) will break differently than a missing-stub failure: `_make_handler_state`
+  already stubs `GetTextureData` (returning 1024 filler bytes), but its
+  `tex_map` contains only texture 42 while the pipe's depth target is
+  ResourceId(500). After this change the handler hits the `tex_map` lookup
+  first and returns -32001 "depth target not found". The fix is to add a depth
+  `TextureDescription` (ResourceId 500, Regular depth format, e.g. D16) to the
+  mock's textures/tex_map and make `GetTextureData` return correctly-sized
+  bytes for it.
+
+- **tex_map miss in local mode**: the unified path requires the depth resource
+  to be present in `state.tex_map` (built from `GetTextures()` at
+  daemon_server.py:446); the old local path did not. A miss returns -32001 and
+  does **not** trigger the SaveTexture fallback (which keys on -32002). Real
+  captures always enumerate depth targets as textures, so this is a
+  mock-environment concern only, but tests must keep tex_map consistent.
+
+- **assert-image golden files**: scan result (2026-06-09, f36b41e):
+  `find tests -iname "*depth*"` finds no depth PNG assets; the repo contains no
+  golden PNGs under `tests/`; no e2e or assert-image test reads the red channel
+  of a depth PNG (snapshot e2e asserts only `color0.png` exists). **No golden
+  update is required.** Any user-side goldens captured in local mode will
+  differ; covered by the changelog entry.
+
+- **Docs**: release notes entry required.
+
+## Out of Scope
+
+- Color export unification (`_handle_rt_export`, `_handle_tex_export`): no
+  change.
+- Remote behaviour: no change for any format.
+- `rdc rt --depth` CLI flag (covered by 2026-06-09-rt-depth-flag).

--- a/openspec/changes/2026-06-09-depth-export-consistency/tasks.md
+++ b/openspec/changes/2026-06-09-depth-export-consistency/tasks.md
@@ -1,0 +1,64 @@
+# Tasks: 2026-06-09-depth-export-consistency
+
+## T1: Handler — unify `_handle_rt_depth`
+
+- [x] In `src/rdc/handlers/texture.py`, remove the `is_remote` branch in
+  `_handle_rt_depth`. Replace both branches with a single code path:
+  1. Look up `tex = state.tex_map.get(int(depth.resource))`.
+  2. If not found, return -32001 "depth target not found in tex_map".
+  3. Call `_export_remote(..., is_depth=True)`.
+  4. If `_export_remote` returned -32002 **and** `state.is_remote is False`:
+     fall back to `SaveTexture` via `_make_texsave` + `controller.SaveTexture`.
+  5. Return the result.
+- [x] No changes to `_export_remote` itself — it contains no `is_remote`
+  logic (verified texture.py:66-96); the fallback decision lives entirely in
+  `_handle_rt_depth` (branch on error code -32002 in the returned response,
+  see proposal "Contract note").
+- [x] Update snapshot.py comment on the `rt_depth` call (line ~63):
+  "depth decode unsupported (combined depth-stencil or MSAA in remote mode)".
+
+## T2: Unit tests
+
+- [x] In `tests/unit/test_tex_stats_handler.py`, add:
+  - `test_rt_depth_local_calls_gettexturedata` (D32_FLOAT, local, SaveTexture
+    must not be called, output mode-L)
+  - `test_rt_depth_local_produces_grayscale_L` (D16, local, mode-L, pixel values)
+  - `test_rt_depth_local_d24s8_fallback_uses_savetexture` (D24S8, local,
+    SaveTexture called, result present)
+  - `test_rt_depth_remote_d24s8_no_fallback` (D24S8, remote, -32002 returned,
+    SaveTexture never called)
+  - `test_rt_depth_local_remote_byte_identical_d16` (same D16 mock data, both
+    modes, identical PNG bytes)
+- [x] In `tests/unit/test_binary_daemon.py`, update `_make_handler_state`:
+  add a depth `TextureDescription` (ResourceId 500, Regular depth format such
+  as D16) to `textures`/`tex_map` — currently only texture 42 is present and
+  the depth target ResourceId(500) would return -32001 "not found" — and make
+  the existing `GetTextureData` stub return correctly-sized bytes for it.
+  Keep the `SaveTexture` stub (still used by rt_export and the fallback path).
+- [x] Run `pixi run test` — all pass, including pre-existing remote grayscale
+  tests (`test_rt_depth_remote_decodes_grayscale`,
+  `test_rt_depth_remote_d16_decodes_grayscale`).
+
+## T3: Golden file update
+
+- [x] Golden scan done at spec time (2026-06-09, f36b41e): no `depth*.png`
+  reference files and no golden PNGs exist under `tests/`; no e2e test asserts
+  depth red-channel content. Nothing to regenerate.
+- [ ] Verify `pixi run test-e2e` (or equivalent golden-file CI target) passes.
+  (gpu-gated; not run in this environment. No golden depth PNG assets exist, so
+  no regeneration is required.)
+
+## T4: Docs / changelog
+
+- [ ] Add entry to `CHANGELOG.md` under the next release:
+  "depth export: local mode now produces grayscale mode-L PNG (min-max stretch)
+  matching remote mode; previously produced RGBA with depth in red channel."
+- [ ] Run `pixi run gen-commands` and `pixi run gen-skill-ref` if depth export
+  is mentioned in any auto-generated reference (unlikely, but verify).
+
+## T5: Manual real-GPU verify
+
+- [ ] Follow test-plan.md Step 1-3: local and remote depth PNGs byte-identical
+  for vkcube D16 capture.
+- [ ] Follow test-plan.md Step 4 if a D24S8 capture is available: fallback
+  produces a file, no error.

--- a/openspec/changes/2026-06-09-depth-export-consistency/test-plan.md
+++ b/openspec/changes/2026-06-09-depth-export-consistency/test-plan.md
@@ -1,0 +1,155 @@
+# Test Plan: 2026-06-09-depth-export-consistency
+
+## Scope
+
+### In scope
+- Local `rt_depth` calls `GetTextureData` (not `SaveTexture`) for decodable formats
+- Local `rt_depth` falls back to `SaveTexture` for D24S8 (non-Regular format)
+- Remote path unchanged: `GetTextureData` + `_decode_texture_png(is_depth=True)`
+- `rdc snapshot` depth file still written when depth target is decodable
+- Grayscale mode-L PNG produced locally for D16 and D32_FLOAT formats
+- Local and remote output byte-identical for the same decodable depth format
+
+### Out of scope
+- Color export paths (`rt_export`, `tex_export`)
+- `--depth` CLI flag routing (covered by 2026-06-09-rt-depth-flag)
+- Remote MSAA depth (already -32002 before change)
+
+## Test Matrix
+
+| Layer | Test Type | File |
+|-------|-----------|------|
+| Unit | local rt_depth calls GetTextureData | `tests/unit/test_tex_stats_handler.py` |
+| Unit | local rt_depth produces grayscale L PNG | `tests/unit/test_tex_stats_handler.py` |
+| Unit | local D24S8 falls back to SaveTexture | `tests/unit/test_tex_stats_handler.py` |
+| Unit | remote path unchanged (D32_FLOAT grayscale) | `tests/unit/test_tex_stats_handler.py` (existing, must still pass) |
+| Unit | remote D24S8 still returns -32002, no SaveTexture fallback | `tests/unit/test_tex_stats_handler.py` (new) |
+| Unit | local == remote byte-identical for D16 (same mock data) | `tests/unit/test_tex_stats_handler.py` (new) |
+| Unit | binary daemon happy path still works | `tests/unit/test_binary_daemon.py` (update mock) |
+| Unit | snapshot depth.png written for decodable format | `tests/unit/test_snapshot_command.py` (update mock) |
+| Manual | vkcube D16: local == remote byte-identical | see below |
+
+## Unit Cases
+
+### `test_rt_depth_local_calls_gettexturedata`
+
+In `tests/unit/test_tex_stats_handler.py`, new test. Construct a D32_FLOAT
+format (`compType=Depth`, `compByteWidth=4`, `ResourceFormatType.Regular`).
+Build a local state (`is_remote=False`) with a `MockReplayController` whose
+`GetTextureData` returns 4 packed float32 bytes `[0.0, 0.25, 0.75, 1.0]` for
+a 2x2 texture, and whose `SaveTexture` raises `AssertionError` if called.
+Call `_handle_rt_depth`. Assert:
+- `result` is present (no error).
+- The PNG at `result["path"]` is mode-L (grayscale).
+- Pixel (0,0) == 0, pixel (1,1) == 255.
+- `SaveTexture` was not called.
+
+### `test_rt_depth_local_produces_grayscale_L`
+
+Simplified variant: verify mode and min-max range for D16 (`compType=Depth`,
+`compByteWidth=2`). Raw bytes: `struct.pack("<4H", 0, 16384, 49152, 65535)`.
+Assert output PNG mode is `"L"`, pixel (0,0)==0, pixel (1,1)==255.
+
+### `test_rt_depth_local_d24s8_fallback_uses_savetexture`
+
+Construct a `D24S8` format (`ResourceFormatType.D24S8 = 20`, non-Regular).
+Build local state. Stub `GetTextureData` to return 8 bytes of zeros (decoder
+will return None because type is non-Regular). Stub `SaveTexture` to write a
+valid PNG and record that it was called. Call `_handle_rt_depth`. Assert:
+- `result` is present.
+- `SaveTexture` was called exactly once.
+
+This is the regression guard for combined depth-stencil fallback.
+
+### `test_rt_depth_remote_d24s8_no_fallback` (new)
+
+Construct a `D24S8` format (non-Regular), build a **remote** state
+(`is_remote=True`) with `SaveTexture` stubbed to raise `AssertionError` if
+called. Call `_handle_rt_depth`. Assert:
+- response is an error with code -32002 (unchanged remote behaviour),
+- `SaveTexture` was never called.
+
+This pins the spec's "remote returns -32002 as-is" rule; no such test exists
+today (existing remote depth tests cover the success path only).
+
+### `test_rt_depth_local_remote_byte_identical_d16` (new)
+
+Run `_handle_rt_depth` twice against the same D16 mock data and depth target,
+once with `is_remote=False` and once with `is_remote=True`. Read both output
+files and assert the PNG bytes are identical. This is the unit-level mirror of
+manual Step 3.
+
+### `test_rt_depth_remote_unchanged` (existing tests, must still pass)
+
+Existing tests `test_rt_depth_remote_decodes_grayscale` and
+`test_rt_depth_remote_d16_decodes_grayscale` in `test_tex_stats_handler.py`
+must continue to pass unchanged. No modifications to these tests.
+
+### Update `TestRtDepth.test_happy_path` in `test_binary_daemon.py`
+
+`_make_handler_state` already stubs `GetTextureData` (1024 filler bytes), but
+its `tex_map` holds only texture 42 while the pipe's depth target is
+ResourceId(500); after the change the handler would return -32001 "depth
+target not found". Update `_make_handler_state`: add a depth
+`TextureDescription` (ResourceId 500, Regular D16-style format) to
+`textures`/`tex_map` and make `GetTextureData` return correctly-sized bytes
+for it (length must match `width * height * compCount * compByteWidth` or the
+decoder rejects it). Keep the `SaveTexture` stub (still used by rt_export and
+the fallback path).
+
+### Update snapshot mock in `test_snapshot_command.py`
+
+The `rt_depth` mock used by snapshot tests returns a pre-created PNG path.
+This mock operates at the `call` level above the daemon handler, so it is
+format-agnostic and does not need changes. Verify all existing snapshot tests
+pass without modification.
+
+## Manual Real-GPU Verify
+
+Prerequisite: a vkcube capture with at least one draw event that has a D16
+depth attachment (any 3D draw should qualify; `rdc rt <EID> --depth -o /dev/null`
+to confirm).
+
+### Step 1 — Local depth PNG
+
+```sh
+rdc open capture.rdc
+rdc rt <EID> --depth -o /tmp/depth_local.png
+```
+
+Assert:
+- exit code 0
+- `/tmp/depth_local.png` is a valid PNG
+- `python3 -c "from PIL import Image; img = Image.open('/tmp/depth_local.png'); print(img.mode)"` prints `L`
+- Image is non-constant (visible grayscale gradient, not all-zero or all-one)
+
+### Step 2 — Remote proxy depth PNG
+
+```sh
+rdc open capture.rdc --proxy host:port
+rdc rt <EID> --depth -o /tmp/depth_remote.png
+```
+
+Assert:
+- exit code 0
+- `/tmp/depth_remote.png` exists and is non-empty
+
+### Step 3 — Byte-identical comparison
+
+```sh
+diff /tmp/depth_local.png /tmp/depth_remote.png && echo "IDENTICAL"
+```
+
+Assert: prints `IDENTICAL`. Both files produced from the same capture at the
+same EID must be byte-for-byte equal after this change.
+
+### Step 4 — D24S8 fallback (if GPU has a D24S8 capture available)
+
+```sh
+rdc open d24s8_capture.rdc
+rdc rt <EID> --depth -o /tmp/depth_d24s8.png
+```
+
+Assert:
+- exit code 0 (fallback to SaveTexture, no error)
+- `/tmp/depth_d24s8.png` exists (RGBA from SaveTexture; grayscale not guaranteed)

--- a/src/rdc/commands/snapshot.py
+++ b/src/rdc/commands/snapshot.py
@@ -60,8 +60,9 @@ def snapshot_cmd(eid: int, output: str, use_json: bool) -> None:
             continue
         break
 
-    # Depth target: surface a warning when remote depth decode is unsupported
-    # (e.g. D24S8 or MSAA) instead of silently omitting depth.png.
+    # Depth target: surface a warning when depth decode is unsupported
+    # (combined depth-stencil or MSAA in remote mode) instead of silently
+    # omitting depth.png.
     depth_result, depth_code = call_with_code("rt_depth", {"eid": eid})
     if depth_result is not None:
         data = fetch_remote_file(depth_result["path"])

--- a/src/rdc/handlers/texture.py
+++ b/src/rdc/handlers/texture.py
@@ -216,21 +216,26 @@ def _handle_rt_depth(
     if int(depth.resource) == 0:
         return _error_response(request_id, -32001, f"no depth target at eid {eid}"), True
     temp_path = state.temp_dir / f"rt_{eid}_depth.png"
-    if state.is_remote:
-        tex = state.tex_map.get(int(depth.resource))
-        if tex is None:
-            return _error_response(
-                request_id, -32001, f"depth target {int(depth.resource)} not found"
-            ), True
-        return _export_remote(request_id, state, tex, depth.resource, temp_path, 0, is_depth=True)
-    texsave = _make_texsave(state.rd, depth.resource)
-    success = state.adapter.controller.SaveTexture(texsave, str(temp_path))  # type: ignore[union-attr]
-    if not success or not temp_path.exists():
-        return _error_response(request_id, -32002, "SaveTexture failed"), True
-    return _result_response(
-        request_id,
-        {"path": str(temp_path), "size": temp_path.stat().st_size},
-    ), True
+    tex = state.tex_map.get(int(depth.resource))
+    if tex is None:
+        return _error_response(
+            request_id, -32001, f"depth target {int(depth.resource)} not found"
+        ), True
+    resp, running = _export_remote(
+        request_id, state, tex, depth.resource, temp_path, 0, is_depth=True
+    )
+    # Combined depth-stencil and MSAA formats decode to None (-32002). Locally,
+    # SaveTexture can still export them (RGBA); remote returns the error as-is.
+    if resp.get("error", {}).get("code") == -32002 and not state.is_remote:
+        texsave = _make_texsave(state.rd, depth.resource)
+        success = state.adapter.controller.SaveTexture(texsave, str(temp_path))  # type: ignore[union-attr]
+        if not success or not temp_path.exists():
+            return _error_response(request_id, -32002, "SaveTexture failed"), True
+        return _result_response(
+            request_id,
+            {"path": str(temp_path), "size": temp_path.stat().st_size},
+        ), True
+    return resp, running
 
 
 def _handle_rt_overlay(

--- a/tests/unit/test_binary_daemon.py
+++ b/tests/unit/test_binary_daemon.py
@@ -14,6 +14,7 @@ from mock_renderdoc import (
     Descriptor,
     MockPipeState,
     ResourceDescription,
+    ResourceFormat,
     ResourceId,
     ShaderStage,
     TextureDescription,
@@ -112,7 +113,17 @@ def _build_textures():
             height=512,
             mips=4,
         ),
+        TextureDescription(
+            resourceId=ResourceId(500),
+            width=2,
+            height=2,
+            format=ResourceFormat(name="D16", compByteWidth=2, compCount=1, compType=8),
+        ),
     ]
+
+
+# D16 2x2 depth bytes for ResourceId(500): width*height*compCount*compByteWidth = 8.
+_DEPTH_500_DATA = (0).to_bytes(2, "little") + (65535).to_bytes(2, "little") * 3
 
 
 def _build_buffers():
@@ -157,7 +168,7 @@ def _make_handler_state(tmp_path: Path):
             _assert_has_resource_id(texsave),
             Path(path).write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100),
         ),
-        GetTextureData=lambda rid, sub: b"\x00\xff" * 512,
+        GetTextureData=lambda rid, sub: _DEPTH_500_DATA if int(rid) == 500 else b"\x00\xff" * 512,
         GetBufferData=lambda rid, offset, length: b"\xab\xcd" * 256,
     )
     return make_daemon_state(

--- a/tests/unit/test_tex_stats_handler.py
+++ b/tests/unit/test_tex_stats_handler.py
@@ -440,6 +440,135 @@ def test_rt_depth_remote_d16_decodes_grayscale(tmp_path: object) -> None:
     assert abs(img.getpixel((1, 0)) - 64) <= 2
 
 
+# ---------------------------------------------------------------------------
+# Local-mode rt_depth: unified GetTextureData decode + SaveTexture fallback
+# ---------------------------------------------------------------------------
+
+
+def _local_depth_state(
+    tex: rd.TextureDescription,
+    raw: bytes,
+    tmp_path: object,
+    *,
+    save_texture: object = None,
+) -> DaemonState:
+    ctrl = rd.MockReplayController()
+    ctrl._textures = [tex]
+    ctrl._texture_data[int(tex.resourceId)] = raw
+    ctrl._pipe_state = rd.MockPipeState(depth_target=rd.Descriptor(resource=tex.resourceId))
+    if save_texture is not None:
+        ctrl.SaveTexture = save_texture  # type: ignore[method-assign]
+    return make_daemon_state(
+        ctrl=ctrl,
+        current_eid=100,
+        rd=rd,
+        tmp_path=tmp_path,
+        tex_map={int(tex.resourceId): tex},
+        is_remote=False,
+    )
+
+
+def test_rt_depth_local_calls_gettexturedata(tmp_path: object) -> None:
+    fmt = rd.ResourceFormat(name="D32_FLOAT", compByteWidth=4, compCount=1, compType=8)
+    tex = rd.TextureDescription(resourceId=rd.ResourceId(305), width=2, height=2, format=fmt)
+    raw = struct.pack("<4f", 0.0, 0.25, 0.75, 1.0)
+
+    def _no_save(texsave: object, path: str) -> bool:
+        raise AssertionError("SaveTexture must not be called for decodable depth")
+
+    state = _local_depth_state(tex, raw, tmp_path, save_texture=_no_save)
+    resp, _ = _handle_request(rpc_request("rt_depth", {"eid": 100}), state)
+    assert "result" in resp
+    img = _read_png(resp["result"]["path"])
+    assert img.mode == "L"
+    assert img.getpixel((0, 0)) == 0
+    assert img.getpixel((1, 1)) == 255
+
+
+def test_rt_depth_local_produces_grayscale_L(tmp_path: object) -> None:  # noqa: N802
+    fmt = rd.ResourceFormat(name="D16", compByteWidth=2, compCount=1, compType=8)
+    tex = rd.TextureDescription(resourceId=rd.ResourceId(306), width=2, height=2, format=fmt)
+    raw = struct.pack("<4H", 0, 16384, 49152, 65535)
+    state = _local_depth_state(tex, raw, tmp_path)
+    resp, _ = _handle_request(rpc_request("rt_depth", {"eid": 100}), state)
+    img = _read_png(resp["result"]["path"])
+    assert img.mode == "L"
+    assert img.getpixel((0, 0)) == 0
+    assert img.getpixel((1, 1)) == 255
+
+
+def test_rt_depth_local_d24s8_fallback_uses_savetexture(tmp_path: object) -> None:
+    fmt = rd.ResourceFormat(
+        name="D24S8",
+        compByteWidth=4,
+        compCount=1,
+        compType=8,
+        type=int(rd.ResourceFormatType.D24S8),
+    )
+    tex = rd.TextureDescription(resourceId=rd.ResourceId(307), width=2, height=2, format=fmt)
+    save_calls: list[str] = []
+
+    def _spy(texsave: object, path: str) -> bool:
+        save_calls.append(path)
+        from pathlib import Path
+
+        Path(path).write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+        return True
+
+    state = _local_depth_state(tex, b"\x00" * 8, tmp_path, save_texture=_spy)
+    resp, _ = _handle_request(rpc_request("rt_depth", {"eid": 100}), state)
+    assert "result" in resp
+    assert len(save_calls) == 1
+
+
+def test_rt_depth_remote_d24s8_no_fallback(tmp_path: object) -> None:
+    fmt = rd.ResourceFormat(
+        name="D24S8",
+        compByteWidth=4,
+        compCount=1,
+        compType=8,
+        type=int(rd.ResourceFormatType.D24S8),
+    )
+    tex = rd.TextureDescription(resourceId=rd.ResourceId(308), width=2, height=2, format=fmt)
+    depth = rd.Descriptor(resource=tex.resourceId)
+    state = _remote_state(tex, b"\x00" * 8, tmp_path, depth_target=depth)
+
+    def _no_save(texsave: object, path: str) -> bool:
+        raise AssertionError("SaveTexture must not be called in remote mode")
+
+    state.adapter.controller.SaveTexture = _no_save  # type: ignore[union-attr,method-assign]
+    resp, _ = _handle_request(rpc_request("rt_depth", {"eid": 100}), state)
+    assert resp["error"]["code"] == -32002
+
+
+def test_rt_depth_local_remote_byte_identical_d16(tmp_path: object) -> None:
+    from pathlib import Path
+
+    fmt = rd.ResourceFormat(name="D16", compByteWidth=2, compCount=1, compType=8)
+    raw = struct.pack("<4H", 0, 16384, 49152, 65535)
+
+    local_dir = Path(str(tmp_path)) / "local"
+    remote_dir = Path(str(tmp_path)) / "remote"
+    local_dir.mkdir()
+    remote_dir.mkdir()
+
+    tex_l = rd.TextureDescription(resourceId=rd.ResourceId(309), width=2, height=2, format=fmt)
+    local_state = _local_depth_state(tex_l, raw, local_dir)
+    local_resp, _ = _handle_request(rpc_request("rt_depth", {"eid": 100}), local_state)
+
+    tex_r = rd.TextureDescription(resourceId=rd.ResourceId(309), width=2, height=2, format=fmt)
+    remote_state = _remote_state(
+        tex_r, raw, remote_dir, depth_target=rd.Descriptor(resource=tex_r.resourceId)
+    )
+    remote_resp, _ = _handle_request(rpc_request("rt_depth", {"eid": 100}), remote_state)
+
+    with open(local_resp["result"]["path"], "rb") as fh:
+        local_bytes = fh.read()
+    with open(remote_resp["result"]["path"], "rb") as fh:
+        remote_bytes = fh.read()
+    assert local_bytes == remote_bytes
+
+
 def test_tex_export_remote_r16_unorm_scales_by_257(tmp_path: object) -> None:
     # R16 UNorm: 16-bit -> 8-bit via /257. 65535/257 = 255, 32896/257 = 128.
     fmt = rd.ResourceFormat(name="R16_UNORM", compByteWidth=2, compCount=1, compType=2)


### PR DESCRIPTION
## Summary

Depth export previously produced different images per replay mode: local mode wrote an RGBA PNG with linear depth in the red channel (RenderDoc `SaveTexture` behavior), while remote mode (since #237) wrote a min-max-stretched grayscale PNG via `GetTextureData` + local decode. Same capture, visually different files — cross-mode golden comparisons were impossible.

Depth export now uses one pipeline in both modes: `_handle_rt_depth` always tries the `GetTextureData` + grayscale decode path first. Output is byte-identical between local and remote replay for decodable depth formats.

## Behavior change

Local depth PNGs change from red-channel RGBA (linear, unstretched) to grayscale mode-L with min-max stretch — now matching remote output exactly. Color/texture export is unchanged (local still uses `SaveTexture`).

## Fallback

When the decoder rejects a format (combined depth-stencil D16S8/D24S8/D32S8/S8, MSAA), local mode falls back to the previous `SaveTexture` path verbatim, preserving existing capability; remote mode returns -32002 as before. A texture-map miss stays -32001 with no fallback.

## Testing

- 5 new unit tests: local uses `GetTextureData` (SaveTexture stubbed to fail), grayscale mode-L output, local D24S8 SaveTexture fallback, remote D24S8 stays -32002 with SaveTexture never called, local/remote byte-identical D16. Binary-daemon mock state extended with a depth texture entry.
- Real-GPU verification on AMD RX 7600 (RADV), vkcube D16 capture: local and remote depth PNGs are byte-identical (same sha256); color rt/texture export and `rdc snapshot` (depth.png + color0.png) unaffected. D24S8 could not be exercised on RADV (format unsupported by the driver); the fallback branch is covered by unit tests.
- Full suite: 2974 passed; lint + mypy strict clean.

Note for remote testing on dual-stack hosts: use `--proxy 127.0.0.1:<port>` rather than `localhost` — `renderdoccmd remoteserver` binds IPv4 only while `localhost` may resolve to `::1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unified depth PNG export behavior between local and remote modes, ensuring consistent grayscale output format.
  * Added automatic fallback mechanism for unsupported depth formats to maintain export reliability.

* **Tests**
  * Expanded test coverage for local and remote depth export scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->