### PR TITLE
Fix Windows Vulkan capture launch environment

### DIFF
--- a/src/rdc/capture_core.py
+++ b/src/rdc/capture_core.py
@@ -118,6 +118,35 @@ def _get_pid_for_ident(rd: Any, ident: int) -> int:
         tc.Shutdown()
 
 
+def _make_env_mod(rd: Any, name: str, value: str) -> Any:
+    """Create a RenderDoc EnvironmentModification with Set/NoSep semantics."""
+    mod = rd.EnvironmentModification()
+    mod.name = name
+    mod.value = value
+    mod.mod = rd.EnvMod.Set
+    mod.sep = rd.EnvSep.NoSep
+    return mod
+
+
+def _build_launch_env(rd: Any) -> list[Any]:
+    """Build environment modifications for a reliable local capture launch."""
+    if sys.platform != "win32":
+        return []
+
+    module_path = getattr(rd, "__file__", None)
+    if not module_path:
+        return []
+
+    renderdoc_dir = Path(module_path).resolve().parent
+    if not (renderdoc_dir / "renderdoc.json").is_file():
+        return []
+
+    return [
+        _make_env_mod(rd, "ENABLE_VULKAN_RENDERDOC_CAPTURE", "1"),
+        _make_env_mod(rd, "VK_IMPLICIT_LAYER_PATH", str(renderdoc_dir)),
+    ]
+
+
 def _inject_failure_hint() -> str:
     if sys.platform == "darwin":
         return (
@@ -187,7 +216,8 @@ def execute_and_capture(
         app = str(app_path.resolve())
 
     _inj_hint = _inject_failure_hint()
-    result = rd.ExecuteAndInject(app, workdir or "", args, [], output, opts, wait_for_exit)
+    env_mods = _build_launch_env(rd)
+    result = rd.ExecuteAndInject(app, workdir or "", args, env_mods, output, opts, wait_for_exit)
     if result.result != 0:
         return CaptureResult(error=f"inject failed (code {result.result}) -- hint: {_inj_hint}")
 


### PR DESCRIPTION
## Summary

Fix Windows local Vulkan captures launched through the Python RenderDoc API by passing RenderDoc environment modifications to `ExecuteAndInject`.

When `rdc capture` launches a Vulkan target on Windows, the target process needs to load the RenderDoc Vulkan capture layer that belongs to the same RenderDoc installation as the Python module. Without an explicit launch environment, the Vulkan loader can select a different globally registered `VK_LAYER_RENDERDOC_Capture` layer or fail to enable the expected layer. In that case target control can connect, but the target never registers a Vulkan API and capture waits until the process exits.

This change sets, when running on Windows and a sibling `renderdoc.json` exists next to the loaded `renderdoc` module:

- `ENABLE_VULKAN_RENDERDOC_CAPTURE=1`
- `VK_IMPLICIT_LAYER_PATH=<renderdoc module directory>`

The behavior is scoped to Windows local launches and leaves other platforms unchanged.

## Verification

- `uv run --with ruff ruff check src\rdc\capture_core.py`
- Manual Windows Vulkan smoke using a local SDL/Vulkan triangle target:
  - `rdc capture --timeout 30 -o ... -- VulkanTriangle.exe --frames 900`
  - `rdc open <capture>`
  - `rdc info` reported `API: Vulkan` and `Draw Calls: 1`
  - `rdc draws -q` returned draw event `7`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved environment configuration handling for capture operations on Windows when local package configuration is detected, ensuring proper environment setup during the capture process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->