### PR TITLE
test(capture): cover launch-env helpers and add EnvironmentModification mock

### DIFF
--- a/tests/mocks/mock_renderdoc.py
+++ b/tests/mocks/mock_renderdoc.py
@@ -415,6 +415,26 @@ class SectionFlags(IntFlag):
     ZstdCompressed = 4
 
 
+class EnvMod(IntEnum):
+    Set = 0
+    Add = 1
+
+
+class EnvSep(IntEnum):
+    Platform = 0
+    SemiColon = 1
+    Colon = 2
+    NoSep = 3
+
+
+@dataclass
+class EnvironmentModification:
+    name: str = ""
+    value: str = ""
+    mod: EnvMod = EnvMod.Set
+    sep: EnvSep = EnvSep.NoSep
+
+
 @dataclass
 class CounterValue:
     d: float = 0.0

--- a/tests/unit/test_capture_core.py
+++ b/tests/unit/test_capture_core.py
@@ -40,12 +40,13 @@ def _make_mock_rd(
         app: str,
         working_dir: str,
         cmd_line: str,
-        env_list: list[str],
+        env_list: list[Any],
         capturefile: str,
         opts: Any,
         wait_for_exit: bool = False,
     ) -> mock_rd.ExecuteResult:
         calls["inject"].append((app, working_dir, cmd_line, capturefile))
+        calls.setdefault("env_list", []).append(env_list)
         return mock_rd.ExecuteResult(result=inject_result, ident=inject_ident)
 
     def fake_create_tc(
@@ -59,6 +60,9 @@ def _make_mock_rd(
         CreateTargetControl=fake_create_tc,
         GetDefaultCaptureOptions=mock_rd.GetDefaultCaptureOptions,
         CaptureOptions=mock_rd.CaptureOptions,
+        EnvironmentModification=mock_rd.EnvironmentModification,
+        EnvMod=mock_rd.EnvMod,
+        EnvSep=mock_rd.EnvSep,
         _calls=calls,
         _tc=tc,
     )
@@ -465,3 +469,141 @@ class TestInjectFailureHint:
         assert "AppArmor" in hint
         assert "SELinux" in hint
         assert "hook-children" in hint
+
+
+class TestMakeEnvMod:
+    def test_name_and_value_set(self) -> None:
+        from rdc.capture_core import _make_env_mod
+
+        rd = SimpleNamespace(
+            EnvironmentModification=mock_rd.EnvironmentModification,
+            EnvMod=mock_rd.EnvMod,
+            EnvSep=mock_rd.EnvSep,
+        )
+        mod = _make_env_mod(rd, "MY_VAR", "hello")
+        assert mod.name == "MY_VAR"
+        assert mod.value == "hello"
+
+    def test_mod_is_set(self) -> None:
+        from rdc.capture_core import _make_env_mod
+
+        rd = SimpleNamespace(
+            EnvironmentModification=mock_rd.EnvironmentModification,
+            EnvMod=mock_rd.EnvMod,
+            EnvSep=mock_rd.EnvSep,
+        )
+        mod = _make_env_mod(rd, "X", "1")
+        assert mod.mod is rd.EnvMod.Set
+
+    def test_sep_is_nosep(self) -> None:
+        from rdc.capture_core import _make_env_mod
+
+        rd = SimpleNamespace(
+            EnvironmentModification=mock_rd.EnvironmentModification,
+            EnvMod=mock_rd.EnvMod,
+            EnvSep=mock_rd.EnvSep,
+        )
+        mod = _make_env_mod(rd, "X", "1")
+        assert mod.sep is rd.EnvSep.NoSep
+
+
+class TestBuildLaunchEnv:
+    def test_non_win32_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from rdc.capture_core import _build_launch_env
+
+        monkeypatch.setattr("rdc.capture_core.sys.platform", "linux")
+        rd = SimpleNamespace(
+            EnvironmentModification=mock_rd.EnvironmentModification,
+            EnvMod=mock_rd.EnvMod,
+            EnvSep=mock_rd.EnvSep,
+        )
+        assert _build_launch_env(rd) == []
+
+    def test_win32_no_file_attr_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from rdc.capture_core import _build_launch_env
+
+        monkeypatch.setattr("rdc.capture_core.sys.platform", "win32")
+        rd = SimpleNamespace(
+            EnvironmentModification=mock_rd.EnvironmentModification,
+            EnvMod=mock_rd.EnvMod,
+            EnvSep=mock_rd.EnvSep,
+        )
+        # No __file__ attribute
+        assert _build_launch_env(rd) == []
+
+    def test_win32_missing_renderdoc_json_returns_empty(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        from rdc.capture_core import _build_launch_env
+
+        monkeypatch.setattr("rdc.capture_core.sys.platform", "win32")
+        module_file = tmp_path / "renderdoc.pyd"
+        module_file.touch()
+        rd = SimpleNamespace(
+            __file__=str(module_file),
+            EnvironmentModification=mock_rd.EnvironmentModification,
+            EnvMod=mock_rd.EnvMod,
+            EnvSep=mock_rd.EnvSep,
+        )
+        # No renderdoc.json sibling
+        assert _build_launch_env(rd) == []
+
+    def test_win32_with_renderdoc_json_returns_two_mods(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        from rdc.capture_core import _build_launch_env
+
+        monkeypatch.setattr("rdc.capture_core.sys.platform", "win32")
+        module_file = tmp_path / "renderdoc.pyd"
+        module_file.touch()
+        (tmp_path / "renderdoc.json").write_text("{}")
+        rd = SimpleNamespace(
+            __file__=str(module_file),
+            EnvironmentModification=mock_rd.EnvironmentModification,
+            EnvMod=mock_rd.EnvMod,
+            EnvSep=mock_rd.EnvSep,
+        )
+        mods = _build_launch_env(rd)
+        assert len(mods) == 2
+        names = [m.name for m in mods]
+        assert "ENABLE_VULKAN_RENDERDOC_CAPTURE" in names
+        assert "VK_IMPLICIT_LAYER_PATH" in names
+        vk_mod = next(m for m in mods if m.name == "VK_IMPLICIT_LAYER_PATH")
+        assert vk_mod.value == str(tmp_path.resolve())
+
+
+class TestExecuteAndCaptureEnvWiring:
+    def _cap_msg(self) -> mock_rd.TargetControlMessage:
+        new_cap = mock_rd.NewCaptureData(
+            path="/tmp/cap.rdc", frameNumber=0, byteSize=4096, api="Vulkan", local=True
+        )
+        return mock_rd.TargetControlMessage(
+            type=mock_rd.TargetControlMessageType.NewCapture, newCapture=new_cap
+        )
+
+    def test_win32_with_renderdoc_json_passes_nonempty_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        from rdc.capture_core import execute_and_capture
+
+        monkeypatch.setattr("rdc.capture_core.sys.platform", "win32")
+        module_file = tmp_path / "renderdoc.pyd"
+        module_file.touch()
+        (tmp_path / "renderdoc.json").write_text("{}")
+
+        rd = _make_mock_rd(messages=[self._cap_msg()])
+        rd.__file__ = str(module_file)
+
+        execute_and_capture(rd, "/usr/bin/app", output="/tmp/cap.rdc")
+        env_lists = rd._calls.get("env_list", [])
+        assert env_lists and len(env_lists[0]) == 2
+
+    def test_non_win32_passes_empty_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from rdc.capture_core import execute_and_capture
+
+        monkeypatch.setattr("rdc.capture_core.sys.platform", "linux")
+        rd = _make_mock_rd(messages=[self._cap_msg()])
+
+        execute_and_capture(rd, "/usr/bin/app", output="/tmp/cap.rdc")
+        env_lists = rd._calls.get("env_list", [])
+        assert env_lists and env_lists[0] == []


### PR DESCRIPTION
## Summary

Follow-up to #254. Adds unit coverage for the Windows launch-env helpers introduced there
(`_build_launch_env` / `_make_env_mod` in `src/rdc/capture_core.py`) and the mock symbols they
require. No production code is changed.

- `tests/mocks/mock_renderdoc.py`: add `EnvMod` / `EnvSep` enums and the `EnvironmentModification`
  dataclass (canonical RenderDoc surface) so the Windows path is exercisable under the mock.
- `tests/unit/test_capture_core.py`: cover `_make_env_mod` (name/value/mod/sep) and all four
  `_build_launch_env` branches — non-win32, missing `__file__`, missing sibling `renderdoc.json`,
  and the happy path (asserts both `ENABLE_VULKAN_RENDERDOC_CAPTURE=1` and
  `VK_IMPLICIT_LAYER_PATH` equal to the module directory). Adds one `execute_and_capture` wiring
  test that the env list reaches `ExecuteAndInject` on win32 and is empty on other platforms.

## Why

#254 shipped with manual Windows smoke only; on Linux CI the helpers were almost entirely
uncovered (only the early non-win32 return). These tests close that gap.

## Verification

- `pixi run lint`: pass
- `pixi run test`: 2999 passed, 6 skipped, 92.94% coverage

## Note

The GPU-gated mock-sync test (`tests/integration/test_mock_api_sync.py`) is intentionally left
unchanged. Registering `EnvMod` / `EnvSep` / `EnvironmentModification` in its curated lists should
be verified against a real renderdoc module and can be a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to validate environment variable modification handling during capture execution.
  * Added comprehensive test coverage for environment setup across different platforms and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->