### PR TITLE
fix(remote): normalize localhost to 127.0.0.1 for IPv4-only remote servers

### DIFF
--- a/openspec/changes/2026-06-10-proxy-localhost-ipv4/proposal.md
+++ b/openspec/changes/2026-06-10-proxy-localhost-ipv4/proposal.md
@@ -1,0 +1,175 @@
+# Normalize `localhost` to `127.0.0.1` in proxy remote URL
+
+## Problem
+
+`rdc open <cap> --proxy localhost:39920` stalls indefinitely at "uploading: 0%"
+on dual-stack hosts. Root cause: `localhost` resolves to `::1` (IPv6) on such
+hosts, while `renderdoccmd remoteserver` binds IPv4-only (`0.0.0.0:39920`).
+`rd.CreateRemoteServerConnection("localhost:39920")` therefore connects to `::1`
+and blocks forever — no error, no timeout surfaced to the user.
+
+`--proxy 127.0.0.1:39920` works immediately. The failure mode is a silent
+indefinite stall, the worst possible UX signal (the user can't distinguish a
+slow upload from a hang).
+
+Verified on real GPU hardware.
+
+## Entry paths traced
+
+Every path where a user-supplied host string eventually reaches a RenderDoc API
+or rdc-cli socket call:
+
+| # | Entry point | File : line | Host string flow |
+|---|-------------|-------------|-----------------|
+| 1 | `rdc open CAP --proxy HOST:PORT` | `commands/session.py:147` — `proxy_url` option | `proxy_url` → `open_session(remote_url=proxy_url)` → `start_daemon(remote_url=...)` → daemon argv `--remote-url HOST:PORT` → `daemon_server.py:817` → `_load_remote_replay(state, remote_url)` → `rd.CreateRemoteServerConnection(remote_url)` at `daemon_server.py:568` |
+| 2 | `rdc open CAP --listen ADDR --proxy HOST:PORT` | `commands/session.py:295` | same `proxy_url` → `listen_open_session(remote_url=proxy_url)` → same daemon path |
+| 3 | `rdc open CAP --android` | `commands/session.py:230` | `_resolve_android_url()` returns `f"localhost:{port}"` at `session.py:97` — this is the same literal-localhost problem, currently in the Android path; the forwarded port is IPv4 only |
+| 4 | `rdc remote connect HOST:PORT` | `commands/remote.py:96` | `parse_url(url)` → `host, port` → `build_conn_url(host, port)` → `connect_remote_server(rd, conn_url)` → `rd.CreateRemoteServerConnection(conn_url)` at `remote_core.py:105` |
+| 5 | `rdc remote list` / `rdc remote capture` | `commands/remote.py:133,244` | host from `--url` via `parse_url`, **or from saved state** via `_resolve_url` → `load_latest_remote_state()` (`remote.py:49`) → same `build_conn_url(host, port)` → same `rd.CreateRemoteServerConnection` |
+| 6 | `rdc android setup` | `commands/android.py:339` | `conn_url = f"localhost:{forwarded_port}"` → `connect_remote_server(rd, conn_url)` at `android.py:342` |
+| 7 | `rdc android capture` (target control) | `commands/android.py:464` | `rd.CreateTargetControl("localhost", local_port, ...)` — this is `CreateTargetControl`, not `CreateRemoteServerConnection`; same IPv6 risk |
+| 8 | `capture_core.py:100,103` | internal enumeration | `rd.EnumerateRemoteTargets("localhost", ...)` — local capture use only, no user-visible flag |
+
+The critical path for the reported bug is entry #1. Paths #3, #6, #7, #8 also
+use the literal `"localhost"` string hardcoded in the implementation; the user
+has no control over them. The `parse_url` function in `remote_core.py` is the
+shared parser for path #4 and for path #5 when `--url` is given; without
+`--url`, path #5 takes its host from the saved state file and bypasses
+`parse_url` entirely.
+
+## Root-cause seam
+
+`daemon_server.py:568` — `rd.CreateRemoteServerConnection(remote_url)` — receives
+`remote_url` as a plain string passed through from the CLI argument without any
+host normalization. The string `"localhost:39920"` is passed directly to the
+RenderDoc C++ API, which resolves it via `getaddrinfo` with no `AI_ADDRCONFIG`
+or family hint, returning `::1` first on a dual-stack host.
+
+## Solution
+
+### Normalization function
+
+Add `_normalize_remote_host(host: str) -> str` to `remote_core.py`. If the
+input is the literal string `"localhost"` (case-insensitive), return
+`"127.0.0.1"`. Otherwise return the input unchanged. Emit one `logging.debug`
+line when normalization fires.
+
+```
+def _normalize_remote_host(host: str) -> str:
+    if host.lower() == "localhost":
+        logging.getLogger(__name__).debug(
+            "normalizing 'localhost' -> '127.0.0.1' (RenderDoc remote protocol is IPv4-only)"
+        )
+        return "127.0.0.1"
+    return host
+```
+
+### Why only the literal `localhost` string
+
+- `::1` literals: genuine IPv6 intent — must not be rewritten.
+- Non-loopback hostnames: may resolve to IPv6 on an IPv6-native remote server
+  that actually runs a dual-stack `renderdoccmd` — must not break.
+- Only `localhost` triggers the systematic mismatch: DNS resolves it to `::1`
+  first on dual-stack Linux; `renderdoccmd remoteserver` never listens on `::1`.
+
+### Chosen normalization point: `parse_url` in `remote_core.py`
+
+`parse_url` (`remote_core.py:52`) is the single entry-point for all
+user-supplied `HOST[:PORT]` strings on the `rdc remote` command family (paths
+#4, #5). Applying normalization there covers those paths with one change.
+
+For path #1 (the bug), `--proxy` bypasses `parse_url` entirely: `proxy_url` is
+passed as a raw string directly to `open_session`. Two options:
+
+**Option A** — normalize inside `parse_url` only, and also add a thin wrapper
+`_parse_proxy_url(url)` called from `open_session` / `listen_open_session` (or
+at `session.py:320`) that strips port and normalizes.
+
+**Option B** — add a standalone `_normalize_remote_host` and call it at the
+single RenderDoc API boundary: `daemon_server.py:568` before passing to
+`rd.CreateRemoteServerConnection`.
+
+**Decision: Option B**, single callsite at `daemon_server.py:568`. Rationale:
+
+- The daemon subprocess receives the raw `--remote-url` argv; normalizing there
+  means the fix covers every path (#1, #2, #3) without touching the CLI parsing
+  layer.
+- Placement detail: normalize at the top of `_load_remote_replay`
+  (`daemon_server.py:552`), not inline at the call, so the normalized string is
+  used both by `rd.CreateRemoteServerConnection` (line 568) and by the
+  `state.remote_url` assignment (line 574) — `rdc status` reads
+  `state.remote_url` (`handlers/core.py:35`) and must report `127.0.0.1:PORT`.
+- Guard: `--proxy` also accepts protocol URLs (`adb://SERIAL`, see
+  `session.py:149` metavar). The daemon-side normalization must not parse or
+  rewrite those — use a plain string check (`remote_url.lower() == "localhost"`
+  or `remote_url.lower().startswith("localhost:")` → replace the `localhost`
+  prefix), which leaves `adb://...`, bracketed IPv6, and everything else
+  untouched.
+- `parse_url` normalization would not reach path #1 without additional plumbing,
+  and would leave daemon_server.py unguarded if called via any other route.
+- Additionally, call `_normalize_remote_host` inside `parse_url` (which feeds
+  paths #4, #5) so `rdc remote connect localhost:39920` also works.
+- Additionally, call `_normalize_remote_host` inside `build_conn_url`
+  (`remote_core.py:38`). This closes a path the two seams above do not cover:
+  `rdc remote list/capture/status` without `--url` load the host from a saved
+  state file (`_resolve_url` → `load_latest_remote_state()` at
+  `commands/remote.py:49`). A state file written before this fix may contain
+  `host: "localhost"`, which would reach `rd.CreateRemoteServerConnection`
+  un-normalized via `build_conn_url`. The same applies to the split-mode daemon
+  handlers (`handlers/capture.py:96,122,162`), which also assemble via
+  `build_conn_url`.
+- The hardcoded literal `"localhost"` strings are **in scope** and changed to
+  `"127.0.0.1"` directly (same IPv4-only renderdoc client risk class):
+  - `commands/android.py:339` — `conn_url = f"localhost:{forwarded_port}"`
+  - `commands/android.py:464` — `rd.CreateTargetControl("localhost", ...)`
+  - `capture_core.py:100,103` — `rd.EnumerateRemoteTargets("localhost", ...)`
+  - `commands/session.py:97` (`_resolve_android_url` returning
+    `f"localhost:{port}"`) needs no literal change: it flows through the daemon
+    `--remote-url` argv and is normalized at the daemon seam (path #3).
+
+### State-file key implication
+
+`remote_state.py:_state_path(host, port)` keys files on the host string as
+provided. A user who previously ran `rdc remote connect localhost:39920` has a
+state file at `~/.rdc/remote/localhost_39920.json`. After normalization inside
+`parse_url`, the same command would save to `127.0.0.1_39920.json`. The
+`localhost_39920.json` file becomes stale (a ghost entry). The read path does
+not break on it: `load_latest_remote_state` iterates the directory and picks
+the most-recently-saved file by `connected_at` timestamp; the ghost is valid
+JSON.
+
+The ghost is **not** purely cosmetic, however: if it is the *latest* state
+(user connected pre-upgrade, then runs `rdc remote list` post-upgrade without
+reconnecting), `_resolve_url(None)` returns `host="localhost"` from the file.
+This is why `build_conn_url` also normalizes (see Solution above) — the stale
+host is rewritten at URL-assembly time and the stall cannot recur. No file
+migration is needed. The stale file can be cleaned with `rdc remote
+disconnect` + reconnect. This should be noted in the changelog.
+
+## Split-mode IPv6 analysis (not a bug — no change needed)
+
+Split mode (`rdc open --listen` / `rdc open --connect`) uses rdc-cli's own
+JSON-RPC socket, not `CreateRemoteServerConnection`. The server side (`run_server`
+at `daemon_server.py:724`) binds via `socket.socket(socket.AF_INET, ...)` —
+explicitly IPv4 only. The client side (`daemon_client.py:17,35`) uses Python's
+`socket.create_connection((host, port), ...)`, which iterates **all**
+`getaddrinfo` results in order: on a dual-stack host where `localhost` resolves
+to `::1` first, the connect to `::1` (no listener) fails with an immediate
+`ECONNREFUSED`, and `create_connection` falls through to `127.0.0.1`, which
+succeeds. There is no silent stall — the failure mode that motivates this
+change does not exist here, because the Python socket layer retries across
+address families while RenderDoc's C++ client does not.
+
+`--connect localhost:PORT` (`session.py:261-278`, parsed via `rsplit`, no
+`parse_url`) therefore works as-is and is intentionally **not** normalized by
+this change. Analyzed and closed; not an open question.
+
+## Risks
+
+- **None for genuine IPv6 deployments**: `::1` literal and non-loopback
+  hostnames are untouched.
+- **`rdc remote setup`** also calls `parse_url` → benefits from normalization in
+  `parse_url` path.
+- **Spec file** (`openspec/specs/daemon/spec.md`): the remote replay scenario
+  should gain a note; no behavioral specification change is needed because the
+  behavior is now correct by construction.

--- a/openspec/changes/2026-06-10-proxy-localhost-ipv4/proposal.md
+++ b/openspec/changes/2026-06-10-proxy-localhost-ipv4/proposal.md
@@ -29,6 +29,7 @@ or rdc-cli socket call:
 | 6 | `rdc android setup` | `commands/android.py:339` | `conn_url = f"localhost:{forwarded_port}"` → `connect_remote_server(rd, conn_url)` at `android.py:342` |
 | 7 | `rdc android capture` (target control) | `commands/android.py:464` | `rd.CreateTargetControl("localhost", local_port, ...)` — this is `CreateTargetControl`, not `CreateRemoteServerConnection`; same IPv6 risk |
 | 8 | `capture_core.py:100,103` | internal enumeration | `rd.EnumerateRemoteTargets("localhost", ...)` — local capture use only, no user-visible flag |
+| 9 | `rdc attach IDENT` / `capture-trigger` / `capture-list` / `capture-copy` | `commands/capture_control.py:47,72,88,139` — `--host` option (default `localhost`) | `host` → `_connect(rd, host, ident)` (`capture_control.py:32`) → `rd.CreateTargetControl(host, ident, ...)` — user-supplied `--host` (default and explicit `localhost`/`LOCALHOST`) reaches `CreateTargetControl` un-normalized; same IPv4-only risk class |
 
 The critical path for the reported bug is entry #1. Paths #3, #6, #7, #8 also
 use the literal `"localhost"` string hardcoded in the implementation; the user
@@ -126,6 +127,13 @@ single RenderDoc API boundary: `daemon_server.py:568` before passing to
   - `commands/session.py:97` (`_resolve_android_url` returning
     `f"localhost:{port}"`) needs no literal change: it flows through the daemon
     `--remote-url` argv and is normalized at the daemon seam (path #3).
+- Path #9 (`commands/capture_control.py`) takes a user-facing `--host` option
+  (default `localhost`) that flows through `_connect` into
+  `rd.CreateTargetControl`. This is normalized by calling `_normalize_remote_host`
+  at the top of `_connect` (`capture_control.py:32`) — covering both the default
+  and an explicit `--host localhost`/`--host LOCALHOST` — without changing the
+  click default (cosmetic once `_connect` normalizes; minimal diff). The
+  standalone helper is imported from `remote_core.py`, no logic is duplicated.
 
 ### State-file key implication
 

--- a/openspec/changes/2026-06-10-proxy-localhost-ipv4/tasks.md
+++ b/openspec/changes/2026-06-10-proxy-localhost-ipv4/tasks.md
@@ -21,6 +21,11 @@
       `"127.0.0.1"`
 - [x] `capture_core.py:100,103`: `rd.EnumerateRemoteTargets("localhost", ...)` →
       `"127.0.0.1"`
+- [x] `commands/capture_control.py`: import `_normalize_remote_host` from
+      `remote_core.py`; call it at the top of `_connect` so the `--host` option
+      (default `localhost`) is normalized before `rd.CreateTargetControl` —
+      covers `rdc attach/capture-trigger/capture-list/capture-copy` (path #9),
+      both default and explicit `localhost`/`LOCALHOST`
 - [x] `tests/unit/test_remote_core.py`: add `TestNormalizeRemoteHost` (items 1-7
       in test-plan); update `TestParseUrl.test_localhost` + add items 8-11;
       update `TestBuildConnUrl` (items 13a-13b, including the existing
@@ -33,6 +38,10 @@
       `"127.0.0.1"` (item 15)
 - [x] `tests/unit/test_capture_core.py`: assert `EnumerateRemoteTargets`
       receives `"127.0.0.1"` as host (item 16)
+- [x] `tests/unit/test_capture_control.py`: assert `rd.CreateTargetControl`
+      receives `"127.0.0.1"` when `--host` is omitted (item 17) and when
+      `--host LOCALHOST` is explicit (item 18); non-localhost host passes through
+      unchanged (item 19)
 - [x] `pixi run check` green (lint + typecheck + tests)
 - [ ] Changelog note: state files previously keyed on `localhost` become stale
       after upgrade; `rdc remote disconnect && rdc remote connect 127.0.0.1:PORT`

--- a/openspec/changes/2026-06-10-proxy-localhost-ipv4/tasks.md
+++ b/openspec/changes/2026-06-10-proxy-localhost-ipv4/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: normalize `localhost` to `127.0.0.1` in proxy remote URL
+
+- [x] `remote_core.py`: add `_normalize_remote_host(host: str) -> str`; maps
+      `"localhost"` (case-insensitive) → `"127.0.0.1"`, else identity; emits
+      `logging.debug` when it fires
+- [x] `remote_core.py`: call `_normalize_remote_host` inside `parse_url` on the
+      extracted `host` before returning — covers `rdc remote connect/list/capture/setup`
+- [x] `remote_core.py`: call `_normalize_remote_host` inside `build_conn_url` —
+      covers hosts loaded from pre-fix state files (`_resolve_url` →
+      `load_latest_remote_state`) and split-mode daemon handlers
+      (`handlers/capture.py:96,122,162`)
+- [x] `daemon_server.py`: normalize the `localhost` host portion of `remote_url`
+      at the top of `_load_remote_replay` (plain string check; skip protocol
+      URLs like `adb://`) so both `rd.CreateRemoteServerConnection` (line 568)
+      and `state.remote_url` (line 574, shown by `rdc status`) see the
+      normalized value — covers `rdc open --proxy` (the primary bug path) and
+      the Android open path (`session.py:97`)
+- [x] `commands/android.py:339`: `f"localhost:{forwarded_port}"` →
+      `f"127.0.0.1:{forwarded_port}"`
+- [x] `commands/android.py:464`: `rd.CreateTargetControl("localhost", ...)` →
+      `"127.0.0.1"`
+- [x] `capture_core.py:100,103`: `rd.EnumerateRemoteTargets("localhost", ...)` →
+      `"127.0.0.1"`
+- [x] `tests/unit/test_remote_core.py`: add `TestNormalizeRemoteHost` (items 1-7
+      in test-plan); update `TestParseUrl.test_localhost` + add items 8-11;
+      update `TestBuildConnUrl` (items 13a-13b, including the existing
+      `localhost` assertion at line 76); add item 14
+- [x] `tests/unit/test_daemon_server_unit.py`: add item 12 (normalization at
+      `CreateRemoteServerConnection` boundary)
+- [x] `tests/unit/test_android_commands.py`: update the existing assertion
+      `CreateRemoteServerConnection.assert_called_once_with("localhost:12345")`
+      (line 325) to `"127.0.0.1:12345"`; assert `CreateTargetControl` receives
+      `"127.0.0.1"` (item 15)
+- [x] `tests/unit/test_capture_core.py`: assert `EnumerateRemoteTargets`
+      receives `"127.0.0.1"` as host (item 16)
+- [x] `pixi run check` green (lint + typecheck + tests)
+- [ ] Changelog note: state files previously keyed on `localhost` become stale
+      after upgrade; `rdc remote disconnect && rdc remote connect 127.0.0.1:PORT`
+      to clean up
+- [ ] Fresh review of the diff
+- [ ] Open PR targeting `master`
+- [ ] Archive this OpenSpec folder after merge
+
+## Out of scope
+
+- Split-mode `--connect localhost:PORT` — analyzed and confirmed not a bug; no
+  change needed (see proposal, "Split-mode IPv6 analysis").

--- a/openspec/changes/2026-06-10-proxy-localhost-ipv4/test-plan.md
+++ b/openspec/changes/2026-06-10-proxy-localhost-ipv4/test-plan.md
@@ -55,6 +55,16 @@ Hardcoded literals (`tests/unit/test_android_commands.py`,
     tests use `lambda _host, ...` mocks — extend or add one assertion capturing
     the host).
 
+`tests/unit/test_capture_control.py` (TargetControl `--host` option,
+`_connect` seam at `capture_control.py:32`):
+
+17. `rdc attach 12345` (no `--host`): the mocked `rd.CreateTargetControl` first
+    argument is `"127.0.0.1"` (default `localhost` normalized).
+18. `rdc attach 12345 --host LOCALHOST`: the mocked `rd.CreateTargetControl`
+    first argument is `"127.0.0.1"` (explicit, case-insensitive).
+19. `rdc attach 12345 --host 192.168.1.50`: the mocked `rd.CreateTargetControl`
+    first argument is `"192.168.1.50"` unchanged (non-localhost passthrough).
+
 Run: `pixi run test` (unit only). Full gate: `pixi run check`.
 
 ## Manual / real-GPU

--- a/openspec/changes/2026-06-10-proxy-localhost-ipv4/test-plan.md
+++ b/openspec/changes/2026-06-10-proxy-localhost-ipv4/test-plan.md
@@ -1,0 +1,78 @@
+# Test Plan: normalize `localhost` to `127.0.0.1` in proxy remote URL
+
+## Unit (mocked — no GPU required)
+
+`tests/unit/test_remote_core.py` (`TestNormalizeRemoteHost`, new class):
+
+1. `_normalize_remote_host("localhost")` returns `"127.0.0.1"`.
+2. `_normalize_remote_host("LOCALHOST")` returns `"127.0.0.1"` (case-insensitive).
+3. `_normalize_remote_host("Localhost")` returns `"127.0.0.1"`.
+4. `_normalize_remote_host("127.0.0.1")` returns `"127.0.0.1"` unchanged.
+5. `_normalize_remote_host("192.168.1.5")` returns unchanged.
+6. `_normalize_remote_host("::1")` returns `"::1"` unchanged — genuine IPv6.
+7. `_normalize_remote_host("myserver.local")` returns unchanged.
+
+`tests/unit/test_remote_core.py` (`TestParseUrl` — extend existing class):
+
+8. `parse_url("localhost")` returns `("127.0.0.1", 39920)` — normalization in parser.
+9. `parse_url("localhost:39920")` returns `("127.0.0.1", 39920)`.
+10. `parse_url("[::1]:39920")` returns `("::1", 39920)` — IPv6 bracket form untouched.
+11. Existing `test_localhost` test updated: `parse_url("localhost")` now returns
+    `("127.0.0.1", 39920)`, not `("localhost", 39920)`.
+
+`tests/unit/test_daemon_server_unit.py` (new test targeting `_load_remote_replay`
+mock path, or a direct unit for the normalization call at the `CreateRemoteServerConnection`
+boundary):
+
+12. `_load_remote_replay` called with `remote_url="localhost:39920"`: verify that
+    `rd.CreateRemoteServerConnection` receives `"127.0.0.1:39920"`, not
+    `"localhost:39920"`. (Mock `rd` and `find_renderdoc`.)
+
+`tests/unit/test_remote_core.py` (`TestBuildConnUrl` — extend existing class):
+
+13a. `build_conn_url("127.0.0.1", 39920)` still returns `"127.0.0.1:39920"`.
+13b. `build_conn_url("localhost", 39920)` returns `"127.0.0.1:39920"` — this
+     updates the existing assertion at `test_remote_core.py:76` (covers hosts
+     loaded from pre-fix state files and split-mode daemon handlers).
+
+State-file key consistency:
+
+14. (In `tests/unit/test_remote_core.py` or a dedicated unit) After
+    `parse_url("localhost:39920")` returns `("127.0.0.1", 39920)`, the resulting
+    `_state_path("127.0.0.1", 39920)` is `…/127.0.0.1_39920.json` — confirm
+    no `localhost` key appears in the path.
+
+Hardcoded literals (`tests/unit/test_android_commands.py`,
+`tests/unit/test_capture_core.py`):
+
+15. Android setup (`android.py:339,342`): the existing assertion at
+    `test_android_commands.py:325` changes from
+    `CreateRemoteServerConnection.assert_called_once_with("localhost:12345")`
+    to `"127.0.0.1:12345"`. Android target control (`android.py:464`): assert
+    the mocked `rd.CreateTargetControl` first argument is `"127.0.0.1"`.
+16. `capture_core.py:100,103`: assert the mocked `rd.EnumerateRemoteTargets`
+    host argument is `"127.0.0.1"` (the existing `_discover_latest_target`
+    tests use `lambda _host, ...` mocks — extend or add one assertion capturing
+    the host).
+
+Run: `pixi run test` (unit only). Full gate: `pixi run check`.
+
+## Manual / real-GPU
+
+Prerequisites: dual-stack Linux host; `renderdoccmd remoteserver` running on
+`localhost:39920` (binds `0.0.0.0:39920`); a valid `.rdc` capture file.
+
+1. **Before fix (baseline)**: `rdc open frame.rdc --proxy localhost:39920` stalls
+   at "uploading: 0%" indefinitely — confirm the regression under test.
+2. **After fix**: same command completes normally; `rdc status` shows
+   `remote: 127.0.0.1:39920`; a replay query (`rdc draws`) succeeds.
+3. **IPv4 explicit still works**: `rdc open frame.rdc --proxy 127.0.0.1:39920`
+   behaves identically to (2).
+4. **IPv6 not broken**: if a genuine IPv6 remoteserver is running on `[::1]:39920`,
+   `rdc open frame.rdc --proxy [::1]:39920` still connects (literal `::1` is
+   not normalized).
+5. **`rdc remote connect localhost:39920`** succeeds; `rdc remote status` shows
+   host `127.0.0.1`; `~/.rdc/remote/127.0.0.1_39920.json` exists (not
+   `localhost_39920.json`).
+
+(Steps 1-3 directly reproduce and verify the reported real-GPU issue.)

--- a/src/rdc/capture_core.py
+++ b/src/rdc/capture_core.py
@@ -97,10 +97,10 @@ def _discover_latest_target(rd: Any, timeout: float = 5.0) -> int:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         latest = 0
-        ident = rd.EnumerateRemoteTargets("localhost", 0)
+        ident = rd.EnumerateRemoteTargets("127.0.0.1", 0)
         while ident != 0:
             latest = ident
-            ident = rd.EnumerateRemoteTargets("localhost", ident)
+            ident = rd.EnumerateRemoteTargets("127.0.0.1", ident)
         if latest != 0:
             return latest
         time.sleep(0.25)

--- a/src/rdc/commands/android.py
+++ b/src/rdc/commands/android.py
@@ -336,7 +336,7 @@ def android_setup_cmd(serial: str | None, use_json: bool) -> None:
     conn_url = url
     forwarded_port = _get_forwarded_port(serial, url)
     if forwarded_port is not None:
-        conn_url = f"localhost:{forwarded_port}"
+        conn_url = f"127.0.0.1:{forwarded_port}"
 
     try:
         remote = connect_remote_server(rd, conn_url)
@@ -461,7 +461,7 @@ def android_capture_cmd(
     local_port = _forward_target_control(device_serial, port)
 
     # Connect via target control
-    tc = rd.CreateTargetControl("localhost", local_port, "rdc-cli", True)
+    tc = rd.CreateTargetControl("127.0.0.1", local_port, "rdc-cli", True)
     if tc is None:
         click.echo("error: failed to connect to target control", err=True)
         _clear_gpu_debug_layers(device_serial)

--- a/src/rdc/commands/capture_control.py
+++ b/src/rdc/commands/capture_control.py
@@ -11,6 +11,7 @@ from typing import Any
 import click
 
 from rdc.commands._helpers import require_renderdoc
+from rdc.remote_core import _normalize_remote_host
 from rdc.target_state import (
     TargetControlState,
     load_latest_target_state,
@@ -31,6 +32,7 @@ def _resolve_ident(ident: int | None) -> int:
 
 def _connect(rd: Any, host: str, ident: int) -> Any:
     """Create a TargetControl connection, exit on failure."""
+    host = _normalize_remote_host(host)
     tc = rd.CreateTargetControl(host, ident, "rdc-cli", True)
     if tc is None:
         click.echo(f"error: failed to connect to target ident={ident}", err=True)

--- a/src/rdc/daemon_server.py
+++ b/src/rdc/daemon_server.py
@@ -556,6 +556,16 @@ def _load_remote_replay(state: DaemonState, remote_url: str) -> str | None:
     """
     from rdc.discover import find_renderdoc
 
+    # Normalize a literal localhost host portion to 127.0.0.1: the RenderDoc
+    # remote protocol is IPv4-only, but localhost resolves to ::1 first on
+    # dual-stack hosts, stalling forever. Plain string check leaves protocol
+    # URLs (adb://...), bracketed IPv6, and real hostnames untouched.
+    if remote_url.lower() == "localhost" or remote_url.lower().startswith("localhost:"):
+        remote_url = "127.0.0.1" + remote_url[len("localhost") :]
+        _log.debug(
+            "normalizing 'localhost' -> '127.0.0.1' (RenderDoc remote protocol is IPv4-only)"
+        )
+
     rd = find_renderdoc()
     if rd is None:
         return "failed to import renderdoc module"

--- a/src/rdc/remote_core.py
+++ b/src/rdc/remote_core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 import shutil
 from typing import Any
@@ -30,13 +31,36 @@ _PRIVATE_NETS = (
 DEFAULT_PORT = 39920
 
 
+def _normalize_remote_host(host: str) -> str:
+    """Map the literal ``localhost`` (case-insensitive) to ``127.0.0.1``.
+
+    The RenderDoc remote protocol is IPv4-only: ``renderdoccmd remoteserver``
+    binds ``0.0.0.0`` and never listens on ``::1``, but ``localhost`` resolves
+    to ``::1`` first on dual-stack hosts, causing a silent indefinite stall.
+    Everything else (``::1`` literals, IPv6 addresses, real hostnames) is
+    returned unchanged.
+    """
+    if host.lower() == "localhost":
+        logging.getLogger(__name__).debug(
+            "normalizing 'localhost' -> '127.0.0.1' (RenderDoc remote protocol is IPv4-only)"
+        )
+        return "127.0.0.1"
+    return host
+
+
 def is_protocol_url(url: str) -> bool:
     """Return True if url is a device protocol URL (e.g. adb://SERIAL)."""
     return "://" in url
 
 
 def build_conn_url(host: str, port: int) -> str:
-    """Build connection URL, re-bracketing IPv6 addresses."""
+    """Build connection URL, re-bracketing IPv6 addresses.
+
+    Normalizes ``localhost`` here too, so hosts loaded from pre-fix state files
+    (``_resolve_url`` -> ``load_latest_remote_state``) and split-mode daemon
+    handlers cannot escape IPv4 normalization.
+    """
+    host = _normalize_remote_host(host)
     if ":" in host:
         return f"[{host}]:{port}"
     return f"{host}:{port}"
@@ -85,8 +109,8 @@ def parse_url(url: str) -> tuple[str, int]:
             raise ValueError(f"invalid port: {port_str!r}") from None
         if not (1 <= port <= 65535):
             raise ValueError(f"invalid port: {port_str!r}")
-        return host, port
-    return url, DEFAULT_PORT
+        return _normalize_remote_host(host), port
+    return _normalize_remote_host(url), DEFAULT_PORT
 
 
 def connect_remote_server(rd: Any, url: str) -> Any:

--- a/tests/unit/test_android_commands.py
+++ b/tests/unit/test_android_commands.py
@@ -322,7 +322,7 @@ class TestGetForwardedPort:
             lambda s, u: 12345,
         )
         CliRunner().invoke(android_setup_cmd, [])
-        rd.CreateRemoteServerConnection.assert_called_once_with("localhost:12345")
+        rd.CreateRemoteServerConnection.assert_called_once_with("127.0.0.1:12345")
 
     def test_setup_falls_back_to_adb_url(
         self,
@@ -560,6 +560,18 @@ class TestAndroidCapture:
             ["com.example.app/.MainActivity", "-o", str(out)],
         )
         assert result.exit_code == 0
+
+    def test_target_control_uses_ipv4(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        mock_rd = self._setup_capture_mocks(monkeypatch)
+        out = tmp_path / "out.rdc"
+        result = CliRunner().invoke(
+            android_capture_cmd,
+            ["com.example.app/.MainActivity", "-o", str(out)],
+        )
+        assert result.exit_code == 0
+        assert mock_rd.CreateTargetControl.call_args[0][0] == "127.0.0.1"
 
     def test_json_output(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         self._setup_capture_mocks(monkeypatch)

--- a/tests/unit/test_capture_control.py
+++ b/tests/unit/test_capture_control.py
@@ -95,6 +95,39 @@ def test_attach_connection_failed(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "error" in result.output.lower() or "error" in (result.stderr or "").lower()
 
 
+# --- localhost -> 127.0.0.1 normalization (RenderDoc remote protocol is IPv4-only) ---
+
+
+def test_attach_host_default_normalized(monkeypatch: pytest.MonkeyPatch) -> None:
+    tc = _make_mock_tc()
+    rd = _make_mock_rd(tc)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
+
+    result = CliRunner().invoke(attach_cmd, ["12345"])
+    assert result.exit_code == 0
+    assert rd.CreateTargetControl.call_args.args[0] == "127.0.0.1"
+
+
+def test_attach_host_explicit_localhost_normalized(monkeypatch: pytest.MonkeyPatch) -> None:
+    tc = _make_mock_tc()
+    rd = _make_mock_rd(tc)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
+
+    result = CliRunner().invoke(attach_cmd, ["12345", "--host", "LOCALHOST"])
+    assert result.exit_code == 0
+    assert rd.CreateTargetControl.call_args.args[0] == "127.0.0.1"
+
+
+def test_attach_host_non_localhost_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    tc = _make_mock_tc()
+    rd = _make_mock_rd(tc)
+    monkeypatch.setattr("rdc.commands._helpers.find_renderdoc", lambda: rd)
+
+    result = CliRunner().invoke(attach_cmd, ["12345", "--host", "192.168.1.50"])
+    assert result.exit_code == 0
+    assert rd.CreateTargetControl.call_args.args[0] == "192.168.1.50"
+
+
 # --- capture-trigger ---
 
 

--- a/tests/unit/test_capture_core.py
+++ b/tests/unit/test_capture_core.py
@@ -329,6 +329,20 @@ class TestDiscoverLatestTarget:
         rd = SimpleNamespace(EnumerateRemoteTargets=lambda _host, prev: next(targets))
         assert _discover_latest_target(rd, timeout=1.0) == 42
 
+    def test_enumerate_uses_ipv4_host(self) -> None:
+        from rdc.capture_core import _discover_latest_target
+
+        seen: list[str] = []
+        targets = iter([7, 0])
+
+        def _enum(host: str, prev: int) -> int:
+            seen.append(host)
+            return next(targets)
+
+        rd = SimpleNamespace(EnumerateRemoteTargets=_enum)
+        assert _discover_latest_target(rd, timeout=1.0) == 7
+        assert seen and all(h == "127.0.0.1" for h in seen)
+
 
 class TestIdentZeroFallback:
     """Regression: ExecuteAndInject returns ident=0 but target is discoverable."""

--- a/tests/unit/test_daemon_server_unit.py
+++ b/tests/unit/test_daemon_server_unit.py
@@ -390,6 +390,44 @@ class TestMatchCaptureGpu:
         assert captured.get("sd") is not None
         assert captured.get("rd") is mock_rd
 
+    def test_remote_replay_normalizes_localhost(self, monkeypatch: Any) -> None:
+        """localhost:PORT reaches CreateRemoteServerConnection as 127.0.0.1:PORT."""
+        import mock_renderdoc as mock_rd
+
+        captured_url: dict[str, str] = {}
+
+        remote = SimpleNamespace(
+            CopyCaptureToRemote=lambda path, cb: path,
+            CopyCaptureFromRemote=lambda path, dst, cb: None,
+            OpenCapture=lambda pref, path, opts, cb: (mock_rd.ResultCode.InternalError, None),
+            ShutdownConnection=lambda: None,
+            Ping=lambda: None,
+        )
+
+        def _create_remote(url: str) -> tuple[Any, Any]:
+            captured_url["url"] = url
+            return mock_rd.ResultCode.Succeeded, remote
+
+        monkeypatch.setattr(mock_rd, "CreateRemoteServerConnection", _create_remote, raising=False)
+        monkeypatch.setattr("rdc.daemon_server._match_capture_gpu", lambda *a, **k: None)
+
+        cap_path = Path("test.rdc")
+        cap_path.write_bytes(b"\x00")
+        try:
+            sys.modules["renderdoc"] = mock_rd  # type: ignore[assignment]
+            try:
+                from rdc.daemon_server import _load_remote_replay
+
+                state = DaemonState(capture=str(cap_path), current_eid=0, token="tok")
+                _load_remote_replay(state, "localhost:39920")
+            finally:
+                sys.modules.pop("renderdoc", None)
+        finally:
+            cap_path.unlink(missing_ok=True)
+
+        assert captured_url["url"] == "127.0.0.1:39920"
+        assert state.remote_url == "127.0.0.1:39920"
+
 
 class TestFix225D3D12ChunkNameAndDeviceId:
     """#225 fix-forward: real chunk name, depth-3 walk, exact DeviceId match.

--- a/tests/unit/test_remote_core.py
+++ b/tests/unit/test_remote_core.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from rdc.remote_core import (
+    _normalize_remote_host,
     build_conn_url,
     connect_remote_server,
     enumerate_remote_targets,
@@ -19,6 +20,29 @@ from rdc.remote_core import (
 )
 
 
+class TestNormalizeRemoteHost:
+    def test_localhost(self) -> None:
+        assert _normalize_remote_host("localhost") == "127.0.0.1"
+
+    def test_localhost_upper(self) -> None:
+        assert _normalize_remote_host("LOCALHOST") == "127.0.0.1"
+
+    def test_localhost_mixed_case(self) -> None:
+        assert _normalize_remote_host("Localhost") == "127.0.0.1"
+
+    def test_ipv4_unchanged(self) -> None:
+        assert _normalize_remote_host("127.0.0.1") == "127.0.0.1"
+
+    def test_private_ipv4_unchanged(self) -> None:
+        assert _normalize_remote_host("192.168.1.5") == "192.168.1.5"
+
+    def test_ipv6_loopback_unchanged(self) -> None:
+        assert _normalize_remote_host("::1") == "::1"
+
+    def test_hostname_unchanged(self) -> None:
+        assert _normalize_remote_host("myserver.local") == "myserver.local"
+
+
 class TestParseUrl:
     def test_host_only(self) -> None:
         assert parse_url("192.168.1.10") == ("192.168.1.10", 39920)
@@ -27,7 +51,10 @@ class TestParseUrl:
         assert parse_url("192.168.1.10:12345") == ("192.168.1.10", 12345)
 
     def test_localhost(self) -> None:
-        assert parse_url("localhost") == ("localhost", 39920)
+        assert parse_url("localhost") == ("127.0.0.1", 39920)
+
+    def test_localhost_with_port(self) -> None:
+        assert parse_url("localhost:39920") == ("127.0.0.1", 39920)
 
     def test_ipv6_brackets(self) -> None:
         assert parse_url("[::1]:39920") == ("::1", 39920)
@@ -72,14 +99,28 @@ class TestBuildConnUrl:
     def test_ipv4(self) -> None:
         assert build_conn_url("192.168.1.1", 39920) == "192.168.1.1:39920"
 
-    def test_hostname(self) -> None:
-        assert build_conn_url("localhost", 39920) == "localhost:39920"
+    def test_ipv4_localhost_unchanged(self) -> None:
+        assert build_conn_url("127.0.0.1", 39920) == "127.0.0.1:39920"
+
+    def test_localhost_normalized(self) -> None:
+        assert build_conn_url("localhost", 39920) == "127.0.0.1:39920"
 
     def test_ipv6_re_brackets(self) -> None:
         assert build_conn_url("::1", 39920) == "[::1]:39920"
 
     def test_ipv6_long(self) -> None:
         assert build_conn_url("2001:db8::1", 8080) == "[2001:db8::1]:8080"
+
+
+class TestStateKeyConsistency:
+    def test_parsed_localhost_keys_on_ipv4(self) -> None:
+        from rdc.remote_state import _state_path
+
+        host, port = parse_url("localhost:39920")
+        assert (host, port) == ("127.0.0.1", 39920)
+        path = _state_path(host, port)
+        assert path.name == "127.0.0.1_39920.json"
+        assert "localhost" not in str(path)
 
 
 class TestWarnIfPublic:


### PR DESCRIPTION
## Summary

`rdc open <capture> --proxy localhost:39920` stalled indefinitely at `uploading: 0%` on dual-stack hosts: `localhost` resolves to `::1` (IPv6) first, while `renderdoccmd remoteserver` binds IPv4 only (verified via `ss -tlnp`: listener on `0.0.0.0:39920`, none on `::1`). RenderDoc's native connection layer does not fall back to IPv4, so the upload never progresses and there is no error.

This change normalizes the literal hostname `localhost` (case-insensitive) to `127.0.0.1` everywhere a host string reaches a RenderDoc remote API.

## Seams covered

- `_normalize_remote_host` helper in `remote_core.py`, applied in `parse_url` and `build_conn_url` (the latter also closes a saved-state path: a stale `localhost_<port>.json` written by an older version would otherwise resurrect the un-normalized host through `rdc remote list/capture`).
- `daemon_server._load_remote_replay` normalizes the incoming `--remote-url` up front (with an `adb://` guard), so both `CreateRemoteServerConnection` and the `rdc status` display use the normalized value.
- Hardcoded `"localhost"` literals replaced in `android.py` (remote-server connect, `CreateTargetControl`) and `capture_core.py` (`EnumerateRemoteTargets`).
- `capture_control._connect` normalizes `--host` for `attach`/`capture-trigger`/`capture-list`/`capture-copy` (review-found gap; covers the default and explicit `--host localhost`).

Untouched by design: `::1` and bracketed IPv6 literals, real hostnames (`mylocalhost`, `localhost.example.com`), `adb://` URLs, and split-mode `--connect` (Python's `socket.create_connection` iterates getaddrinfo with immediate ECONNREFUSED fallback, so it does not stall).

## Testing

- 19 unit test additions/updates across `test_remote_core.py`, `test_daemon_server_unit.py`, `test_android_commands.py`, `test_capture_core.py`, `test_capture_control.py` — asserting the host actually passed to the (mocked) RenderDoc APIs, plus an 8-case normalization boundary matrix (`LOCALHOST`, `mylocalhost`, `localhost.example.com`, `[::1]`, etc.).
- Real-GPU verification (AMD RX 7600, RADV): pre-fix base reproduces the `uploading: 0%` stall with `--proxy localhost:39920`; with this fix the same command opens the session, `rdc status` shows `127.0.0.1:39920`, remote draws and depth export work end-to-end; explicit `--proxy 127.0.0.1` unchanged; no `localhost_*.json` state ghost created.
- Full suite: 2992 passed; ruff + mypy strict clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `rdc` hanging when using proxy URLs with `localhost` (e.g., `localhost:39920`) on dual-stack hosts by normalizing `localhost` to `127.0.0.1` for IPv4 loopback resolution.

* **Tests**
  * Added comprehensive unit tests verifying localhost normalization across proxy connections, remote URL parsing, daemon server handling, and capture control paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->