### PR TITLE
build: add renderdoc pin-consistency test locking RDOC_TAG/SWIG_SHA256 to a single source

### DIFF
--- a/tests/unit/test_tooling_files.py
+++ b/tests/unit/test_tooling_files.py
@@ -6,6 +6,28 @@ from pathlib import Path
 
 import pytest
 
+from rdc._build_renderdoc import RDOC_TAG, SWIG_SHA256
+
+# Build files that pin the renderdoc git tag.
+_RENDERDOC_TAG_FILES = (
+    "src/rdc/_build_renderdoc.py",
+    "docker/Dockerfile",
+    "aur/PKGBUILD",
+    "aur/stable/PKGBUILD",
+    "scripts/build-renderdoc.sh",
+    "scripts/setup-renderdoc.sh",
+)
+
+# Build files that fetch and sha256-verify the SWIG fork archive.
+# Excludes docker/Dockerfile (does not fetch the SWIG fork) and
+# scripts/setup-renderdoc.sh (fetches but does not verify a sha256).
+_SWIG_SHA_FILES = (
+    "src/rdc/_build_renderdoc.py",
+    "aur/PKGBUILD",
+    "aur/stable/PKGBUILD",
+    "scripts/build-renderdoc.sh",
+)
+
 
 @pytest.mark.skipif(sys.platform == "win32", reason="bash not available on Windows CI")
 def test_build_renderdoc_script_syntax() -> None:
@@ -33,3 +55,19 @@ def test_dockerfile_exists() -> None:
     assert path.exists()
     text = path.read_text()
     assert "uv/install.sh" in text
+
+
+def test_renderdoc_pin_consistency() -> None:
+    """Lock the renderdoc tag and SWIG sha to a single source of truth.
+
+    ``_build_renderdoc.py`` is the canonical pin. Every build file that
+    references renderdoc must use the same ``RDOC_TAG``, and every file that
+    fetches the SWIG fork archive must use the same ``SWIG_SHA256``.
+    """
+    for rel in _RENDERDOC_TAG_FILES:
+        text = Path(rel).read_text()
+        assert RDOC_TAG in text, f"{rel} does not pin renderdoc tag {RDOC_TAG}"
+
+    for rel in _SWIG_SHA_FILES:
+        text = Path(rel).read_text()
+        assert SWIG_SHA256 in text, f"{rel} does not pin SWIG sha256 {SWIG_SHA256}"


### PR DESCRIPTION
`_build_renderdoc.py` already defines `RDOC_TAG` and `SWIG_SHA256` constants, but six build definitions (Dockerfile, both PKGBUILDs, two shell scripts) hard-code the same values with nothing to keep them in sync.

Adds `test_renderdoc_pin_consistency` asserting every renderdoc-referencing build file pins the same `RDOC_TAG`, and every SWIG-fetching file pins the same `SWIG_SHA256`. Two documented exclusions: `docker/Dockerfile` does not fetch the SWIG fork, and `scripts/setup-renderdoc.sh` fetches without sha verification. Test-only, no build-behavior change. Unit suite 2993 passed.

Held for a follow-up (needs a real docker build to validate): the Dockerfile not building the SWIG fork at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests to ensure build configuration files maintain consistent version pinning across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->