### PR TITLE
fix(setup): substitute Vulkan layer manifest template vars and detect duplicate layers

### DIFF
--- a/openspec/changes/2026-06-22-fix-256-vulkan-layer-manifest/proposal.md
+++ b/openspec/changes/2026-06-22-fix-256-vulkan-layer-manifest/proposal.md
@@ -1,0 +1,113 @@
+# Fix #256: Vulkan layer manifest template substitution + duplicate layer detection
+
+## Motivation
+
+Issue #256: on Windows, `rdc`'s own implicit Vulkan capture layer can never self-enable,
+so Vulkan captures launched through `rdc capture` silently time out.
+
+Two root causes were verified against the real code and the cloned RenderDoc source tree
+(`.local/renderdoc-build/renderdoc/renderdoc/driver/vulkan/`):
+
+| Cause | Where | Effect |
+|-------|-------|--------|
+| Unsubstituted CMake template vars in the layer manifest | `_build_renderdoc.py:_install_vulkan_layer` | `rdc`'s layer never self-enables |
+| `doctor` returns green on the first manifest and never warns on duplicates | `commands/doctor.py:_check_win_vulkan_layer` | the system + `rdc` split-brain stays invisible |
+
+### Cause 1: unsubstituted template vars
+
+Upstream RenderDoc substitutes `renderdoc.json` via CMake `configure_file`, but that block is
+UNIX-only (`driver/vulkan/CMakeLists.txt`: the substitution lives inside `elseif(UNIX)`). On
+Windows the file ships verbatim (`<None Include="renderdoc.json"/>`), so the manifest still
+contains `@...@` placeholders.
+
+`_install_vulkan_layer` reads that template with `json.loads` and rewrites only `library_path`,
+leaving the placeholders intact. In the in-scope version (`RDOC_TAG = "v1.41"`) the surviving
+placeholders are:
+
+- `enable_environment`: `{"@VULKAN_ENABLE_VAR@": "1"}` — the enable key the loader looks for is
+  literally `@VULKAN_ENABLE_VAR@`, which no process ever sets, so the layer is never enabled.
+- `implementation_version`: `"@RENDERDOC_VERSION_MINOR@"`.
+- `disable_environment` key: `DISABLE_VULKAN_RENDERDOC_CAPTURE_@RENDERDOC_VERSION_MAJOR@_@RENDERDOC_VERSION_MINOR@`.
+
+Newer upstream templates (e.g. v1.44) additionally template `name` as `"@VULKAN_LAYER_NAME@"`,
+so the fix force-sets `name` too, making it version-robust.
+
+The canonical substitution values come from `driver/vulkan/CMakeLists.txt`:
+`VULKAN_ENABLE_VAR = ENABLE_VULKAN_${RDOC_BASE_NAME_UPPER}_CAPTURE` with base name `renderdoc`,
+i.e. `ENABLE_VULKAN_RENDERDOC_CAPTURE`; the disable key is
+`DISABLE_VULKAN_RENDERDOC_CAPTURE_<MAJOR>_<MINOR>`. The version is the SSOT `RDOC_TAG`
+(or the `--version` arg), e.g. `v1.41` -> MAJOR=1, MINOR=41. This matches
+`api/replay/version.h` in the cloned tree (`RENDERDOC_VERSION_MAJOR 1`, `RENDERDOC_VERSION_MINOR 41`).
+
+This enable var (`ENABLE_VULKAN_RENDERDOC_CAPTURE`) is the same one already set at launch by
+`capture_core.py:_build_launch_env`, so once the manifest declares it as its enable key the
+existing launch env actually takes effect.
+
+### Cause 2: doctor never warns on duplicate layers
+
+`_check_win_vulkan_layer` collects candidate manifests from both HKLM and HKCU `ImplicitLayers`,
+but returns green on the FIRST existing manifest. When a system RenderDoc install and `rdc`'s own
+install both register a layer named `VK_LAYER_RENDERDOC_Capture`, the Vulkan loader picks one
+non-deterministically (the split-brain), and capture silently times out. `doctor` gives no signal.
+
+## Design
+
+### Part 1: substitute all manifest template vars (`_install_vulkan_layer`)
+
+Thread the in-scope version into `_install_vulkan_layer` (currently it receives only
+`install_dir` and `build_dir`; `main()` passes `args.version`, default `RDOC_TAG`). Derive
+`(major, minor)` from that version string with a small `_parse_version` helper (`v1.41` ->
+`(1, 41)`).
+
+After `json.loads`, force every layer field to a fully-resolved value rather than trusting the
+template:
+
+- `name = "VK_LAYER_RENDERDOC_Capture"` (canonical; robust against `@VULKAN_LAYER_NAME@`).
+- `enable_environment = {"ENABLE_VULKAN_RENDERDOC_CAPTURE": "1"}`.
+- `disable_environment = {f"DISABLE_VULKAN_RENDERDOC_CAPTURE_{major}_{minor}": "1"}`.
+- `implementation_version = str(minor)`.
+- `library_path = ".\\renderdoc.dll"` (unchanged behavior).
+
+After serialization, assert no `@` remains in the written text. If any does, raise a clear
+`RuntimeError` naming the offending content. This guard makes a future template change that
+introduces a new placeholder fail loudly instead of silently shipping a dead layer.
+
+### Part 2: detect duplicate layers (`_check_win_vulkan_layer`)
+
+Refactor the registry enumeration into a small helper `_enumerate_implicit_layers()` that returns
+the list of manifest paths registered under HKLM+HKCU `ImplicitLayers`. Importing `winreg` inside
+the helper keeps it unit-testable cross-platform by mocking `sys.modules["winreg"]`.
+
+In `_check_win_vulkan_layer`, resolve each manifest's `layer.name` and collect those that resolve
+to `VK_LAYER_RENDERDOC_Capture`. If more than one resolves to that name, return a FAIL
+`CheckResult` listing each manifest path, its resolved DLL, and its version. A single layer keeps
+the existing green behavior (`registered at {path}`).
+
+## Risks
+
+- Force-setting `name`/`enable_environment` ignores any future upstream rename of these fields.
+  Mitigated by the no-`@` guard (a renamed placeholder would still be caught) and by the fact that
+  these names are loader-facing constants, not free to change without breaking the loader anyway.
+- Duplicate detection reads each manifest file; a malformed JSON manifest is skipped (best-effort)
+  rather than failing the whole check.
+
+## DEFERRED: Part 3 — force `rdc`'s own layer for the spawned child
+
+A third improvement was considered and is explicitly DEFERRED to a follow-up: forcing the spawned
+capture target to load `rdc`'s own layer (and only that one) via the `ExecuteAndInject` env arg in
+`capture_core.py`, using `VK_ADD_LAYER_PATH` / `VK_LOADER_LAYERS_ENABLE` / `VK_LOADER_LAYERS_DISABLE`.
+
+Rationale for deferral:
+
+1. It cannot be verified without a real Windows box with a dual RenderDoc install (system + `rdc`).
+   The split-brain only reproduces with two registered layers; CI cannot exercise it.
+2. The two layers share the exact name `VK_LAYER_RENDERDOC_Capture`, so
+   `VK_LOADER_LAYERS_DISABLE=VK_LAYER_RENDERDOC_Capture` would disable BOTH layers, not just the
+   system one. There is no by-name way to disable only the foreign layer. Selecting `rdc`'s layer
+   while suppressing the other is an unresolved design question (candidate approaches:
+   `VK_LOADER_LAYERS_ENABLE` precedence, manifest-path scoping, or renaming `rdc`'s layer — each
+   has trade-offs that need on-device validation).
+
+Parts 1 and 2 are independently correct and shippable: Part 1 makes `rdc`'s layer enable-able at
+all, and Part 2 surfaces the split-brain to the user so they can act, without needing the unresolved
+Part 3 design.

--- a/openspec/changes/2026-06-22-fix-256-vulkan-layer-manifest/tasks.md
+++ b/openspec/changes/2026-06-22-fix-256-vulkan-layer-manifest/tasks.md
@@ -1,0 +1,25 @@
+# Fix #256: Tasks
+
+## Part 1: manifest substitution
+
+- [x] `_build_renderdoc.py`: add `_parse_version(version) -> (major, minor)` helper
+- [x] `_build_renderdoc.py`: `_install_vulkan_layer` takes a `version` arg
+- [x] `_build_renderdoc.py`: substitute all manifest fields (`name`, `enable_environment`,
+      `disable_environment`, `implementation_version`, `library_path`)
+- [x] `_build_renderdoc.py`: assert no `@` remains after serialization, else raise
+- [x] `_build_renderdoc.py`: `main()` forwards `args.version` to `_install_vulkan_layer`
+
+## Part 2: duplicate detection
+
+- [x] `commands/doctor.py`: extract `_enumerate_implicit_layers()` helper (mockable `winreg`)
+- [x] `commands/doctor.py`: resolve each manifest `layer.name`; warn when >1 resolves to
+      `VK_LAYER_RENDERDOC_Capture`, listing path + DLL + version
+- [x] `commands/doctor.py`: dedup candidates by resolved path so one manifest registered
+      under both hives is not double-counted
+
+## Tests
+
+- [x] `test_build_renderdoc.py`: real-template substitution case + guard case + `_parse_version`
+- [x] `test_build_renderdoc.py`: keep existing clean-fixture test green
+- [x] `test_doctor.py`: duplicate-detection cases via mocked `winreg` (incl. same-manifest-both-hives dedup)
+- [x] `pixi run lint && pixi run typecheck && pixi run test` all green

--- a/openspec/changes/2026-06-22-fix-256-vulkan-layer-manifest/test-plan.md
+++ b/openspec/changes/2026-06-22-fix-256-vulkan-layer-manifest/test-plan.md
@@ -1,0 +1,35 @@
+# Fix #256: Test Plan
+
+## Part 1: manifest template substitution (`test_build_renderdoc.py`)
+
+- [ ] Unit: real-template fixture containing `@VULKAN_ENABLE_VAR@`, `@VULKAN_LAYER_NAME@`,
+      `@RENDERDOC_VERSION_MAJOR@`, `@RENDERDOC_VERSION_MINOR@` -> written manifest has zero `@`.
+- [ ] Unit: written `enable_environment == {"ENABLE_VULKAN_RENDERDOC_CAPTURE": "1"}`.
+- [ ] Unit: written `name == "VK_LAYER_RENDERDOC_Capture"`.
+- [ ] Unit: written `disable_environment` has key `DISABLE_VULKAN_RENDERDOC_CAPTURE_1_41` for version `v1.41`.
+- [ ] Unit: written `library_path == ".\\renderdoc.dll"`.
+- [ ] Unit: `implementation_version == "41"` for version `v1.41`.
+- [ ] Unit: existing clean-fixture test (`library_path` only) stays green.
+- [ ] Unit: a fixture that would leave a stray `@FOO@` after substitution raises a clear error
+      (guard test) — exercised by force-injecting an extra placeholder field.
+- [ ] Unit: `_parse_version("v1.41") == (1, 41)` and `_parse_version("1.44") == (1, 44)`.
+- [ ] Unit: `main()` forwards `args.version` into `_install_vulkan_layer` on Windows.
+
+## Part 2: duplicate layer detection (`test_doctor.py`)
+
+Cross-platform via mocked `winreg` (`patch.dict("sys.modules", {"winreg": fake})`):
+
+- [ ] Unit: two registered manifests, both resolving to `VK_LAYER_RENDERDOC_Capture` with
+      different DLLs -> FAIL CheckResult listing both manifest paths.
+- [ ] Unit: single registered manifest resolving to `VK_LAYER_RENDERDOC_Capture` -> ok,
+      `registered at {path}`.
+- [ ] Unit: `_enumerate_implicit_layers()` returns manifest paths from both HKLM and HKCU.
+- [ ] Existing Windows-only tests stay green.
+
+## Manual (Windows VM, post-merge)
+
+- [ ] `rdc setup-renderdoc` then inspect installed `renderdoc.json`: no `@` placeholders,
+      `enable_environment` is `ENABLE_VULKAN_RENDERDOC_CAPTURE`.
+- [ ] With both a system RenderDoc and `rdc`'s install registered, `rdc doctor` reports the
+      duplicate `win-vulkan-layer` as FAIL listing both paths.
+- [ ] `rdc capture` against a Vulkan target no longer times out (Part 1 effect).

--- a/src/rdc/_build_renderdoc.py
+++ b/src/rdc/_build_renderdoc.py
@@ -440,8 +440,19 @@ def copy_artifacts(build_dir: Path, install_dir: Path, plat: str) -> None:
     _log(f"artifacts copied to {install_dir}")
 
 
-def _install_vulkan_layer(install_dir: Path, build_dir: Path) -> None:
-    """Copy Vulkan layer JSON and register as implicit layer on Windows."""
+def _parse_version(version: str) -> tuple[int, int]:
+    """Parse a RenderDoc tag like ``v1.41`` into ``(major, minor)``."""
+    parts = version.lstrip("v").split(".")
+    return int(parts[0]), int(parts[1])
+
+
+def _install_vulkan_layer(install_dir: Path, build_dir: Path, version: str = RDOC_TAG) -> None:
+    """Copy Vulkan layer JSON and register as implicit layer on Windows.
+
+    Upstream substitutes ``renderdoc.json`` via CMake ``configure_file``, but that block is
+    UNIX-only, so on Windows the template ships with unsubstituted ``@...@`` placeholders.
+    Resolve every templated field here so the layer can self-enable.
+    """
     src_dir = build_dir / "renderdoc"
 
     # Find layer JSON from build output
@@ -459,10 +470,23 @@ def _install_vulkan_layer(install_dir: Path, build_dir: Path) -> None:
 
     import json
 
+    major, minor = _parse_version(version)
     data = json.loads(layer_src.read_text(encoding="utf-8"))
-    data["layer"]["library_path"] = ".\\renderdoc.dll"
+    layer = data["layer"]
+    layer["name"] = "VK_LAYER_RENDERDOC_Capture"
+    layer["library_path"] = ".\\renderdoc.dll"
+    layer["implementation_version"] = str(minor)
+    layer["enable_environment"] = {"ENABLE_VULKAN_RENDERDOC_CAPTURE": "1"}
+    layer["disable_environment"] = {f"DISABLE_VULKAN_RENDERDOC_CAPTURE_{major}_{minor}": "1"}
+
+    serialized = json.dumps(data, indent=2)
+    if "@" in serialized:
+        raise RuntimeError(
+            f"Vulkan layer manifest still contains unsubstituted template vars: {serialized}"
+        )
+
     layer_dst = install_dir / "renderdoc.json"
-    layer_dst.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    layer_dst.write_text(serialized, encoding="utf-8")
     _log(f"Vulkan layer JSON installed to {layer_dst}")
 
     # Register in Windows registry
@@ -789,7 +813,7 @@ def main(argv: list[str] | None = None) -> None:
     copy_artifacts(build_dir, install_dir, plat)
 
     if plat == "windows":
-        _install_vulkan_layer(install_dir, build_dir)
+        _install_vulkan_layer(install_dir, build_dir, args.version)
 
     _log("=== Done ===")
     _log(f'  export RENDERDOC_PYTHON_PATH="{install_dir}"')

--- a/src/rdc/commands/doctor.py
+++ b/src/rdc/commands/doctor.py
@@ -241,23 +241,23 @@ def _check_win_renderdoc_install() -> CheckResult:
     )
 
 
-def _check_win_vulkan_layer() -> CheckResult:
-    """Check Vulkan implicit layer JSON and registry for capture support."""
-    if sys.platform != "win32":
-        return CheckResult("win-vulkan-layer", True, "n/a")
+_RENDERDOC_LAYER_NAME = "VK_LAYER_RENDERDOC_Capture"
 
+
+def _enumerate_implicit_layers() -> list[Path]:
+    """Return all renderdoc implicit-layer manifest paths from HKLM+HKCU."""
     import winreg  # noqa: PLC0415
 
-    # 1. Collect all renderdoc layer entries from registry
     reg_path = r"SOFTWARE\Khronos\Vulkan\ImplicitLayers"
     candidates: list[Path] = []
-    for hive in (winreg.HKEY_CURRENT_USER, winreg.HKEY_LOCAL_MACHINE):
+    hives = (winreg.HKEY_CURRENT_USER, winreg.HKEY_LOCAL_MACHINE)  # type: ignore[attr-defined,unused-ignore]
+    for hive in hives:
         try:
-            with winreg.OpenKey(hive, reg_path) as key:
+            with winreg.OpenKey(hive, reg_path) as key:  # type: ignore[attr-defined,unused-ignore]
                 i = 0
                 while True:
                     try:
-                        name, _val, _typ = winreg.EnumValue(key, i)
+                        name, _val, _typ = winreg.EnumValue(key, i)  # type: ignore[attr-defined,unused-ignore]
                         if "renderdoc" in name.lower():
                             candidates.append(Path(name))
                     except OSError:
@@ -265,7 +265,25 @@ def _check_win_vulkan_layer() -> CheckResult:
                     i += 1
         except OSError:
             continue
+    return candidates
 
+
+def _read_layer_manifest(path: Path) -> dict[str, Any]:
+    """Read a Vulkan layer manifest's ``layer`` object, empty dict on failure."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        layer = data.get("layer", {})
+        return layer if isinstance(layer, dict) else {}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _check_win_vulkan_layer() -> CheckResult:
+    """Check Vulkan implicit layer JSON and registry for capture support."""
+    if sys.platform != "win32":
+        return CheckResult("win-vulkan-layer", True, "n/a")
+
+    candidates = _enumerate_implicit_layers()
     if not candidates:
         return CheckResult(
             "win-vulkan-layer",
@@ -274,7 +292,33 @@ def _check_win_vulkan_layer() -> CheckResult:
             " -- register renderdoc.json in HKCU\\SOFTWARE\\Khronos\\Vulkan\\ImplicitLayers",
         )
 
-    # 2. Find first candidate whose JSON file exists
+    # Detect the system + rdc split-brain: two layers sharing the same name make the
+    # Vulkan loader pick one non-deterministically and capture silently times out.
+    # Dedup by resolved path so one manifest registered under both hives isn't double-counted.
+    duplicates: list[Path] = []
+    seen: set[Path] = set()
+    for p in candidates:
+        if _read_layer_manifest(p).get("name") != _RENDERDOC_LAYER_NAME:
+            continue
+        resolved = p.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            duplicates.append(p)
+    if len(duplicates) > 1:
+        lines = []
+        for p in duplicates:
+            layer = _read_layer_manifest(p)
+            dll = (p.parent / layer.get("library_path", "")).resolve()
+            ver = layer.get("implementation_version", "?")
+            lines.append(f"{p} -> {dll} (v{ver})")
+        return CheckResult(
+            "win-vulkan-layer",
+            False,
+            f"{len(duplicates)} '{_RENDERDOC_LAYER_NAME}' layers registered "
+            "(capture is ambiguous): " + "; ".join(lines),
+        )
+
+    # Single layer: find first candidate whose JSON file exists and validate its DLL
     layer_json_path = next((p for p in candidates if p.is_file()), None)
     if layer_json_path is None:
         return CheckResult(
@@ -283,20 +327,15 @@ def _check_win_vulkan_layer() -> CheckResult:
             f"registry points to {candidates[0]} but file not found",
         )
 
-    # 3. Validate layer JSON references renderdoc.dll that exists
-    try:
-        data = json.loads(layer_json_path.read_text(encoding="utf-8"))
-        lib_path = data.get("layer", {}).get("library_path", "")
-        if lib_path:
-            dll = (layer_json_path.parent / lib_path).resolve()
-            if not dll.is_file():
-                return CheckResult(
-                    "win-vulkan-layer",
-                    False,
-                    f"layer JSON references {lib_path} but {dll} not found",
-                )
-    except Exception:  # noqa: BLE001
-        pass
+    lib_path = _read_layer_manifest(layer_json_path).get("library_path", "")
+    if lib_path:
+        dll = (layer_json_path.parent / lib_path).resolve()
+        if not dll.is_file():
+            return CheckResult(
+                "win-vulkan-layer",
+                False,
+                f"layer JSON references {lib_path} but {dll} not found",
+            )
 
     return CheckResult("win-vulkan-layer", True, f"registered at {layer_json_path}")
 

--- a/tests/unit/test_build_renderdoc.py
+++ b/tests/unit/test_build_renderdoc.py
@@ -522,6 +522,23 @@ def test_main_windows_uses_msbuild(tmp_path: Path) -> None:
     mock_msb.assert_called_once()
 
 
+def test_main_windows_forwards_version_to_vulkan_layer(tmp_path: Path) -> None:
+    with (
+        patch("rdc._build_renderdoc._platform", return_value="windows"),
+        patch("rdc._build_renderdoc._artifacts_present", return_value=False),
+        patch("rdc._build_renderdoc.default_install_dir", return_value=tmp_path / "install"),
+        patch("rdc._build_renderdoc.check_prerequisites"),
+        patch("rdc._build_renderdoc.verify_tool_versions"),
+        patch("rdc._build_renderdoc.clone_renderdoc"),
+        patch("rdc._build_renderdoc._prepare_win_python", return_value=Path("C:/prefix")),
+        patch("rdc._build_renderdoc._run_msbuild"),
+        patch("rdc._build_renderdoc.copy_artifacts"),
+        patch("rdc._build_renderdoc._install_vulkan_layer") as mock_layer,
+    ):
+        br.main(["--version", "v1.44"])
+    assert mock_layer.call_args[0][2] == "v1.44"
+
+
 # ---------------------------------------------------------------------------
 # MSBuild (Windows)
 # ---------------------------------------------------------------------------
@@ -748,37 +765,107 @@ def test_prepare_win_python_props_already_patched(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _fake_winreg() -> MagicMock:
+    """Mock winreg for the registry registration side-effect (we run on Linux)."""
+    fake = MagicMock()
+    fake_key = MagicMock()
+    fake_key.__enter__ = lambda self: self
+    fake_key.__exit__ = MagicMock(return_value=False)
+    fake.CreateKey.return_value = fake_key
+    fake.HKEY_CURRENT_USER = 0x80000001
+    fake.REG_DWORD = 4
+    return fake
+
+
+def _write_layer_template(build_dir: Path, content: str) -> None:
+    vk_dir = build_dir / "renderdoc" / "renderdoc" / "driver" / "vulkan"
+    vk_dir.mkdir(parents=True)
+    (vk_dir / "renderdoc.json").write_text(content, encoding="utf-8")
+
+
+def test_parse_version() -> None:
+    assert br._parse_version("v1.41") == (1, 41)
+    assert br._parse_version("1.44") == (1, 44)
+
+
 def test_install_vulkan_layer_copies_json_and_patches_library_path(tmp_path: Path) -> None:
-    """Layer JSON is copied with library_path rewritten to .\\renderdoc.dll."""
+    """Clean fixture (library_path only) stays green and gets a full substitution."""
     import json
 
     install_dir = tmp_path / "install"
     install_dir.mkdir()
     build_dir = tmp_path / "build"
-    vk_dir = build_dir / "renderdoc" / "renderdoc" / "driver" / "vulkan"
-    vk_dir.mkdir(parents=True)
-    layer_src = vk_dir / "renderdoc.json"
-    layer_src.write_text(
+    _write_layer_template(
+        build_dir,
         json.dumps({"layer": {"library_path": "/usr/local/lib/librenderdoc.so"}}),
-        encoding="utf-8",
     )
 
-    # Mock winreg since we may be on Linux
-    fake_winreg = MagicMock()
-    fake_key = MagicMock()
-    fake_key.__enter__ = lambda self: self
-    fake_key.__exit__ = MagicMock(return_value=False)
-    fake_winreg.CreateKey.return_value = fake_key
-    fake_winreg.HKEY_CURRENT_USER = 0x80000001
-    fake_winreg.REG_DWORD = 4
-
-    with patch.dict("sys.modules", {"winreg": fake_winreg}):
+    with patch.dict("sys.modules", {"winreg": _fake_winreg()}):
         br._install_vulkan_layer(install_dir, build_dir)
 
     dst = install_dir / "renderdoc.json"
     assert dst.is_file()
     data = json.loads(dst.read_text(encoding="utf-8"))
     assert data["layer"]["library_path"] == ".\\renderdoc.dll"
+
+
+def test_install_vulkan_layer_substitutes_template_vars(tmp_path: Path) -> None:
+    """Real-template placeholders are all substituted to canonical values."""
+    import json
+
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+    build_dir = tmp_path / "build"
+    # Mirrors the real upstream template that ships unsubstituted on Windows.
+    _write_layer_template(
+        build_dir,
+        json.dumps(
+            {
+                "layer": {
+                    "name": "@VULKAN_LAYER_NAME@",
+                    "library_path": "@VULKAN_LAYER_MODULE_PATH@",
+                    "implementation_version": "@RENDERDOC_VERSION_MINOR@",
+                    "enable_environment": {"@VULKAN_ENABLE_VAR@": "1"},
+                    "disable_environment": {
+                        "DISABLE_VULKAN_RENDERDOC_CAPTURE_"
+                        "@RENDERDOC_VERSION_MAJOR@_@RENDERDOC_VERSION_MINOR@": "1"
+                    },
+                }
+            }
+        ),
+    )
+
+    with patch.dict("sys.modules", {"winreg": _fake_winreg()}):
+        br._install_vulkan_layer(install_dir, build_dir, "v1.41")
+
+    dst = install_dir / "renderdoc.json"
+    serialized = dst.read_text(encoding="utf-8")
+    assert "@" not in serialized
+    layer = json.loads(serialized)["layer"]
+    assert layer["name"] == "VK_LAYER_RENDERDOC_Capture"
+    assert layer["library_path"] == ".\\renderdoc.dll"
+    assert layer["implementation_version"] == "41"
+    assert layer["enable_environment"] == {"ENABLE_VULKAN_RENDERDOC_CAPTURE": "1"}
+    assert layer["disable_environment"] == {"DISABLE_VULKAN_RENDERDOC_CAPTURE_1_41": "1"}
+
+
+def test_install_vulkan_layer_guards_unsubstituted_placeholder(tmp_path: Path) -> None:
+    """A stray placeholder field not handled by the substitution raises loudly."""
+    import json
+
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+    build_dir = tmp_path / "build"
+    _write_layer_template(
+        build_dir,
+        json.dumps({"layer": {"library_path": "x", "description": "@SOME_NEW_VAR@"}}),
+    )
+
+    with (
+        patch.dict("sys.modules", {"winreg": _fake_winreg()}),
+        pytest.raises(RuntimeError, match="unsubstituted template vars"),
+    ):
+        br._install_vulkan_layer(install_dir, build_dir, "v1.41")
 
 
 def test_install_vulkan_layer_skips_when_no_json(tmp_path: Path) -> None:

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
@@ -21,6 +22,7 @@ from rdc.commands.doctor import (
     _check_win_renderdoc_install,
     _check_win_vs_build_tools,
     _check_win_vulkan_layer,
+    _enumerate_implicit_layers,
     _import_renderdoc,
     _make_build_hint,
     doctor_cmd,
@@ -882,3 +884,115 @@ class TestCheckWinVulkanLayer:
         result = _check_win_vulkan_layer()
         assert result.ok is True
         assert "registered" in result.detail
+
+
+# ── Vulkan layer check (cross-platform, mocked winreg) ───────────────
+
+
+def _make_fake_winreg(values: dict[int, list[str]]) -> object:
+    """Build a fake winreg whose ImplicitLayers values come from *values* per-hive."""
+
+    class _FakeKey:
+        def __init__(self, hive: int) -> None:
+            self._values = list(values.get(hive, []))
+
+        def __enter__(self) -> _FakeKey:
+            return self
+
+        def __exit__(self, *a: object) -> None:
+            pass
+
+    fake = SimpleNamespace(HKEY_CURRENT_USER=0x80000001, HKEY_LOCAL_MACHINE=0x80000002, REG_DWORD=4)
+
+    def _open_key(hive: int, path: str) -> _FakeKey:
+        if hive not in values:
+            raise OSError("no such key")
+        return _FakeKey(hive)
+
+    def _enum_value(key: _FakeKey, i: int) -> tuple[str, int, int]:
+        if i >= len(key._values):
+            raise OSError("done")
+        return (key._values[i], 0, 4)
+
+    fake.OpenKey = _open_key  # type: ignore[attr-defined]
+    fake.EnumValue = _enum_value  # type: ignore[attr-defined]
+    return fake
+
+
+def _write_manifest(path: Path, name: str, dll_name: str = "renderdoc.dll") -> None:
+    # Forward-slash library_path resolves on both POSIX (test host) and Windows.
+    (path.parent / dll_name).write_bytes(b"\x00")
+    path.write_text(
+        f'{{"layer":{{"name":"{name}","library_path":"./{dll_name}",'
+        f'"implementation_version":"41"}}}}',
+        encoding="utf-8",
+    )
+
+
+def test_vulkan_layer_warns_on_duplicate(tmp_path: Path) -> None:
+    """Two registered layers sharing VK_LAYER_RENDERDOC_Capture is reported as FAIL."""
+    sys_json = tmp_path / "system" / "renderdoc.json"
+    rdc_json = tmp_path / "rdc" / "renderdoc.json"
+    sys_json.parent.mkdir()
+    rdc_json.parent.mkdir()
+    _write_manifest(sys_json, "VK_LAYER_RENDERDOC_Capture", "system_renderdoc.dll")
+    _write_manifest(rdc_json, "VK_LAYER_RENDERDOC_Capture", "renderdoc.dll")
+
+    fake = _make_fake_winreg({0x80000002: [str(sys_json)], 0x80000001: [str(rdc_json)]})
+    with (
+        patch.object(sys, "platform", "win32"),
+        patch.dict("sys.modules", {"winreg": fake}),
+    ):
+        result = _check_win_vulkan_layer()
+
+    assert result.ok is False
+    assert "2 'VK_LAYER_RENDERDOC_Capture' layers" in result.detail
+    assert str(sys_json) in result.detail
+    assert str(rdc_json) in result.detail
+
+
+def test_vulkan_layer_ok_on_single(tmp_path: Path) -> None:
+    """A single registered renderdoc layer stays green."""
+    rdc_json = tmp_path / "rdc" / "renderdoc.json"
+    rdc_json.parent.mkdir()
+    _write_manifest(rdc_json, "VK_LAYER_RENDERDOC_Capture")
+
+    fake = _make_fake_winreg({0x80000001: [str(rdc_json)]})
+    with (
+        patch.object(sys, "platform", "win32"),
+        patch.dict("sys.modules", {"winreg": fake}),
+    ):
+        result = _check_win_vulkan_layer()
+
+    assert result.ok is True
+    assert f"registered at {rdc_json}" == result.detail
+
+
+def test_vulkan_layer_same_manifest_both_hives_not_duplicate(tmp_path: Path) -> None:
+    """One manifest registered under both hives is a single layer, not a duplicate."""
+    rdc_json = tmp_path / "rdc" / "renderdoc.json"
+    rdc_json.parent.mkdir()
+    _write_manifest(rdc_json, "VK_LAYER_RENDERDOC_Capture")
+
+    fake = _make_fake_winreg({0x80000001: [str(rdc_json)], 0x80000002: [str(rdc_json)]})
+    with (
+        patch.object(sys, "platform", "win32"),
+        patch.dict("sys.modules", {"winreg": fake}),
+    ):
+        result = _check_win_vulkan_layer()
+
+    assert result.ok is True
+    assert f"registered at {rdc_json}" == result.detail
+
+
+def test_enumerate_implicit_layers_both_hives(tmp_path: Path) -> None:
+    """_enumerate_implicit_layers collects renderdoc entries from HKLM and HKCU."""
+    a = str(tmp_path / "a" / "renderdoc.json")
+    b = str(tmp_path / "b" / "renderdoc.json")
+    fake = _make_fake_winreg({0x80000001: [a, "C:/other/foo.json"], 0x80000002: [b]})
+    with patch.dict("sys.modules", {"winreg": fake}):
+        layers = _enumerate_implicit_layers()
+
+    assert Path(a) in layers
+    assert Path(b) in layers
+    assert Path("C:/other/foo.json") not in layers


### PR DESCRIPTION
Addresses #256 (Parts 1 and 2; Part 3 deferred).

## Problem
On Windows, rdc's installed Vulkan layer manifest (`renderdoc.json`) kept unsubstituted CMake template vars, because upstream's `configure_file` runs only in the UNIX CMake branch. The installer rewrote only `library_path`, so `@VULKAN_ENABLE_VAR@` survived as the enable-environment key and rdc's own implicit layer could never self-enable. Combined with a system RenderDoc install (a second `VK_LAYER_RENDERDOC_Capture` layer), Vulkan captures silently timed out, and `rdc doctor` stayed green.

## Fix
**Part 1 — manifest substitution** (`_build_renderdoc.py:_install_vulkan_layer`): thread the in-scope version (`RDOC_TAG` / `--version`) through and resolve every templated field — force `name=VK_LAYER_RENDERDOC_Capture`, `enable_environment={ENABLE_VULKAN_RENDERDOC_CAPTURE: "1"}` (matching the env var `capture_core` already sets for the child), derive the `DISABLE_VULKAN_RENDERDOC_CAPTURE_<major>_<minor>` key and `implementation_version` from the version, keep `library_path=.\renderdoc.dll`. A post-serialization guard raises if any `@` remains, so a future template change fails loudly instead of regressing silently.

**Part 2 — duplicate-layer detection** (`doctor.py:_check_win_vulkan_layer`): enumerate HKLM+HKCU implicit layers (mockable `winreg` helper), resolve each manifest's `layer.name`, dedup by resolved path, and warn when more than one distinct layer resolves to `VK_LAYER_RENDERDOC_Capture` — listing each manifest path, DLL, and version. A single layer stays green.

## Deferred (Part 3)
Forcing rdc's own layer for the spawned child via `VK_ADD_LAYER_PATH` / `VK_LOADER_LAYERS_ENABLE` / `VK_LOADER_LAYERS_DISABLE` is documented in the proposal as a follow-up: it needs a real Windows box with a dual RenderDoc install to verify, and because both layers share the exact name `VK_LAYER_RENDERDOC_Capture`, a name-based `VK_LOADER_LAYERS_DISABLE` would disable both — an unresolved design question.

## Tests
New cases in `test_build_renderdoc.py` (real-template substitution → zero `@`, correct values; `@` guard raises; version threading) and `test_doctor.py` (duplicate warn; single green; same-manifest-both-hives dedup; both-hive enumeration), all cross-platform via mocked `winreg`.

`pixi run lint && pixi run typecheck && pixi run test`: all green (2998 passed, 6 skipped, 93.09% coverage).

## Verification note
Parts 1 and 2 are fully covered by deterministic unit tests. Their end-to-end effect (capture succeeds with a dual install) is only fully confirmable on a real Windows machine with two RenderDoc installs, which the deferred Part 3 also requires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Vulkan capture layer manifest configuration on Windows—all template fields now properly substitute during installation, preventing layer self-enable failures.
  * Enhanced `rdc doctor` to detect and report duplicate Vulkan layer registrations across system registries that could interfere with capture operations.

* **Tests**
  * Added test coverage for manifest substitution validation and duplicate layer detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->