### PR TITLE
fix(cbuffer): handle D3D raw export and vs-in fallback

### DIFF
--- a/src/rdc/commands/cbuffer.py
+++ b/src/rdc/commands/cbuffer.py
@@ -50,7 +50,7 @@ def cbuffer_cmd(
             raise click.UsageError("-o/--output is required with --raw")
         if eid is None:
             raise click.UsageError("EID is required with --raw")
-        _export_vfs_path(f"/draws/{eid}/cbuffer/{cb_set}/{binding}/data", output, raw)
+        _export_vfs_path(f"/draws/{eid}/cbuffer/{stage}/{cb_set}/{binding}/data", output, raw)
         return
 
     del use_json

--- a/src/rdc/handlers/buffer.py
+++ b/src/rdc/handlers/buffer.py
@@ -44,6 +44,56 @@ def _decode_index_buffer(data: bytes, stride: int) -> list[int]:
     return [struct.unpack_from(fmt, data, i)[0] for i in range(0, len(data), item_size)]
 
 
+def _shader_variable_value_kind(var_type: Any) -> str:
+    """Return the ShaderValue lane name for a reflected variable type."""
+    if isinstance(var_type, int):
+        if var_type == 4:
+            return "u32v"
+        if var_type == 5:
+            return "s32v"
+        return "f32v"
+
+    type_name = getattr(var_type, "name", var_type)
+    type_str = str(type_name).lower()
+    if "uint" in type_str or type_str in {"u32", "uint32"}:
+        return "u32v"
+    if "sint" in type_str or "int" in type_str or type_str in {"s32", "int32"}:
+        return "s32v"
+    return "f32v"
+
+
+def _shader_variable_values(var: Any) -> Any:
+    """Extract a scalar or row-major vector/matrix value from ShaderValue."""
+    val = getattr(var, "value", None)
+    if val is None:
+        return None
+    r = getattr(var, "rows", 1) or 1
+    c = getattr(var, "columns", 1) or 1
+    lane = getattr(val, _shader_variable_value_kind(getattr(var, "type", "")), None)
+    if lane is None:
+        return val
+    values = [lane[ri * c + ci] for ri in range(r) for ci in range(c)]
+    return values if len(values) > 1 else values[0]
+
+
+def _shader_stage_param(params: dict[str, Any], default: str = "ps") -> tuple[str, int]:
+    stage_name = str(params.get("stage", default)).lower()
+    if stage_name not in STAGE_MAP:
+        allowed = ", ".join(STAGE_MAP)
+        raise ValueError(f"invalid stage {stage_name!r}; use {allowed}")
+    return stage_name, STAGE_MAP[stage_name]
+
+
+def _find_action(actions: list[Any], eid: int) -> Any | None:
+    for action in actions:
+        if getattr(action, "eventId", None) == eid:
+            return action
+        found = _find_action(getattr(action, "children", []), eid)
+        if found is not None:
+            return found
+    return None
+
+
 def _handle_buf_info(
     request_id: int, params: dict[str, Any], state: DaemonState
 ) -> tuple[dict[str, Any], bool]:
@@ -110,8 +160,10 @@ def _handle_cbuffer_decode(  # noqa: PLR0912
 ) -> tuple[dict[str, Any], bool]:
     cb_set = int(params.get("set", 0))
     cb_binding = int(params.get("binding", 0))
-    stage_name = str(params.get("stage", "ps"))
-    stage_val = STAGE_MAP.get(stage_name, 4)
+    try:
+        stage_name, stage_val = _shader_stage_param(params)
+    except ValueError as exc:
+        return _error_response(request_id, -32602, str(exc)), True
     try:
         eid, pipe_state = require_pipe(params, state, request_id)
     except PipeError as exc:
@@ -160,18 +212,6 @@ def _handle_cbuffer_decode(  # noqa: PLR0912
         cb_size,
     )
 
-    def _extract_value(v: Any) -> Any:
-        val = getattr(v, "value", None)
-        if val is None:
-            return None
-        f32v = getattr(val, "f32v", None)
-        if f32v is not None:
-            r = getattr(v, "rows", 1) or 1
-            c = getattr(v, "columns", 1) or 1
-            values = [f32v[ri * c + ci] for ri in range(r) for ci in range(c)]
-            return values if len(values) > 1 else values[0]
-        return val
-
     def _flatten_vars(
         vs: list[Any],
         prefix: str = "",
@@ -187,7 +227,9 @@ def _handle_cbuffer_decode(  # noqa: PLR0912
                 cb_rows.extend(_flatten_vars(members, f"{name}.", depth + 1))
             else:
                 vtype = getattr(v, "type", "")
-                cb_rows.append({"name": name, "type": str(vtype), "value": _extract_value(v)})
+                cb_rows.append(
+                    {"name": name, "type": str(vtype), "value": _shader_variable_values(v)}
+                )
         return cb_rows
 
     flat = _flatten_vars(variables)
@@ -201,8 +243,10 @@ def _handle_cbuffer_raw(
 ) -> tuple[dict[str, Any], bool]:
     cb_set = int(params.get("set", 0))
     cb_binding = int(params.get("binding", 0))
-    stage_name = str(params.get("stage", "ps"))
-    stage_val = STAGE_MAP.get(stage_name, 4)
+    try:
+        stage_name, stage_val = _shader_stage_param(params)
+    except ValueError as exc:
+        return _error_response(request_id, -32602, str(exc)), True
     if state.temp_dir is None:
         return _error_response(request_id, -32002, "temp directory not available"), True
     try:
@@ -257,7 +301,7 @@ def _handle_cbuffer_raw(
             "cbuffer size is unknown (descriptor and reflection both report 0)",
         ), True
     raw_data = controller.GetBufferData(cb_resource, cb_offset, cb_size)
-    temp_path = state.temp_dir / f"cbuffer_{eid}_{cb_set}_{cb_binding}.bin"
+    temp_path = state.temp_dir / f"cbuffer_{eid}_{stage_name}_{cb_set}_{cb_binding}.bin"
     temp_path.write_bytes(raw_data)
     return _result_response(
         request_id,
@@ -338,6 +382,185 @@ def _handle_vbuffer_decode(  # noqa: PLR0912
 
 
 _MESH_STAGE_MAP: dict[str, int] = {"vs-in": 0, "vs-out": 1, "gs-out": 2}
+_ACTION_INDEXED = 0x10000
+_UINT64_MAX = (1 << 64) - 1
+
+
+def _known_byte_size(value: Any) -> int:
+    size = int(value or 0)
+    return 0 if size < 0 or size >= _UINT64_MAX else size
+
+
+def _mesh_data_usable(mesh: Any) -> bool:
+    return (
+        int(getattr(mesh, "vertexResourceId", 0)) != 0 and getattr(mesh, "vertexByteStride", 0) > 0
+    )
+
+
+def _same_postvs_source(a: Any, b: Any) -> bool:
+    keys = (
+        "vertexResourceId",
+        "vertexByteStride",
+        "vertexByteOffset",
+        "vertexByteSize",
+        "indexResourceId",
+        "indexByteOffset",
+        "indexByteSize",
+        "indexByteStride",
+    )
+    return all(getattr(a, key, None) == getattr(b, key, None) for key in keys)
+
+
+def _decode_mesh_postvs(controller: Any, mesh: Any) -> dict[str, Any]:
+    vrid = int(getattr(mesh, "vertexResourceId", 0))
+    stride = getattr(mesh, "vertexByteStride", 0)
+    if vrid == 0 or stride == 0:
+        raise ValueError("no PostVS data at this event")
+    fmt = getattr(mesh, "format", None)
+    comp_width = getattr(fmt, "compByteWidth", 4) if fmt else 4
+    comp_count = getattr(fmt, "compCount", 4) if fmt else 4
+    pos_offset = getattr(mesh, "vertexByteOffset", 0)
+    v_size = _known_byte_size(getattr(mesh, "vertexByteSize", 0))
+    if v_size == 0:
+        raise ValueError("PostVS vertex buffer size is unknown")
+    raw = controller.GetBufferData(mesh.vertexResourceId, 0, v_size)
+    num_verts = len(raw) // stride if stride > 0 else 0
+    num_indices = getattr(mesh, "numIndices", 0)
+    if num_indices > 0:
+        irid = getattr(mesh, "indexResourceId", None)
+        if irid is None or int(irid) == 0:
+            num_verts = min(num_verts, num_indices)
+    vertices = _decode_position_rows(raw, num_verts, stride, pos_offset, comp_width, comp_count)
+
+    irid = int(getattr(mesh, "indexResourceId", 0))
+    base_vertex = getattr(mesh, "baseVertex", 0)
+    indices: list[int] = []
+    if irid != 0:
+        i_offset = getattr(mesh, "indexByteOffset", 0)
+        i_size = getattr(mesh, "indexByteSize", 0)
+        i_stride = getattr(mesh, "indexByteStride", 0)
+        if i_stride in (2, 4) and i_size > 0:
+            iraw = controller.GetBufferData(mesh.indexResourceId, i_offset, i_size)
+            indices = [i + base_vertex for i in _decode_index_buffer(iraw, i_stride)]
+    return {
+        "topology": _enum_name(getattr(mesh, "topology", "")),
+        "vertex_count": num_verts,
+        "comp_count": comp_count,
+        "stride": stride,
+        "vertices": vertices,
+        "index_count": len(indices),
+        "indices": indices,
+    }
+
+
+def _decode_position_rows(
+    raw: bytes,
+    num_verts: int,
+    stride: int,
+    pos_offset: int,
+    comp_width: int,
+    comp_count: int,
+) -> list[list[float]]:
+    vertices: list[list[float]] = []
+    for i in range(num_verts):
+        base = i * stride + pos_offset
+        if base + comp_width * comp_count <= len(raw) and comp_width in (1, 2, 4):
+            vertices.append(_decode_float_components(raw, base, comp_width, comp_count))
+        else:
+            comps: list[float] = []
+            for c in range(comp_count):
+                off = base + c * comp_width
+                if off + comp_width <= len(raw) and comp_width in (1, 2, 4):
+                    comps.extend(_decode_float_components(raw, off, comp_width, 1))
+                else:
+                    comps.append(0.0)
+            vertices.append(comps)
+    return vertices
+
+
+def _position_input(inputs: list[Any]) -> Any | None:
+    for vi in inputs:
+        name = str(getattr(vi, "name", "") or getattr(vi, "semanticName", "")).lower()
+        if "position" in name or name.startswith("pos"):
+            return vi
+    return None
+
+
+def _mesh_data_from_ia(controller: Any, pipe_state: Any, action: Any | None) -> dict[str, Any]:
+    if action is None:
+        raise ValueError("no draw action found for eid")
+    inputs = pipe_state.GetVertexInputs()
+    pos_input = _position_input(inputs)
+    if pos_input is None:
+        raise ValueError("no vertex input POSITION at this event")
+    vbuffers = pipe_state.GetVBuffers()
+    slot = getattr(pos_input, "vertexBuffer", 0)
+    if slot >= len(vbuffers):
+        raise ValueError(f"vertex buffer slot {slot} is not bound")
+    vb = vbuffers[slot]
+    vrid = getattr(vb, "resourceId", None)
+    stride = getattr(vb, "byteStride", 0)
+    if vrid is None or int(vrid) == 0 or stride == 0:
+        raise ValueError("POSITION vertex buffer is not bound")
+
+    fmt = getattr(pos_input, "format", None)
+    comp_width = getattr(fmt, "compByteWidth", 4) if fmt else 4
+    comp_count = getattr(fmt, "compCount", 3) if fmt else 3
+    vb_offset = getattr(vb, "byteOffset", 0)
+    action_count = int(getattr(action, "numIndices", 0) or 0)
+
+    first_vertex = 0
+    local_indices: list[int] = []
+    ib = pipe_state.GetIBuffer()
+    irid = getattr(ib, "resourceId", None)
+    i_stride = getattr(ib, "byteStride", 0)
+    is_indexed = bool(int(getattr(action, "flags", 0)) & _ACTION_INDEXED)
+    if action_count <= 0:
+        num_verts = 0
+    elif is_indexed and irid is not None and int(irid) != 0 and i_stride in (1, 2, 4):
+        i_offset = getattr(ib, "byteOffset", 0)
+        i_offset += int(getattr(action, "indexOffset", 0) or 0) * i_stride
+        i_size = action_count * i_stride
+        if i_size > 0:
+            iraw = controller.GetBufferData(irid, i_offset, i_size)
+            base_vertex = int(getattr(action, "baseVertex", 0) or 0)
+            referenced = [i + base_vertex for i in _decode_index_buffer(iraw, i_stride)]
+            if referenced:
+                first_vertex = min(referenced)
+                if first_vertex < 0:
+                    raise ValueError("indexed draw references a negative vertex")
+                local_indices = [i - first_vertex for i in referenced]
+        num_verts = max(local_indices) + 1 if local_indices else 0
+    elif is_indexed:
+        raise ValueError("indexed draw index buffer is not bound")
+    else:
+        first_vertex = int(getattr(action, "vertexOffset", 0) or 0)
+        num_verts = action_count
+
+    known_vb_size = _known_byte_size(getattr(vb, "byteSize", 0))
+    if known_vb_size > 0:
+        remaining = max(known_vb_size - first_vertex * stride, 0)
+        num_verts = min(num_verts, remaining // stride)
+        if local_indices and any(i >= num_verts for i in local_indices):
+            raise ValueError("indexed draw references vertices outside the bound vertex buffer")
+    pos_offset = getattr(pos_input, "byteOffset", 0)
+    read_size = num_verts * stride
+    raw = (
+        controller.GetBufferData(vrid, vb_offset + first_vertex * stride, read_size)
+        if read_size
+        else b""
+    )
+    vertices = _decode_position_rows(raw, num_verts, stride, pos_offset, comp_width, comp_count)
+
+    return {
+        "topology": _enum_name(pipe_state.GetPrimitiveTopology()),
+        "vertex_count": len(vertices),
+        "comp_count": comp_count,
+        "stride": stride,
+        "vertices": vertices,
+        "index_count": len(local_indices),
+        "indices": local_indices,
+    }
 
 
 def _handle_mesh_data(
@@ -357,64 +580,28 @@ def _handle_mesh_data(
         return _error_response(request_id, -32002, err), True
     controller = state.adapter.controller
     mesh = controller.GetPostVSData(0, 0, stage_val)
-    vrid = int(getattr(mesh, "vertexResourceId", 0))
-    stride = getattr(mesh, "vertexByteStride", 0)
-    if vrid == 0 or stride == 0:
-        return _error_response(request_id, -32001, "no PostVS data at this event"), True
-    fmt = getattr(mesh, "format", None)
-    comp_width = getattr(fmt, "compByteWidth", 4) if fmt else 4
-    comp_count = getattr(fmt, "compCount", 4) if fmt else 4
-    # RenderDoc's decode_mesh reads each vertex buffer from the start of the
-    # bound region and locates the position attribute at vertexByteOffset
-    # within the interleaved vertex stride.
-    pos_offset = getattr(mesh, "vertexByteOffset", 0)
-    v_size = getattr(mesh, "vertexByteSize", 0)
-    raw = controller.GetBufferData(mesh.vertexResourceId, 0, v_size)
-    num_verts = len(raw) // stride if stride > 0 else 0
-    num_indices = getattr(mesh, "numIndices", 0)
-    if num_indices > 0:
-        irid = getattr(mesh, "indexResourceId", None)
-        if irid is None or int(irid) == 0:
-            num_verts = min(num_verts, num_indices)
-    vertices: list[list[float]] = []
-    for i in range(num_verts):
-        base = i * stride + pos_offset
-        if base + comp_width * comp_count <= len(raw) and comp_width in (1, 2, 4):
-            vertices.append(_decode_float_components(raw, base, comp_width, comp_count))
+    try:
+        if stage_name == "vs-in":
+            use_ia = not _mesh_data_usable(mesh)
+            if not use_ia:
+                vs_out = controller.GetPostVSData(0, 0, _MESH_STAGE_MAP["vs-out"])
+                use_ia = _mesh_data_usable(vs_out) and _same_postvs_source(mesh, vs_out)
+            if use_ia:
+                pipe_state = state.adapter.get_pipeline_state()
+                action = _find_action(state.adapter.get_root_actions(), eid)
+                decoded = _mesh_data_from_ia(controller, pipe_state, action)
+            else:
+                decoded = _decode_mesh_postvs(controller, mesh)
         else:
-            comps: list[float] = []
-            for c in range(comp_count):
-                off = base + c * comp_width
-                if off + comp_width <= len(raw) and comp_width in (1, 2, 4):
-                    comps.extend(_decode_float_components(raw, off, comp_width, 1))
-                else:
-                    comps.append(0.0)
-            vertices.append(comps)
-    # Decode index buffer. RenderDoc's decode_mesh adds mesh.baseVertex to
-    # every index (0 for vs-out/gs-out, non-zero for vs-in base-vertex draws).
-    irid = int(getattr(mesh, "indexResourceId", 0))
-    base_vertex = getattr(mesh, "baseVertex", 0)
-    indices: list[int] = []
-    if irid != 0:
-        i_offset = getattr(mesh, "indexByteOffset", 0)
-        i_size = getattr(mesh, "indexByteSize", 0)
-        i_stride = getattr(mesh, "indexByteStride", 0)
-        if i_stride in (2, 4) and i_size > 0:
-            iraw = controller.GetBufferData(mesh.indexResourceId, i_offset, i_size)
-            indices = [i + base_vertex for i in _decode_index_buffer(iraw, i_stride)]
-    topology = _enum_name(getattr(mesh, "topology", ""))
+            decoded = _decode_mesh_postvs(controller, mesh)
+    except ValueError as exc:
+        return _error_response(request_id, -32001, str(exc)), True
     return _result_response(
         request_id,
         {
             "eid": eid,
             "stage": stage_name,
-            "topology": topology,
-            "vertex_count": num_verts,
-            "comp_count": comp_count,
-            "stride": stride,
-            "vertices": vertices,
-            "index_count": len(indices),
-            "indices": indices,
+            **decoded,
         },
     ), True
 

--- a/src/rdc/vfs/router.py
+++ b/src/rdc/vfs/router.py
@@ -103,6 +103,30 @@ _r(
 _r(r"/draws/(?P<eid>\d+)/postvs", "leaf", "postvs", [("eid", int)])
 _r(r"/draws/(?P<eid>\d+)/cbuffer", "dir", None, [("eid", int)])
 _r(
+    rf"/draws/(?P<eid>\d+)/cbuffer/(?P<stage>{_STAGES})",
+    "dir",
+    None,
+    [("eid", int)],
+)
+_r(
+    rf"/draws/(?P<eid>\d+)/cbuffer/(?P<stage>{_STAGES})/(?P<set>\d+)",
+    "dir",
+    None,
+    [("eid", int), ("set", int)],
+)
+_r(
+    rf"/draws/(?P<eid>\d+)/cbuffer/(?P<stage>{_STAGES})/(?P<set>\d+)/(?P<binding>\d+)",
+    "leaf",
+    "cbuffer_decode",
+    [("eid", int), ("set", int), ("binding", int)],
+)
+_r(
+    rf"/draws/(?P<eid>\d+)/cbuffer/(?P<stage>{_STAGES})/(?P<set>\d+)/(?P<binding>\d+)/data",
+    "leaf_bin",
+    "cbuffer_raw",
+    [("eid", int), ("set", int), ("binding", int)],
+)
+_r(
     r"/draws/(?P<eid>\d+)/cbuffer/(?P<set>\d+)/(?P<binding>\d+)",
     "leaf",
     "cbuffer_decode",

--- a/src/rdc/vfs/tree_cache.py
+++ b/src/rdc/vfs/tree_cache.py
@@ -335,6 +335,7 @@ def populate_draw_subtree(
 
     # Populate cbuffer/ subtree
     cbuffer_sets: dict[int, set[int]] = {}
+    cbuffer_stage_sets: dict[str, dict[int, set[int]]] = {}
     for stage_name in stages:
         stage_idx = STAGE_MAP[stage_name]
         refl = pipe_state.GetShaderReflection(stage_idx)
@@ -344,11 +345,30 @@ def populate_draw_subtree(
             s = getattr(cb, "fixedBindSetOrSpace", 0)
             b = getattr(cb, "fixedBindNumber", 0)
             cbuffer_sets.setdefault(s, set()).add(b)
+            cbuffer_stage_sets.setdefault(stage_name, {}).setdefault(s, set()).add(b)
 
     cbuffer_path = f"{prefix}/cbuffer"
+    cbuffer_stage_names = [stage for stage in stages if stage in cbuffer_stage_sets]
     cbuffer_set_names = sorted(str(s) for s in cbuffer_sets)
-    tree.static[cbuffer_path].children = list(cbuffer_set_names)
-    subtree[cbuffer_path] = list(cbuffer_set_names)
+    cbuffer_children = cbuffer_stage_names + cbuffer_set_names
+    tree.static[cbuffer_path].children = list(cbuffer_children)
+    subtree[cbuffer_path] = list(cbuffer_children)
+    for stage in cbuffer_stage_names:
+        stage_path = f"{cbuffer_path}/{stage}"
+        stage_sets = cbuffer_stage_sets[stage]
+        stage_set_names = sorted(str(s) for s in stage_sets)
+        tree.static[stage_path] = VfsNode(stage, "dir", list(stage_set_names))
+        subtree[stage_path] = list(stage_set_names)
+        for s in sorted(stage_sets):
+            set_path = f"{stage_path}/{s}"
+            binding_names = sorted(str(b) for b in stage_sets[s])
+            tree.static[set_path] = VfsNode(str(s), "dir", list(binding_names))
+            subtree[set_path] = list(binding_names)
+            for b in stage_sets[s]:
+                leaf_path = f"{set_path}/{b}"
+                tree.static[leaf_path] = VfsNode(str(b), "leaf", ["data"])
+                subtree[leaf_path] = ["data"]
+                tree.static[f"{leaf_path}/data"] = VfsNode("data", "leaf_bin")
     for s, bindings in cbuffer_sets.items():
         set_path = f"{cbuffer_path}/{s}"
         binding_names = sorted(str(b) for b in bindings)

--- a/tests/mocks/mock_renderdoc.py
+++ b/tests/mocks/mock_renderdoc.py
@@ -650,6 +650,7 @@ class ActionDescription:
     numIndices: int = 0
     numInstances: int = 1
     indexOffset: int = 0
+    vertexOffset: int = 0
     baseVertex: int = 0
     instanceOffset: int = 0
     children: list[ActionDescription] = field(default_factory=list)

--- a/tests/unit/test_buffer_decode.py
+++ b/tests/unit/test_buffer_decode.py
@@ -240,6 +240,18 @@ class TestCbufferDecode:
         )
         assert resp["error"]["code"] == -32001
 
+    def test_invalid_stage_rejected(self, state: DaemonState) -> None:
+        resp, _ = _handle_request(
+            rpc_request(
+                "cbuffer_decode",
+                {"eid": 10, "set": 0, "binding": 0, "stage": "../ps"},
+                token="abcdef1234567890",
+            ),
+            state,
+        )
+        assert resp["error"]["code"] == -32602
+        assert "invalid stage" in resp["error"]["message"]
+
     def test_invalid_binding(self, state: DaemonState) -> None:
         resp, _ = _handle_request(
             rpc_request(
@@ -287,8 +299,43 @@ class TestCbufferDecode:
         assert r["variables"][0]["name"] == "light.dir"
         assert r["variables"][1]["name"] == "light.color"
 
+    def test_uint_numeric_type_extracts_u32v(self, state: DaemonState) -> None:
+        """RenderDoc may expose uint cbuffer variables as numeric type 4."""
+        uint_val = ShaderValue(f32v=[0.0] * 16, u32v=[13, 17, 19, 23] + [0] * 12)
+        state.adapter.controller.GetCBufferVariableContents = lambda *args: [
+            ShaderVariable(
+                name="tileCounts",
+                type=4,
+                rows=1,
+                columns=4,
+                value=uint_val,
+            )
+        ]
+        resp, _ = _handle_request(
+            rpc_request(
+                "cbuffer_decode", {"eid": 10, "set": 0, "binding": 0}, token="abcdef1234567890"
+            ),
+            state,
+        )
+        r = resp["result"]
+        assert r["variables"][0]["type"] == "4"
+        assert r["variables"][0]["value"] == [13, 17, 19, 23]
+
 
 class TestCbufferRaw:
+    def test_stageful_raw_data_node_visible_to_vfs_ls(self, state: DaemonState) -> None:
+        resp, _ = _handle_request(
+            rpc_request(
+                "vfs_ls",
+                {"path": "/draws/10/cbuffer/ps/0/0/data"},
+                token="abcdef1234567890",
+            ),
+            state,
+        )
+        r = resp["result"]
+        assert r["path"] == "/draws/10/cbuffer/ps/0/0/data"
+        assert r["kind"] == "leaf_bin"
+
     def test_happy_path(self, state: DaemonState, tmp_path: Path) -> None:
         resp, _ = _handle_request(
             rpc_request(
@@ -301,7 +348,66 @@ class TestCbufferRaw:
         out = Path(r["path"])
         assert out.exists()
         assert out.read_bytes() == bytes(range(16))
-        assert out == tmp_path / "cbuffer_10_0_0.bin"
+        assert out == tmp_path / "cbuffer_10_ps_0_0.bin"
+
+    def test_stage_specific_resources_with_same_set_binding(
+        self, state: DaemonState, tmp_path: Path
+    ) -> None:
+        pipe = state.adapter.controller.GetPipelineState()
+        pipe._shaders[ShaderStage.Vertex] = ResourceId(101)
+        pipe._reflections[ShaderStage.Vertex] = ShaderReflection(
+            constantBlocks=[
+                ConstantBlock(
+                    name="VsParams",
+                    byteSize=4,
+                    fixedBindSetOrSpace=0,
+                    fixedBindNumber=0,
+                ),
+            ],
+        )
+        pipe._cbuffer_descriptors[(ShaderStage.Vertex, 0)] = Descriptor(
+            resource=ResourceId(51),
+            byteOffset=0,
+            byteSize=4,
+        )
+        pipe._cbuffer_descriptors[(ShaderStage.Pixel, 0)] = Descriptor(
+            resource=ResourceId(50),
+            byteOffset=0,
+            byteSize=4,
+        )
+        orig_get = state.adapter.controller.GetBufferData
+
+        def _get(rid: Any, offset: int, length: int) -> bytes:
+            if int(rid) == 51:
+                return b"VS!!"[offset : offset + length]
+            if int(rid) == 50:
+                return b"PS!!"[offset : offset + length]
+            return orig_get(rid, offset, length)
+
+        state.adapter.controller.GetBufferData = _get
+
+        vs_resp, _ = _handle_request(
+            rpc_request(
+                "cbuffer_raw",
+                {"eid": 10, "stage": "vs", "set": 0, "binding": 0},
+                token="abcdef1234567890",
+            ),
+            state,
+        )
+        ps_resp, _ = _handle_request(
+            rpc_request(
+                "cbuffer_raw",
+                {"eid": 10, "stage": "ps", "set": 0, "binding": 0},
+                token="abcdef1234567890",
+            ),
+            state,
+        )
+        vs_path = Path(vs_resp["result"]["path"])
+        ps_path = Path(ps_resp["result"]["path"])
+        assert vs_path.read_bytes() == b"VS!!"
+        assert ps_path.read_bytes() == b"PS!!"
+        assert vs_path == tmp_path / "cbuffer_10_vs_0_0.bin"
+        assert ps_path == tmp_path / "cbuffer_10_ps_0_0.bin"
 
     def test_not_buffer_backed(self, state: DaemonState, tmp_path: Path) -> None:
         pipe = state.adapter.controller.GetPipelineState()
@@ -314,7 +420,7 @@ class TestCbufferRaw:
         )
         assert "error" in resp
         assert "not buffer-backed" in resp["error"]["message"].lower()
-        assert not (tmp_path / "cbuffer_10_0_0.bin").exists()
+        assert not (tmp_path / "cbuffer_10_ps_0_0.bin").exists()
 
     def test_no_adapter(self) -> None:
         s = DaemonState(
@@ -349,6 +455,25 @@ class TestCbufferRaw:
             state,
         )
         assert resp["error"]["code"] == -32001
+
+    def test_invalid_stage_rejected_before_temp_filename(
+        self, state: DaemonState, tmp_path: Path
+    ) -> None:
+        def _fail_get(*args: Any) -> bytes:
+            pytest.fail("invalid stage should not read buffer data")
+
+        state.adapter.controller.GetBufferData = _fail_get
+        resp, _ = _handle_request(
+            rpc_request(
+                "cbuffer_raw",
+                {"eid": 10, "set": 0, "binding": 0, "stage": "../ps"},
+                token="abcdef1234567890",
+            ),
+            state,
+        )
+        assert resp["error"]["code"] == -32602
+        assert "invalid stage" in resp["error"]["message"]
+        assert list(tmp_path.iterdir()) == []
 
     def test_constant_block_unavailable(self, state: DaemonState, monkeypatch: Any) -> None:
         pipe = state.adapter.controller.GetPipelineState()
@@ -388,7 +513,7 @@ class TestCbufferRaw:
         )
         assert resp["error"]["code"] == -32001
         assert "not bound" in resp["error"]["message"].lower()
-        assert not (tmp_path / "cbuffer_10_0_0.bin").exists()
+        assert not (tmp_path / "cbuffer_10_ps_0_0.bin").exists()
 
     def test_zero_byte_size_falls_back_to_reflected(
         self, state: DaemonState, tmp_path: Path
@@ -436,7 +561,7 @@ class TestCbufferRaw:
             state,
         )
         assert "error" in resp
-        assert not (tmp_path / "cbuffer_10_0_0.bin").exists()
+        assert not (tmp_path / "cbuffer_10_ps_0_0.bin").exists()
 
 
 class TestVbufferDecode:
@@ -538,6 +663,307 @@ class TestIbufferDecode:
         r = resp["result"]
         assert r["format"] == "none"
         assert r["indices"] == []
+
+
+class TestMeshVsInFallback:
+    def test_empty_postvs_uses_ia_position(self, state: DaemonState) -> None:
+        resp, _ = _handle_request(
+            rpc_request("mesh_data", {"eid": 10, "stage": "vs-in"}, token="abcdef1234567890"),
+            state,
+        )
+        r = resp["result"]
+        assert r["stage"] == "vs-in"
+        assert r["vertex_count"] == 3
+        assert r["comp_count"] == 3
+        assert r["vertices"][0] == pytest.approx([-1.0, -1.0, 0.0])
+        assert r["vertices"][1] == pytest.approx([1.0, -1.0, 0.0])
+        assert r["vertices"][2] == pytest.approx([0.0, 1.0, 0.0])
+
+    def test_empty_postvs_bounds_unknown_vbuffer_size_by_draw_count(
+        self, state: DaemonState
+    ) -> None:
+        pipe = state.adapter.controller.GetPipelineState()
+        pipe._vbuffers[0].byteSize = (1 << 64) - 1
+        reads: list[tuple[int, int, int]] = []
+        orig_get = state.adapter.controller.GetBufferData
+
+        def _get(rid: Any, offset: int, length: int) -> bytes:
+            reads.append((int(rid), offset, length))
+            assert length < 1024
+            return orig_get(rid, offset, length)
+
+        state.adapter.controller.GetBufferData = _get
+        resp, _ = _handle_request(
+            rpc_request("mesh_data", {"eid": 10, "stage": "vs-in"}, token="abcdef1234567890"),
+            state,
+        )
+        assert resp["result"]["vertices"][0] == pytest.approx([-1.0, -1.0, 0.0])
+        assert (42, 0, 60) in reads
+
+    def test_non_indexed_fallback_applies_first_vertex(self, state: DaemonState) -> None:
+        pipe = state.adapter.controller.GetPipelineState()
+        actions = state.adapter.controller.GetRootActions()
+        actions[0].indexOffset = 2
+        actions[0].vertexOffset = 1
+        actions[0].numIndices = 3
+        vbuf_data = _make_vbuffer_data() + struct.pack("<5f", 2.0, 2.0, 0.0, 0.0, 0.0)
+        reads: list[tuple[int, int, int]] = []
+        orig_get = state.adapter.controller.GetBufferData
+
+        def _get(rid: Any, offset: int, length: int) -> bytes:
+            reads.append((int(rid), offset, length))
+            if int(rid) == 42:
+                return vbuf_data[offset : offset + length]
+            return orig_get(rid, offset, length)
+
+        pipe._vbuffers[0].byteSize = len(vbuf_data)
+        state.adapter.controller.GetBufferData = _get
+        resp, _ = _handle_request(
+            rpc_request("mesh_data", {"eid": 10, "stage": "vs-in"}, token="abcdef1234567890"),
+            state,
+        )
+        r = resp["result"]
+        assert r["indices"] == []
+        assert r["vertex_count"] == 3
+        assert r["vertices"][0] == pytest.approx([1.0, -1.0, 0.0])
+        assert r["vertices"][2] == pytest.approx([2.0, 2.0, 0.0])
+        assert (42, 20, 60) in reads
+
+    def test_fallback_uses_adapter_root_action_compat(self, state: DaemonState) -> None:
+        controller = state.adapter.controller
+        actions = controller.GetRootActions()
+        controller.GetDrawcalls = lambda: actions
+        delattr(controller, "GetRootActions")
+
+        resp, _ = _handle_request(
+            rpc_request("mesh_data", {"eid": 10, "stage": "vs-in"}, token="abcdef1234567890"),
+            state,
+        )
+        assert resp["result"]["vertices"][0] == pytest.approx([-1.0, -1.0, 0.0])
+
+    def test_fallback_requires_position_semantic(self, state: DaemonState) -> None:
+        pipe = state.adapter.controller.GetPipelineState()
+        pipe._vertex_inputs = [
+            VertexInputAttribute(
+                name="TEXCOORD",
+                vertexBuffer=0,
+                byteOffset=12,
+                format=ResourceFormat(
+                    name="R32G32_FLOAT",
+                    compByteWidth=4,
+                    compCount=2,
+                ),
+            )
+        ]
+        state.adapter.controller.GetBufferData = pytest.fail
+
+        resp, _ = _handle_request(
+            rpc_request("mesh_data", {"eid": 10, "stage": "vs-in"}, token="abcdef1234567890"),
+            state,
+        )
+        assert resp["error"]["code"] == -32001
+        assert resp["error"]["message"] == "no vertex input POSITION at this event"
+
+    def test_fallback_requires_draw_action(self, state: DaemonState) -> None:
+        state.adapter.controller.GetRootActions().clear()
+        state.adapter.controller.GetBufferData = pytest.fail
+
+        resp, _ = _handle_request(
+            rpc_request("mesh_data", {"eid": 10, "stage": "vs-in"}, token="abcdef1234567890"),
+            state,
+        )
+        assert resp["error"]["code"] == -32001
+        assert resp["error"]["message"] == "no draw action found for eid"
+
+    def test_zero_count_indexed_fallback_does_not_read_index_buffer(
+        self, state: DaemonState
+    ) -> None:
+        pipe = state.adapter.controller.GetPipelineState()
+        pipe._ibuffer.byteSize = (1 << 64) - 1
+        actions = state.adapter.controller.GetRootActions()
+        actions[0].flags |= ActionFlags.Indexed
+        actions[0].numIndices = 0
+        reads: list[tuple[int, int, int]] = []
+        orig_get = state.adapter.controller.GetBufferData
+
+        def _get(rid: Any, offset: int, length: int) -> bytes:
+            reads.append((int(rid), offset, length))
+            return orig_get(rid, offset, length)
+
+        state.adapter.controller.GetBufferData = _get
+        resp, _ = _handle_request(
+            rpc_request("mesh_data", {"eid": 10, "stage": "vs-in"}, token="abcdef1234567890"),
+            state,
+        )
+        r = resp["result"]
+        assert r["vertex_count"] == 0
+        assert r["indices"] == []
+        assert reads == []
+
+    def test_matching_postvs_vsin_and_vsout_uses_ia_position(self, state: DaemonState) -> None:
+        postvs = MeshFormat(
+            vertexResourceId=ResourceId(99),
+            vertexByteStride=12,
+            vertexByteSize=36,
+            numIndices=3,
+            format=ResourceFormat(name="R32G32B32_FLOAT", compByteWidth=4, compCount=3),
+            topology="TriangleList",
+        )
+        postvs_data = struct.pack("<9f", 9.0, 9.0, 9.0, 8.0, 8.0, 8.0, 7.0, 7.0, 7.0)
+        orig_get = state.adapter.controller.GetBufferData
+        state.adapter.controller.GetPostVSData = lambda inst, view, stage: postvs
+
+        def _get(rid: Any, offset: int, length: int) -> bytes:
+            if int(rid) == 99:
+                return postvs_data[offset : offset + length]
+            return orig_get(rid, offset, length)
+
+        state.adapter.controller.GetBufferData = _get
+        resp, _ = _handle_request(
+            rpc_request("mesh_data", {"eid": 10, "stage": "vs-in"}, token="abcdef1234567890"),
+            state,
+        )
+        r = resp["result"]
+        assert r["vertices"][0] == pytest.approx([-1.0, -1.0, 0.0])
+        assert r["vertices"][0] != pytest.approx([9.0, 9.0, 9.0])
+
+    def test_indexed_fallback_reads_only_referenced_base_vertex_range(
+        self, state: DaemonState
+    ) -> None:
+        pipe = state.adapter.controller.GetPipelineState()
+        pipe._vbuffers = [
+            BoundVBuffer(
+                resourceId=ResourceId(45),
+                byteOffset=0,
+                byteSize=(1 << 64) - 1,
+                byteStride=20,
+            ),
+        ]
+        pipe._ibuffer = BoundVBuffer(
+            resourceId=ResourceId(46),
+            byteOffset=0,
+            byteSize=6,
+            byteStride=2,
+        )
+        actions = state.adapter.controller.GetRootActions()
+        actions[0].flags |= ActionFlags.Indexed
+        actions[0].baseVertex = 100
+        actions[0].numIndices = 3
+        verts = [(float(i), float(-i), 0.0, 0.0, 0.0) for i in range(103)]
+        vbuf_data = b"".join(struct.pack("<5f", *v) for v in verts)
+        ibuf_data = struct.pack("<3H", 0, 1, 2)
+        reads: list[tuple[int, int, int]] = []
+        orig_get = state.adapter.controller.GetBufferData
+
+        def _get(rid: Any, offset: int, length: int) -> bytes:
+            reads.append((int(rid), offset, length))
+            assert length < 1024
+            if int(rid) == 45:
+                return vbuf_data[offset : offset + length]
+            if int(rid) == 46:
+                return ibuf_data[offset : offset + length]
+            return orig_get(rid, offset, length)
+
+        state.adapter.controller.GetBufferData = _get
+        resp, _ = _handle_request(
+            rpc_request("mesh_data", {"eid": 10, "stage": "vs-in"}, token="abcdef1234567890"),
+            state,
+        )
+        r = resp["result"]
+        assert r["vertex_count"] == 3
+        assert r["indices"] == [0, 1, 2]
+        assert r["vertices"][0] == pytest.approx([100.0, -100.0, 0.0])
+        assert r["vertices"][2] == pytest.approx([102.0, -102.0, 0.0])
+        assert (45, 2000, 60) in reads
+
+    def test_fallback_applies_indices_and_base_vertex(self, state: DaemonState) -> None:
+        pipe = state.adapter.controller.GetPipelineState()
+        pipe._vbuffers = [
+            BoundVBuffer(
+                resourceId=ResourceId(45),
+                byteOffset=0,
+                byteSize=100,
+                byteStride=20,
+            ),
+        ]
+        pipe._ibuffer = BoundVBuffer(
+            resourceId=ResourceId(46),
+            byteOffset=0,
+            byteSize=6,
+            byteStride=2,
+        )
+        actions = state.adapter.controller.GetRootActions()
+        actions[0].flags |= ActionFlags.Indexed
+        actions[0].baseVertex = 1
+        actions[0].numIndices = 3
+        vbuf_data = _make_vbuffer_data() + struct.pack("<5f", 2.0, 2.0, 0.0, 0.0, 0.0)
+        ibuf_data = struct.pack("<3H", 0, 1, 2)
+        orig_get = state.adapter.controller.GetBufferData
+
+        def _get(rid: Any, offset: int, length: int) -> bytes:
+            if int(rid) == 45:
+                return vbuf_data[offset : offset + length]
+            if int(rid) == 46:
+                return ibuf_data[offset : offset + length]
+            return orig_get(rid, offset, length)
+
+        state.adapter.controller.GetBufferData = _get
+        resp, _ = _handle_request(
+            rpc_request("mesh_data", {"eid": 10, "stage": "vs-in"}, token="abcdef1234567890"),
+            state,
+        )
+        r = resp["result"]
+        assert r["vertex_count"] == 3
+        assert r["indices"] == [0, 1, 2]
+        assert r["vertices"][0] == pytest.approx([1.0, -1.0, 0.0])
+        assert r["vertices"][1] == pytest.approx([0.0, 1.0, 0.0])
+        assert r["vertices"][2] == pytest.approx([2.0, 2.0, 0.0])
+
+    def test_indexed_fallback_honors_index_offset(self, state: DaemonState) -> None:
+        pipe = state.adapter.controller.GetPipelineState()
+        pipe._vbuffers = [
+            BoundVBuffer(
+                resourceId=ResourceId(45),
+                byteOffset=0,
+                byteSize=80,
+                byteStride=20,
+            ),
+        ]
+        pipe._ibuffer = BoundVBuffer(
+            resourceId=ResourceId(46),
+            byteOffset=0,
+            byteSize=10,
+            byteStride=2,
+        )
+        actions = state.adapter.controller.GetRootActions()
+        actions[0].flags |= ActionFlags.Indexed
+        actions[0].indexOffset = 2
+        actions[0].vertexOffset = 99
+        actions[0].numIndices = 3
+        vbuf_data = _make_vbuffer_data() + struct.pack("<5f", 2.0, 2.0, 0.0, 0.0, 0.0)
+        ibuf_data = struct.pack("<5H", 99, 98, 0, 1, 2)
+        reads: list[tuple[int, int, int]] = []
+        orig_get = state.adapter.controller.GetBufferData
+
+        def _get(rid: Any, offset: int, length: int) -> bytes:
+            reads.append((int(rid), offset, length))
+            if int(rid) == 45:
+                return vbuf_data[offset : offset + length]
+            if int(rid) == 46:
+                return ibuf_data[offset : offset + length]
+            return orig_get(rid, offset, length)
+
+        state.adapter.controller.GetBufferData = _get
+        resp, _ = _handle_request(
+            rpc_request("mesh_data", {"eid": 10, "stage": "vs-in"}, token="abcdef1234567890"),
+            state,
+        )
+        r = resp["result"]
+        assert r["indices"] == [0, 1, 2]
+        assert r["vertices"][0] == pytest.approx([-1.0, -1.0, 0.0])
+        assert r["vertices"][2] == pytest.approx([0.0, 1.0, 0.0])
+        assert (46, 4, 6) in reads
+        assert (45, 0, 60) in reads
 
 
 # --- P2-MAINT-1: buffer decode helper unit tests ---
@@ -697,6 +1123,31 @@ class TestMeshDataGolden:
         state.adapter.controller.GetBufferData = orig_get
         state.adapter.controller.GetPostVSData = orig_postvs
 
+    def test_postvs_rejects_unknown_vertex_byte_size(self, state: DaemonState) -> None:
+        """PostVS decode should not turn an unresolved size sentinel into a huge read."""
+        mesh = SimpleNamespace(
+            vertexResourceId=ResourceId(99),
+            vertexByteStride=16,
+            vertexByteOffset=0,
+            vertexByteSize=(1 << 64) - 1,
+            numIndices=3,
+            indexResourceId=ResourceId(0),
+            format=ResourceFormat(name="R32G32B32A32_FLOAT", compByteWidth=4, compCount=4),
+            topology="TriangleList",
+        )
+
+        def _fail_get(*args: Any) -> bytes:
+            pytest.fail("unknown PostVS byte size should not read buffer data")
+
+        state.adapter.controller.GetPostVSData = lambda inst, view, stage: mesh
+        state.adapter.controller.GetBufferData = _fail_get
+        resp, _ = _handle_request(
+            rpc_request("mesh_data", {"eid": 10, "stage": "vs-out"}, token="abcdef1234567890"),
+            state,
+        )
+        assert resp["error"]["code"] == -32001
+        assert resp["error"]["message"] == "PostVS vertex buffer size is unknown"
+
 
 class TestMeshDataVsIn:
     """mesh_data handler accepts the vs-in stage (issue #224)."""
@@ -741,17 +1192,18 @@ class TestMeshDataVsIn:
         assert r["vertices"][0] == pytest.approx([1.0, 2.0, 3.0])
         assert r["vertices"][2] == pytest.approx([7.0, 8.0, 9.0])
 
-    def test_vs_in_non_draw_returns_error(self, state: DaemonState) -> None:
-        """stage=vs-in on a non-draw event returns JSON-RPC error -32001."""
+    def test_vs_in_without_postvs_or_ia_returns_error(self, state: DaemonState) -> None:
+        """stage=vs-in fails only when neither PostVS nor IA POSITION can provide data."""
         empty = SimpleNamespace(vertexResourceId=ResourceId(0), vertexByteStride=0)
         orig_postvs = state.adapter.controller.GetPostVSData
         state.adapter.controller.GetPostVSData = lambda inst, view, stage: empty
+        state.adapter.controller.GetPipelineState()._vertex_inputs = []
         resp, _ = _handle_request(
             rpc_request("mesh_data", {"eid": 10, "stage": "vs-in"}, token="abcdef1234567890"),
             state,
         )
         assert resp["error"]["code"] == -32001
-        assert resp["error"]["message"] == "no PostVS data at this event"
+        assert resp["error"]["message"] == "no vertex input POSITION at this event"
         state.adapter.controller.GetPostVSData = orig_postvs
 
     def test_invalid_stage_lists_vs_in(self, state: DaemonState) -> None:

--- a/tests/unit/test_cbuffer_commands.py
+++ b/tests/unit/test_cbuffer_commands.py
@@ -65,7 +65,23 @@ class TestCbufferCmd:
         result = runner.invoke(cbuffer_cmd, ["10", "--raw", "-o", str(out)])
         assert result.exit_code == 0
         assert out.read_bytes() == bytes(range(16))
-        assert captured["vfs_path"] == "/draws/10/cbuffer/0/0/data"
+        assert captured["vfs_path"] == "/draws/10/cbuffer/ps/0/0/data"
+
+    def test_raw_output_uses_requested_stage(self, monkeypatch: Any, tmp_path: Path) -> None:
+        out = tmp_path / "cb.bin"
+        captured: dict[str, Any] = {}
+
+        def mock_export(vfs_path: str, output: str | None, raw: bool) -> None:
+            captured["vfs_path"] = vfs_path
+            captured["output"] = output
+            Path(output).write_bytes(b"VS")
+
+        monkeypatch.setattr("rdc.commands.cbuffer._export_vfs_path", mock_export)
+        runner = CliRunner()
+        result = runner.invoke(cbuffer_cmd, ["10", "--stage", "vs", "--raw", "-o", str(out)])
+        assert result.exit_code == 0
+        assert out.read_bytes() == b"VS"
+        assert captured["vfs_path"] == "/draws/10/cbuffer/vs/0/0/data"
 
     def test_raw_without_output(self, monkeypatch: Any) -> None:
         monkeypatch.setattr(

--- a/tests/unit/test_fix2_vfs_intermediate_dirs.py
+++ b/tests/unit/test_fix2_vfs_intermediate_dirs.py
@@ -90,6 +90,13 @@ class TestRouterIntermediateDirs:
         assert m.handler == "cbuffer_decode"
         assert m.args == {"eid": 11, "set": 0, "binding": 3}
 
+    def test_cbuffer_stageful_raw_leaf(self) -> None:
+        m = resolve_path("/draws/11/cbuffer/vs/0/3/data")
+        assert m is not None
+        assert m.kind == "leaf_bin"
+        assert m.handler == "cbuffer_raw"
+        assert m.args == {"eid": 11, "stage": "vs", "set": 0, "binding": 3}
+
     def test_bindings_dir_still_works(self) -> None:
         m = resolve_path("/draws/11/bindings")
         assert m is not None
@@ -137,6 +144,20 @@ class TestPopulateBindings:
         populate_draw_subtree(skel, 11, pipe)
         leaf = skel.static["/draws/11/cbuffer/0/0"]
         assert leaf.kind == "leaf"
+
+    def test_cbuffer_stage_nodes_and_data_leaf_created(self) -> None:
+        skel = build_vfs_skeleton(_make_actions(), _make_resources())
+        pipe = _make_pipe_with_bindings()
+        populate_draw_subtree(skel, 11, pipe)
+        cbuffer = skel.static["/draws/11/cbuffer"]
+        assert "vs" in cbuffer.children
+        assert "ps" in cbuffer.children
+        stage_set = skel.static["/draws/11/cbuffer/vs/0"]
+        assert "0" in stage_set.children
+        binding = skel.static["/draws/11/cbuffer/vs/0/0"]
+        assert binding.kind == "leaf"
+        assert "data" in binding.children
+        assert skel.static["/draws/11/cbuffer/vs/0/0/data"].kind == "leaf_bin"
 
     def test_no_reflections_empty(self) -> None:
         skel = build_vfs_skeleton(_make_actions(), _make_resources())

--- a/tests/unit/test_vfs_router.py
+++ b/tests/unit/test_vfs_router.py
@@ -264,12 +264,26 @@ class TestBufferDecodeRoutes:
         assert m.handler == "cbuffer_decode"
         assert m.args == {"eid": 42, "set": 0, "binding": 3}
 
+    def test_cbuffer_stageful_decode(self) -> None:
+        m = resolve_path("/draws/42/cbuffer/vs/0/3")
+        assert m is not None
+        assert m.kind == "leaf"
+        assert m.handler == "cbuffer_decode"
+        assert m.args == {"eid": 42, "stage": "vs", "set": 0, "binding": 3}
+
     def test_cbuffer_raw(self) -> None:
         m = resolve_path("/draws/42/cbuffer/0/3/data")
         assert m is not None
         assert m.kind == "leaf_bin"
         assert m.handler == "cbuffer_raw"
         assert m.args == {"eid": 42, "set": 0, "binding": 3}
+
+    def test_cbuffer_stageful_raw(self) -> None:
+        m = resolve_path("/draws/42/cbuffer/ps/0/3/data")
+        assert m is not None
+        assert m.kind == "leaf_bin"
+        assert m.handler == "cbuffer_raw"
+        assert m.args == {"eid": 42, "stage": "ps", "set": 0, "binding": 3}
 
     def test_vbuffer_decode(self) -> None:
         m = resolve_path("/draws/42/vbuffer")


### PR DESCRIPTION
## Summary

- Decode cbuffer values from the reflected value lane instead of always using `f32v`, including numeric uint variables reported by D3D captures.
- Route raw cbuffer exports through stageful VFS paths so `vs bN` and `ps bN` can resolve different resources at the same set/binding, with stage validation before temp-file output.
- Add an IA decode fallback for `mesh --stage vs-in` when RenderDoc PostVS VSIn data is missing or mirrors VSOut.

## Test Evidence

- `uv run --extra dev pytest tests/unit/test_buffer_decode.py tests/unit/test_cbuffer_commands.py tests/unit/test_vfs_router.py tests/unit/test_fix2_vfs_intermediate_dirs.py -q`
- `pixi run lint`
- `pixi run typecheck`
- `pixi run test` (`3071 passed, 6 skipped`, coverage `93.20%`)
- Pre-commit `pixi run check`
- GitHub CI is green on `00371d29acfa8bae1da82d7a68604ab410f76493`

## Notes

- Refs #224.
- Legacy decoded cbuffer paths remain routed; raw CLI export now uses `/draws/<eid>/cbuffer/<stage>/<set>/<binding>/data`.
- Local manual replay against real `.rdc` captures was not run because `rdc doctor` reports the RenderDoc Python replay module is unavailable in this environment. The unit tests cover the reported failure modes with mocks, but Windows D3D11/D3D12 capture verification remains needed.
