### PR TITLE
fix(capture): use platform-appropriate cmdline quoting for child app args

### DIFF
--- a/openspec/changes/2026-06-22-fix-257-windows-arg-quoting/proposal.md
+++ b/openspec/changes/2026-06-22-fix-257-windows-arg-quoting/proposal.md
@@ -1,0 +1,38 @@
+# Fix #257: Platform-appropriate command-line quoting for child app args
+
+## Motivation
+
+`rdc capture -- <exe> <args>` passes child arguments to RenderDoc's
+`ExecuteAndInject` as a single cmdline string built with `shlex.join`.
+`shlex.join` follows POSIX quoting rules (single-quote wrapping), so a
+Windows path like `D:\path\script.das` reaches the target process wrapped in
+literal single quotes.  On Windows, `ExecuteAndInject` delegates to Win32
+`CommandLineToArgvW`, which does not recognise POSIX quoting — the single
+quotes are passed literally into `argv[0]`, breaking the launch.
+
+## Design
+
+Add `join_cmdline(args: list[str]) -> str` to `rdc._platform`.  The helper
+dispatches on the module-level `_WIN` flag:
+
+- **Windows**: delegates to `subprocess.list2cmdline`, which produces a
+  string that `CommandLineToArgvW` parses correctly (double-quote wrapping,
+  backslash escaping).
+- **POSIX**: delegates to `shlex.join`, preserving existing behaviour.
+
+`subprocess.list2cmdline` is pure-Python and ships with every CPython; no new
+dependency is introduced.  Both `_platform.py` and `subprocess` are already
+imported by callers, so the import footprint is zero.
+
+Both call sites in `commands/capture.py` — the direct Python API path (line
+~137) and the split-session path (line ~172) — are rerouted to
+`_platform.join_cmdline(app_args)`.  The now-unused `import shlex` in
+`capture.py` is removed.
+
+## Risks
+
+- `subprocess.list2cmdline` is a documented, stable part of the `subprocess`
+  module and is the standard reference implementation for Win32 cmdline
+  encoding.  Risk: negligible.
+- Changing quoting on POSIX is a no-op (same `shlex.join` result), so no
+  regression on Linux/macOS.

--- a/openspec/changes/2026-06-22-fix-257-windows-arg-quoting/tasks.md
+++ b/openspec/changes/2026-06-22-fix-257-windows-arg-quoting/tasks.md
@@ -1,0 +1,7 @@
+# Fix #257: Tasks
+
+- [x] `src/rdc/_platform.py`: add `import shlex`; add `join_cmdline(args: list[str]) -> str`
+- [x] `src/rdc/commands/capture.py`: replace both `shlex.join(app_args)` call sites with `_platform.join_cmdline(app_args)`
+- [x] `src/rdc/commands/capture.py`: remove now-unused `import shlex`
+- [x] `tests/unit/test_platform.py`: add `TestJoinCmdline` with 6 cases covering both branches
+- [x] `pixi run lint && pixi run typecheck && pixi run test` passes

--- a/openspec/changes/2026-06-22-fix-257-windows-arg-quoting/test-plan.md
+++ b/openspec/changes/2026-06-22-fix-257-windows-arg-quoting/test-plan.md
@@ -1,0 +1,15 @@
+# Fix #257: Test Plan
+
+## Unit: join_cmdline() — tests/unit/test_platform.py
+
+- [ ] `test_join_cmdline_posix_simple`: POSIX branch, no-space arg — output equals `shlex.join(["app"])`
+- [ ] `test_join_cmdline_posix_space`: POSIX branch, arg with spaces — output equals `shlex.join(["my app"])`
+- [ ] `test_join_cmdline_posix_multi`: POSIX branch, multiple args including backslash path — `shlex.join` result
+- [ ] `test_join_cmdline_windows_backslash_path`: Windows branch, `D:\path\script.das` — no single quotes in output
+- [ ] `test_join_cmdline_windows_space_arg`: Windows branch, arg with spaces — double-quoted by `list2cmdline`
+- [ ] `test_join_cmdline_windows_multi`: Windows branch, multiple args — matches `subprocess.list2cmdline` output
+
+## Integration smoke (manual, Windows VM)
+
+- [ ] `rdc capture -- myapp.exe D:\path\script.das` launches without single-quote artefacts in injected cmdline
+- [ ] `rdc capture -- "my app.exe" "arg with space"` still works on POSIX

--- a/src/rdc/_platform.py
+++ b/src/rdc/_platform.py
@@ -7,6 +7,7 @@ callers never need ``sys.platform`` checks themselves.
 from __future__ import annotations
 
 import os
+import shlex
 import signal
 import subprocess
 import sys
@@ -16,6 +17,16 @@ from typing import Any
 
 _WIN: bool = sys.platform == "win32"
 _MAC: bool = sys.platform == "darwin"
+
+
+def join_cmdline(args: list[str]) -> str:
+    """Join *args* into a single command-line string, platform-appropriately.
+
+    On Windows, uses subprocess.list2cmdline so that CommandLineToArgvW
+    parses it correctly (double-quote wrapping, backslash escaping).
+    On POSIX, uses shlex.join (single-quote wrapping).
+    """
+    return subprocess.list2cmdline(args) if _WIN else shlex.join(args)
 
 
 def data_dir() -> Path:

--- a/src/rdc/commands/capture.py
+++ b/src/rdc/commands/capture.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import shlex
 import shutil
 import subprocess
 import sys
@@ -134,7 +133,7 @@ def capture_cmd(
         result = execute_and_capture(
             rd,
             executable,
-            args=shlex.join(app_args),
+            args=_platform.join_cmdline(app_args),
             workdir="",
             output=output_path,
             opts=cap_opts,
@@ -169,7 +168,7 @@ def _run_split_capture(
 ) -> None:
     payload = {
         "app": executable,
-        "args": shlex.join(app_args),
+        "args": _platform.join_cmdline(app_args),
         "output": output_path,
         "opts": opts,
         "frame": frame,

--- a/tests/unit/test_platform.py
+++ b/tests/unit/test_platform.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import signal
 import subprocess
 from pathlib import Path
@@ -15,6 +16,7 @@ from rdc._platform import (
     find_pid_by_port,
     install_shutdown_signal,
     is_pid_alive,
+    join_cmdline,
     popen_flags,
     renderdoc_search_paths,
     renderdoccmd_search_paths,
@@ -593,3 +595,54 @@ class TestFindPidByPort:
 
         monkeypatch.setattr("rdc._platform.subprocess.run", _raise)
         assert find_pid_by_port(9999) == 0
+
+
+# ── Group L: join_cmdline() ──────────────────────────────────────────
+
+
+class TestJoinCmdline:
+    """Issue #257: platform-appropriate cmdline quoting for child app args."""
+
+    # POSIX branch
+
+    def test_posix_simple(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """POSIX branch: single simple arg matches shlex.join."""
+        monkeypatch.setattr("rdc._platform._WIN", False)
+        assert join_cmdline(["myapp"]) == shlex.join(["myapp"])
+
+    def test_posix_arg_with_spaces(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """POSIX branch: arg with spaces is single-quoted by shlex.join."""
+        monkeypatch.setattr("rdc._platform._WIN", False)
+        result = join_cmdline(["my app"])
+        assert result == shlex.join(["my app"])
+        assert "'" in result
+
+    def test_posix_multi_with_backslash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """POSIX branch: multiple args including Windows-style path."""
+        monkeypatch.setattr("rdc._platform._WIN", False)
+        args = ["myapp.exe", r"D:\path\script.das"]
+        assert join_cmdline(args) == shlex.join(args)
+
+    # Windows branch
+
+    def test_windows_backslash_path_not_single_quoted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Windows branch: backslash path is not wrapped in single quotes."""
+        monkeypatch.setattr("rdc._platform._WIN", True)
+        result = join_cmdline([r"D:\path\script.das"])
+        assert "'" not in result
+        assert result == subprocess.list2cmdline([r"D:\path\script.das"])
+
+    def test_windows_arg_with_spaces_double_quoted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Windows branch: arg with spaces is double-quoted by list2cmdline."""
+        monkeypatch.setattr("rdc._platform._WIN", True)
+        result = join_cmdline(["my app"])
+        assert result == subprocess.list2cmdline(["my app"])
+        assert '"' in result
+
+    def test_windows_multi_matches_list2cmdline(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Windows branch: multiple args produce same output as list2cmdline."""
+        monkeypatch.setattr("rdc._platform._WIN", True)
+        args = ["myapp.exe", r"D:\path\script.das", "arg with space"]
+        assert join_cmdline(args) == subprocess.list2cmdline(args)


### PR DESCRIPTION
Closes #257.

## Problem
`rdc capture -- <exe> <args>` built the child command line with POSIX `shlex.join`, which single-quotes any argument containing a backslash. On Windows, `ExecuteAndInject` delegates to `CommandLineToArgvW`, which does not recognise POSIX single-quoting, so a path like `D:\path\script.das` reached the target process as the literal `'D:\path\script.das'` and the launch failed.

## Fix
Add `join_cmdline(args)` to `rdc._platform`, dispatching on the existing `_WIN` flag:
- **Windows**: `subprocess.list2cmdline` (the reference encoder that `CommandLineToArgvW` parses back).
- **POSIX**: `shlex.join` (unchanged behaviour).

Both call sites in `commands/capture.py` are rerouted; the now-unused `shlex` import is removed. The remote path forwards a single verbatim string and is correctly out of scope.

## Tests
`tests/unit/test_platform.py::TestJoinCmdline` (6 cases) covers both branches, including the regression: a backslash path is not single-quoted on Windows.

`pixi run lint && pixi run typecheck && pixi run test`: all green (2996 passed, 6 skipped, 92.82% coverage).