### PR TITLE
fix(diff): emit event_count from stats RPC so summary events delta is real

### DIFF
--- a/src/rdc/handlers/query.py
+++ b/src/rdc/handlers/query.py
@@ -410,7 +410,13 @@ def _handle_stats(
     largest = largest[:5]
 
     return _result_response(
-        request_id, {"per_pass": per_pass, "top_draws": top_draws, "largest_resources": largest}
+        request_id,
+        {
+            "per_pass": per_pass,
+            "top_draws": top_draws,
+            "largest_resources": largest,
+            "event_count": state.max_eid,
+        },
     ), True
 
 

--- a/tests/e2e/test_diff.py
+++ b/tests/e2e/test_diff.py
@@ -8,6 +8,7 @@ available.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -129,3 +130,27 @@ class TestDiffVkcubeVsTriangle:
         assert "STATUS" in combined or "status" in combined.lower()
         assert "NAME" in combined or "name" in combined.lower()
         assert "TYPE" in combined or "type" in combined.lower()
+
+    def test_summary_events_delta_nonzero(self, vkcube_session: str) -> None:
+        """``rdc diff VKCUBE HELLO_TRIANGLE`` summary reports a real, non-zero events delta.
+
+        Two captures with different event spans must not show ``events: N -> N (=)``.
+        Regression for the stats RPC omitting event_count (summary events stuck at 0->0).
+        """
+        r = rdc(
+            "diff",
+            str(VKCUBE),
+            str(HELLO_TRIANGLE),
+            "--json",
+            session=vkcube_session,
+        )
+        assert r.returncode == 1, (
+            f"Expected exit 1 (captures differ):\nstdout: {r.stdout}\nstderr: {r.stderr}"
+        )
+        data = json.loads(r.stdout)
+        events = data["events"]
+        assert events["a"] > 0
+        assert events["b"] > 0
+        assert events["a"] != events["b"]
+        assert events["delta"] == events["b"] - events["a"]
+        assert events["delta"] != 0

--- a/tests/unit/test_diff_command.py
+++ b/tests/unit/test_diff_command.py
@@ -51,9 +51,17 @@ def _stats_resp(
     per_pass: list[dict[str, object]] | None = None,
     event_count: int = 100,
 ) -> dict[str, Any]:
+    """Mirror the real stats RPC envelope (handlers.query._handle_stats)."""
     if per_pass is None:
         per_pass = [{"name": "GBuffer", "draws": 10, "triangles": 5000, "dispatches": 0}]
-    return {"result": {"per_pass": per_pass, "event_count": event_count, "top_draws": []}}
+    return {
+        "result": {
+            "per_pass": per_pass,
+            "top_draws": [],
+            "largest_resources": [],
+            "event_count": event_count,
+        }
+    }
 
 
 def _resources_resp(
@@ -505,6 +513,27 @@ class TestDiffSummaryCLI:
         result = CliRunner().invoke(diff_cmd, [str(a), str(b)])
         assert result.exit_code == 1
         assert "draws:" in result.output
+
+    def test_summary_events_differ_exit_1(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """C-21: identical draws/passes/resources but differing event spans exits 1.
+
+        Regression for the permanently 0->0 events row: the stats RPC must carry a real
+        event_count so the summary surfaces a non-zero events delta.
+        """
+        a, b = tmp_path / "a.rdc", tmp_path / "b.rdc"
+        a.touch()
+        b.touch()
+        per_pass = [{"name": "GBuffer", "draws": 10, "triangles": 5000, "dispatches": 0}]
+        sa = _stats_resp(per_pass, event_count=100)
+        sb = _stats_resp(per_pass, event_count=150)
+        _patch_summary(monkeypatch, sa, sb)
+        result = CliRunner().invoke(diff_cmd, [str(a), str(b)])
+        assert result.exit_code == 1
+        assert "events:" in result.output
+        assert "100 -> 150" in result.output
+        assert "(+50)" in result.output
 
     def test_summary_json(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """C-19: no flag --json produces valid JSON with four keys."""

--- a/tests/unit/test_diff_summary.py
+++ b/tests/unit/test_diff_summary.py
@@ -8,7 +8,13 @@ from rdc.diff.summary import SummaryRow, diff_summary, render_json, render_text
 
 
 def _stats(per_pass: list[dict[str, object]], event_count: int = 0) -> dict[str, object]:
-    return {"per_pass": per_pass, "event_count": event_count}
+    """Mirror the real stats RPC result shape (handlers.query._handle_stats)."""
+    return {
+        "per_pass": per_pass,
+        "top_draws": [],
+        "largest_resources": [],
+        "event_count": event_count,
+    }
 
 
 def _pass(
@@ -67,6 +73,18 @@ class TestDiffSummary:
         rows = diff_summary(s, s, 0, 0)
         assert all(r.delta == 0 for r in rows)
         assert all(r.value_a == 0 and r.value_b == 0 for r in rows)
+
+    def test_event_count_delta_when_spans_differ(self) -> None:
+        """S-15: identical draws/passes/resources but differing event spans yield events delta."""
+        sa = _stats([_pass(draws=10)], event_count=100)
+        sb = _stats([_pass(draws=10)], event_count=150)
+        rows = diff_summary(sa, sb, 5, 5)
+        events_row = next(r for r in rows if r.category == "events")
+        assert events_row.value_a == 100
+        assert events_row.value_b == 150
+        assert events_row.delta == 50
+        # only the events category changed
+        assert sum(1 for r in rows if r.delta != 0) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_stats_event_count.py
+++ b/tests/unit/test_stats_event_count.py
@@ -1,0 +1,39 @@
+"""Regression test: stats RPC must emit event_count (drives diff summary 'events')."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import mock_renderdoc as rd
+from conftest import make_daemon_state, rpc_request
+
+from rdc.daemon_server import _handle_request
+
+
+def _make_state(max_eid: int) -> Any:
+    ctrl = rd.MockReplayController()
+    ctrl._actions = []
+    return make_daemon_state(
+        capture="x.rdc",
+        ctrl=ctrl,
+        structured_file=SimpleNamespace(chunks=[]),
+        max_eid=max_eid,
+    )
+
+
+def test_stats_result_carries_event_count() -> None:
+    """The stats RPC result includes event_count equal to state.max_eid."""
+    state = _make_state(max_eid=137)
+    resp, _ = _handle_request(rpc_request("stats"), state)
+    result = resp["result"]
+    assert "event_count" in result, "stats RPC must emit event_count"
+    assert result["event_count"] == 137
+
+
+def test_stats_event_count_matches_status_rpc() -> None:
+    """stats and status report the same event_count (both = max_eid)."""
+    state = _make_state(max_eid=42)
+    stats_resp, _ = _handle_request(rpc_request("stats"), state)
+    status_resp, _ = _handle_request(rpc_request("status"), state)
+    assert stats_resp["result"]["event_count"] == status_resp["result"]["event_count"] == 42


### PR DESCRIPTION
The `rdc diff` summary "events" row was permanently 0 to 0: `diff/summary.py` reads `event_count` from the stats RPC result, but `_handle_stats` never emitted it (the value lived only in the status RPC).

Adds `event_count: state.max_eid` (already computed at load) to the stats RPC result. De-fabricates the two test fixtures that were masking the bug and adds a handler-level regression test plus a gpu-marked e2e diff test.

Behavior change: diffs of captures with differing event spans now report a real delta and exit 1. Unit suite 2996 passed.