### PR TITLE
chore: remove dead request builders, recv_binary, and query_both_sync

### DIFF
--- a/src/rdc/_transport.py
+++ b/src/rdc/_transport.py
@@ -33,24 +33,3 @@ def recv_line(sock: socket.socket, max_bytes: int = 256 * 1024 * 1024) -> str:
     if not chunks:
         return ""
     return b"".join(chunks).split(b"\n", 1)[0].decode("utf-8")
-
-
-def recv_binary(sock: socket.socket, size: int) -> bytes:
-    """Read exactly *size* bytes from a socket.
-
-    Raises:
-        OSError: If the connection closes before *size* bytes are received.
-    """
-    if size < 0:
-        raise ValueError("size must be >= 0")
-    if size == 0:
-        return b""
-    chunks: list[bytes] = []
-    remaining = size
-    while remaining > 0:
-        chunk = sock.recv(min(remaining, 65536))
-        if not chunk:
-            raise OSError("connection closed before all binary data received")
-        chunks.append(chunk)
-        remaining -= len(chunk)
-    return b"".join(chunks)

--- a/src/rdc/protocol.py
+++ b/src/rdc/protocol.py
@@ -42,20 +42,3 @@ def goto_request(token: str, eid: int, request_id: int = 1) -> dict[str, Any]:
 
 def shutdown_request(token: str, request_id: int = 1) -> dict[str, Any]:
     return _request("shutdown", request_id, {"_token": token}).to_dict()
-
-
-def count_request(
-    token: str,
-    what: str,
-    *,
-    pass_name: str | None = None,
-    request_id: int = 1,
-) -> dict[str, Any]:
-    params: dict[str, Any] = {"_token": token, "what": what}
-    if pass_name is not None:
-        params["pass"] = pass_name
-    return _request("count", request_id, params).to_dict()
-
-
-def shader_map_request(token: str, request_id: int = 1) -> dict[str, Any]:
-    return _request("shader_map", request_id, {"_token": token}).to_dict()

--- a/src/rdc/services/diff_service.py
+++ b/src/rdc/services/diff_service.py
@@ -180,45 +180,6 @@ def query_both(
     return out[0], out[1], err
 
 
-def query_both_sync(
-    ctx: DiffContext,
-    calls: list[tuple[str, dict[str, Any]]],
-    *,
-    timeout_s: float = 30.0,
-) -> tuple[list[dict[str, Any] | None], list[dict[str, Any] | None], str]:
-    """Batch variant: send N calls to both daemons (2N threads).
-
-    Returns:
-        (results_a, results_b, error_string). Order matches input calls.
-    """
-    n = len(calls)
-    out_a: list[dict[str, Any] | None] = [None] * n
-    out_b: list[dict[str, Any] | None] = [None] * n
-    threads: list[threading.Thread] = []
-
-    for i, (method, params) in enumerate(calls):
-        t_a = threading.Thread(
-            target=_do_query,
-            args=(ctx.host, ctx.port_a, ctx.token_a, method, params, timeout_s, out_a, i),
-            daemon=True,
-        )
-        t_b = threading.Thread(
-            target=_do_query,
-            args=(ctx.host, ctx.port_b, ctx.token_b, method, params, timeout_s, out_b, i),
-            daemon=True,
-        )
-        threads.extend([t_a, t_b])
-
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-
-    all_none = n > 0 and all(r is None for r in out_a) and all(r is None for r in out_b)
-    err = "all queries failed" if all_none else ""
-    return out_a, out_b, err
-
-
 def query_each_sync(
     ctx: DiffContext,
     calls_a: list[tuple[str, dict[str, Any]]],
@@ -228,8 +189,7 @@ def query_each_sync(
 ) -> tuple[list[dict[str, Any] | None], list[dict[str, Any] | None], str]:
     """Send N calls to daemon A and M calls to daemon B concurrently.
 
-    Unlike ``query_both_sync`` which sends identical calls to both daemons,
-    this variant accepts separate call lists (e.g. different EIDs per side).
+    Accepts separate call lists per side (e.g. different EIDs per daemon).
 
     Returns:
         (results_a, results_b, error_string). Order matches input call lists.

--- a/tests/unit/test_diff_service.py
+++ b/tests/unit/test_diff_service.py
@@ -8,7 +8,6 @@ from rdc.services import diff_service
 from rdc.services.diff_service import (
     DiffContext,
     query_both,
-    query_both_sync,
     start_diff_session,
     stop_diff_session,
 )
@@ -360,40 +359,3 @@ def test_query_both_both_fail(monkeypatch: pytest.MonkeyPatch) -> None:
     assert ra is None
     assert rb is None
     assert err != ""
-
-
-# ---------------------------------------------------------------------------
-# #22–23  query_both_sync
-# ---------------------------------------------------------------------------
-
-
-def test_query_both_sync_ordering(monkeypatch: pytest.MonkeyPatch) -> None:
-    def mock_send(host: str, port: int, payload: dict, **kw: object) -> dict:
-        method = payload["method"]
-        return {"result": {"method": method, "port": port}}
-
-    monkeypatch.setattr(diff_service, "send_request", mock_send)
-
-    calls = [("m1", {"x": 1}), ("m2", {"x": 2})]
-    ra_list, rb_list, err = query_both_sync(_make_ctx(), calls)
-    assert err == ""
-    assert ra_list[0] is not None and ra_list[0]["result"]["method"] == "m1"
-    assert ra_list[1] is not None and ra_list[1]["result"]["method"] == "m2"
-    assert rb_list[0] is not None and rb_list[0]["result"]["method"] == "m1"
-    assert rb_list[1] is not None and rb_list[1]["result"]["method"] == "m2"
-
-
-def test_query_both_sync_partial_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    def mock_send(host: str, port: int, payload: dict, **kw: object) -> dict:
-        if port == 5000 and payload["method"] == "m2":
-            raise ConnectionRefusedError
-        return {"result": {"ok": True}}
-
-    monkeypatch.setattr(diff_service, "send_request", mock_send)
-
-    calls = [("m1", {}), ("m2", {})]
-    ra_list, rb_list, err = query_both_sync(_make_ctx(), calls)
-    assert ra_list[0] is not None
-    assert ra_list[1] is None
-    assert rb_list[0] is not None
-    assert rb_list[1] is not None

--- a/tests/unit/test_split_binary.py
+++ b/tests/unit/test_split_binary.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock
 import pytest
 from click.testing import CliRunner
 
-from rdc._transport import recv_binary
 from rdc.commands import _helpers as helpers_mod
 from rdc.commands.export import rt_cmd
 from rdc.commands.snapshot import snapshot_cmd
@@ -42,38 +41,6 @@ def _make_state(tmp_path: Path | None = None) -> Any:
     state.temp_dir = tmp_path
     state.token = "tok"
     return state
-
-
-# ===========================================================================
-# T1: recv_binary
-# ===========================================================================
-
-
-class TestRecvBinary:
-    def test_exact_read(self) -> None:
-        """T1.1: Read exactly N bytes in one chunk."""
-        sock = MagicMock()
-        sock.recv.return_value = b"hello"
-        assert recv_binary(sock, 5) == b"hello"
-
-    def test_partial_reads(self) -> None:
-        """T1.2: Multiple small chunks summing to N."""
-        sock = MagicMock()
-        sock.recv.side_effect = [b"he", b"ll", b"o"]
-        assert recv_binary(sock, 5) == b"hello"
-
-    def test_premature_eof(self) -> None:
-        """T1.3: Socket closes before N bytes."""
-        sock = MagicMock()
-        sock.recv.side_effect = [b"he", b""]
-        with pytest.raises(OSError, match="connection closed"):
-            recv_binary(sock, 5)
-
-    def test_zero_bytes(self) -> None:
-        """T1.4: Zero size returns empty bytes without reading."""
-        sock = MagicMock()
-        assert recv_binary(sock, 0) == b""
-        sock.recv.assert_not_called()
 
 
 # ===========================================================================


### PR DESCRIPTION
Removes four verified-dead symbols and their orphaned tests:

- `protocol.count_request`, `protocol.shader_map_request` (no callers; the wire-level `count`/`shader_map` RPCs go through the generic `call()` path and are unaffected)
- `_transport.recv_binary` (no callers; `send_request_binary` inlines the same logic)
- `diff_service.query_both_sync` (~37 lines, referenced only by its own tests) + fixes the stale docstring cross-reference in `query_each_sync`

Net 1 insertion / 150 deletions. lint + mypy + unit suite (2986 passed) green.