### PR TITLE
docs: fix stale command signatures and add cbuffer/rt-depth/--gpu coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ rdc search "shadowMap"                # grep across all shaders in the frame
 ```bash
 rdc texture 5 -o albedo.png           # export a texture
 rdc rt 142 -o render.png              # export render target
+rdc rt 142 --depth -o depth.png       # export raw depth attachment
 rdc buffer 88 -o verts.bin            # export raw buffer
+rdc cbuffer 142 --stage ps --binding 0  # decode a constant buffer to JSON
 rdc snapshot 142 -o ./snap/           # pipeline + shaders + render targets
 rdc draws --json | jq '.[] | select(.triangles > 10000)'  # filter with jq
 ```
@@ -150,6 +152,9 @@ rdc-cli supports three deployment modes:
 | **Split** (`--listen`/`--connect`) | server | server-local GPU | **no** |
 
 ```bash
+# Multi-GPU host: force the replay GPU (0-based index, name, or device ID)
+rdc open frame.rdc --gpu 1
+
 # Proxy: local daemon, remote GPU (needs renderdoccmd on remote)
 rdc open frame.rdc --proxy gpu-server:39920
 
@@ -211,12 +216,12 @@ Run `rdc --help` for the full list, or `rdc <command> --help` for details.  See 
 | Debug | `debug pixel`, `debug vertex`, `debug thread`, `pixel`, `pick-pixel`, `tex-stats` |
 | Shader edit | `shader-build`, `shader-replace`, `shader-restore`, `shader-restore-all`, `shader-encodings` |
 | Resources | `resources`, `resource`, `passes`, `pass`, `usage`, `unused-targets` |
-| Export | `texture`, `rt`, `buffer`, `mesh`, `snapshot` |
+| Export | `texture`, `rt`, `buffer`, `cbuffer`, `mesh`, `snapshot` |
 | Search | `search`, `counters` |
 | Assertions | `assert-pixel`, `assert-state`, `assert-image`, `assert-count`, `assert-clean` |
 | Diff | `diff` (with `--draws`, `--stats`, `--framebuffer`, `--pipeline`, etc.) |
 | VFS | `ls`, `cat`, `tree` |
-| Remote | `remote connect`, `remote list`, `remote capture` |
+| Remote | `remote connect`, `remote list`, `remote capture`, `remote setup`, `remote status`, `remote disconnect` |
 | Android | `android setup`, `android stop`, `android capture` |
 | Target control | `attach`, `capture-trigger`, `capture-list`, `capture-copy` |
 | Capture file | `sections`, `section`, `callstacks`, `gpus`, `thumbnail` |

--- a/docs-astro/src/pages/docs/examples.astro
+++ b/docs-astro/src/pages/docs/examples.astro
@@ -52,7 +52,9 @@ rdc draws --no-header
 
 {"# Quiet — IDs only, great for xargs loops"}
 rdc draws -q
-{"# → 11\n14\n19"}
+{"# → 11"}
+{"#   14"}
+{"#   19"}
 
 {"# Combine: export all draw render targets"}
 for eid in $(rdc draws -q); do
@@ -171,7 +173,9 @@ rdc snapshot 142 -o ./snapshot/
 {"# Individual exports"}
 rdc texture 5 -o albedo.png             {"# specific texture"}
 rdc buffer 3 -o vertex_data.bin         {"# raw buffer data"}
-rdc mesh 142 -o geometry.obj            {"# post-transform mesh"}</code></pre>
+rdc mesh 142 -o geometry.obj            {"# post-transform mesh"}
+rdc rt 142 --depth -o depth.png         {"# raw depth attachment"}
+rdc cbuffer 142 --stage ps --binding 0  {"# decode constant buffer to JSON"}</code></pre>
 
   <h2 id="shell-pipelines">Shell Pipeline Power</h2>
 
@@ -282,12 +286,6 @@ rdc passes --json | jq '.[] | select(.load_ops[]? == "Clear" and .store_ops[]? =
 
   <pre><code>{"# Per-pass reads/writes/load/store table"}
 rdc passes --deps --table
-
-{"# TBR/mobile: identify passes that switch render targets frequently"}
-rdc passes --switches
-
-{"# Passes with RT_SWITCHES > 2 (high bandwidth pressure on tile-based GPUs)"}
-rdc passes --switches --json | jq '.[] | select(.rt_switches > 2) | {"{ name, rt_switches }"}'
 
 {"# Full dependency graph as DOT (render with Graphviz)"}
 rdc passes --deps --dot | dot -Tsvg -o passes.svg</code></pre>

--- a/docs-astro/src/pages/docs/install.astro
+++ b/docs-astro/src/pages/docs/install.astro
@@ -108,7 +108,11 @@ export RENDERDOC_PYTHON_PATH=$PWD/build/lib</code></pre>
   <pre><code>rdc doctor</code></pre>
   <p>
     This checks renderdoc module availability, Python version compatibility,
-    and system configuration.
+    and system configuration. It also warns when more than one
+    <code>VK_LAYER_RENDERDOC_Capture</code> Vulkan layer is registered (a
+    system-installed RenderDoc plus the rdc-managed one create a split-brain
+    where the loader picks one non-deterministically and capture can silently
+    time out).
   </p>
 
   <h2>Shell Completions</h2>

--- a/docs-astro/src/pages/docs/remote.astro
+++ b/docs-astro/src/pages/docs/remote.astro
@@ -451,6 +451,9 @@ rdc pipeline</code></pre>
   <pre><code># Local mode (default)
 rdc open capture.rdc
 
+# Force a specific replay GPU on a multi-GPU host
+rdc open capture.rdc --gpu INDEX|NAME|DEVICEID
+
 # Proxy mode
 rdc open capture.rdc --proxy HOST[:PORT]|adb://SERIAL
 
@@ -475,6 +478,8 @@ rdc remote capture APP [-o OUTPUT]</code></pre>
     <li><code>--android</code> is mutually exclusive with <code>--proxy</code>, <code>--connect</code>, and <code>--listen</code>.</li>
     <li><code>--listen</code> can be combined with <code>--proxy</code> for Split+Proxy setups.</li>
     <li>For <code>rdc open</code>, <code>--remote</code> is a deprecated alias for <code>--proxy</code> (hidden, shows deprecation warning).</li>
+    <li><code>--gpu INDEX|NAME|DEVICEID</code> forces the replay GPU on a multi-GPU host, by 0-based index, name substring, or device ID (overrides auto-selection).</li>
+    <li>Remote and <code>--proxy</code> hosts given as <code>localhost</code> are auto-normalized to <code>127.0.0.1</code>, because <code>renderdoccmd</code> remoteserver is IPv4-only.</li>
     <li>The daemon has a 30-minute idle timeout by default. Any command resets the timer.</li>
     <li>IPv6 is not currently supported (<code>HOST:PORT</code> parsing uses <code>rsplit(":", 1)</code>).</li>
   </ul>

--- a/docs-astro/src/pages/docs/usage.astro
+++ b/docs-astro/src/pages/docs/usage.astro
@@ -107,9 +107,6 @@ rdc passes
 # Per-pass dependency graph (reads/writes/load/store)
 rdc passes --deps --table
 
-# Add RT_SWITCHES column for TBR/mobile bandwidth analysis
-rdc passes --switches
-
 # Inspect attachments, load/store ops, and dimensions for a pass
 rdc pass GBuffer
 

--- a/src/rdc/_skills/SKILL.md
+++ b/src/rdc/_skills/SKILL.md
@@ -26,10 +26,10 @@ Follow this session lifecycle for any capture analysis task:
    - Split thin-client: `rdc open --connect host:port --token TOKEN`
    - Android device: `rdc open capture.rdc --android [--serial SERIAL]`
 2. **Inspect** metadata: `rdc info`, `rdc stats`, `rdc events`
-3. **Navigate** the VFS: `rdc ls /`, `rdc ls /textures`, `rdc cat /pipelines/0`
+3. **Navigate** the VFS: `rdc ls /`, `rdc ls /textures`, `rdc cat /draws/0/pipeline/summary`
 4. **Analyze** specifics: `rdc shaders`, `rdc pipeline`, `rdc resources`, `rdc bindings`
-5. **Debug** shaders: `rdc debug pixel X Y`, `rdc debug vertex EID VTXID`, `rdc debug thread EID GX GY GZ`
-6. **Export** data: `rdc texture EID -o out.png`, `rdc rt EID`, `rdc buffer EID -o buf.bin`, `rdc log`
+5. **Debug** shaders: `rdc debug pixel EID X Y`, `rdc debug vertex EID VTXID`, `rdc debug thread EID GX GY GZ`
+6. **Export** data: `rdc texture ID -o out.png`, `rdc rt EID`, `rdc buffer ID -o buf.bin`, `rdc cbuffer EID --stage ps --binding 0`, `rdc log`
 7. **Close** the session: `rdc close`
 
 ### Session Management
@@ -118,15 +118,16 @@ rdc draws --pass "GBuffer" --json
 ### Trace a pixel
 
 ```bash
-rdc debug pixel 512 384
-rdc debug pixel 512 384 --json    # structured output
-rdc debug pixel 512 384 --trace   # full step-by-step trace
+rdc debug pixel 1024 512 384            # EID first, then X Y
+rdc debug pixel 1024 512 384 --json     # structured output
+rdc debug pixel 1024 512 384 --trace    # full step-by-step trace
 ```
 
 ### Search shaders by name or source
 
 ```bash
-rdc search "main" --type shader
+rdc search "main"                  # regex search over shader disassembly
+rdc search "Sample" --stage ps -C 2
 rdc shaders --name "GBuffer*"
 ```
 
@@ -134,7 +135,15 @@ rdc shaders --name "GBuffer*"
 
 ```bash
 rdc rt EID -o output.png
-rdc texture EID --format png -o tex.png
+rdc rt EID --depth -o depth.png      # export the raw depth attachment
+rdc texture ID -o tex.png            # export a texture by resource ID (PNG)
+```
+
+### Decode a constant buffer
+
+```bash
+rdc cbuffer EID --stage ps --binding 0           # decode to JSON
+rdc cbuffer EID --stage vs --binding 0 --raw -o cbuffer.bin
 ```
 
 ### Browse VFS paths
@@ -142,7 +151,8 @@ rdc texture EID --format png -o tex.png
 ```bash
 rdc ls /
 rdc ls /textures -l
-rdc tree /pipelines --depth 2
+rdc tree /draws/42/pipeline --depth 2     # pipeline state lives under /draws/<eid>/pipeline/
+rdc cat /draws/42/pipeline/summary
 rdc cat /events/42
 ```
 
@@ -168,11 +178,11 @@ rdc-cli provides assertion commands that exit non-zero on failure, designed for 
 
 | Command | Purpose |
 |---------|---------|
-| `rdc assert-pixel X Y --expect R,G,B,A` | Assert pixel color at coordinates |
+| `rdc assert-pixel EID X Y --expect "R G B A"` | Assert pixel RGBA (4 space-separated floats) at EID/coordinates |
 | `rdc assert-clean` | Assert no validation errors in capture |
-| `rdc assert-count --type DrawIndexed --min N` | Assert minimum draw call count |
-| `rdc assert-state FIELD VALUE` | Assert pipeline state field matches value |
-| `rdc assert-image EID --ref reference.png` | Assert render target matches reference image |
+| `rdc assert-count <what> --expect N [--op CHOICE]` | Assert a capture metric (e.g. `draws`) satisfies a comparison |
+| `rdc assert-state EID KEY-PATH --expect VALUE` | Assert pipeline state value at EID matches expected |
+| `rdc assert-image EXPECTED ACTUAL [--threshold FLOAT]` | Compare two image files pixel-by-pixel |
 
 Example CI script:
 
@@ -181,8 +191,8 @@ Example CI script:
 set -e
 rdc open test_capture.rdc
 rdc assert-clean
-rdc assert-count --type DrawIndexed --min 10
-rdc assert-pixel 256 256 --expect 1.0,0.0,0.0,1.0
+rdc assert-count draws --expect 10 --op ge
+rdc assert-pixel 1024 256 256 --expect "1.0 0.0 0.0 1.0"
 rdc close
 ```
 
@@ -191,13 +201,13 @@ rdc close
 Modify and replay shaders without recompiling the application:
 
 ```bash
-rdc shader-encodings EID          # list available encodings
-rdc shader EID --source > s.frag  # extract shader source
+rdc shader-encodings                       # list available encodings
+rdc shader EID ps --source > s.frag        # extract shader source
 # ... edit s.frag ...
-rdc shader-build s.frag --encoding glsl  # compile edited shader
-rdc shader-replace EID s.frag     # hot-swap into capture
-rdc shader-restore EID            # revert single shader
-rdc shader-restore-all            # revert all modifications
+rdc shader-build s.frag --stage ps         # compile; prints the built shader ID
+rdc shader-replace EID ps --with <ID>      # hot-swap built shader ID into capture
+rdc shader-restore EID ps                  # revert single shader (STAGE required)
+rdc shader-restore-all                     # revert all modifications
 ```
 
 ## Remote Capture Workflow
@@ -244,6 +254,7 @@ Common failure categories (conceptual, not literal error strings — map from th
 - **version mismatch** — host and target RenderDoc versions differ. Re-run `rdc setup-renderdoc` or `rdc setup-renderdoc --android` to align.
 - **inject failed / ident=0** — injection blocked (Android EMUI, macOS SIP, Windows privilege). Run `rdc doctor` and check the platform-specific detail.
 - **OpenCapture unsupported** — local GPU can't replay the capture's API surface; switch to `--proxy` or `--android` remote replay.
+- **duplicate Vulkan layer** — `rdc doctor` warns when more than one `VK_LAYER_RENDERDOC_Capture` Vulkan layer is registered (a system-installed RenderDoc plus the rdc-managed one create a split-brain). The loader then picks one non-deterministically and capture can silently time out; unregister the extra manifest so only one remains.
 - **not loaded / no session** — forgot `rdc open`; use `rdc status` to inspect.
 
 For long operations (large capture transfers, remote replay init), the CLI has limited progress feedback — this is a known UX gap, not a hang. Wait up to the `--timeout` value before concluding failure.


### PR DESCRIPTION
Comprehensive refresh of the hand-written user docs against the current command surface (auto-generated `commands.json`/`commands-quick-ref.md` were already fresh; the hand-written docs had drifted).

## Fixes
**`SKILL.md` — wrong command signatures (agents execute these verbatim, so they were failing):**
- `texture` (dropped non-existent `--format`), `assert-count`/`assert-pixel`/`assert-image`/`assert-state`, `search` (dropped `--type`), `shader-replace`/`shader-restore`/`shader-build` forms, `debug pixel` EID-first, and all `/pipelines` VFS paths → `/draws/<eid>/pipeline/`.
- Added `cbuffer` to the export workflow + the `rdc doctor` duplicate-Vulkan-layer warning note.

**Astro site:**
- Removed the dead `passes --switches` / `RT_SWITCHES` docs (that flag was removed) from `usage.astro` + `examples.astro`.
- Added `cbuffer` and `rt --depth` examples; fixed a literal `\n` render artifact.
- `remote.astro`: documented `open --gpu` and the `localhost`→`127.0.0.1` remote normalization.

**README:** added `cbuffer` to Export, completed the `remote` subcommand list, added `cbuffer`/`rt --depth`/`--gpu` examples.

Every corrected signature was verified against `commands.json` + source. No auto-generated files touched.

## Verification
`check-commands` / `check-replay` exit 0 · `lint` clean · `test` 3037 passed/6 skipped (93.17%) · `docs-build` built all 10 pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI command examples and syntax for export, debugging, and assertion workflows
  * Added multi-GPU replay support documentation with `--gpu` option
  * Enhanced offline analysis examples with additional export commands
  * Added Vulkan layer configuration warning in installation guide
  * Removed deprecated features from documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->